### PR TITLE
Refactor adding factories

### DIFF
--- a/JPetBarrelSlot/JPetBarrelSlotFactory.cpp
+++ b/JPetBarrelSlot/JPetBarrelSlotFactory.cpp
@@ -1,0 +1,60 @@
+/**
+ *  @copyright Copyright 2016 The J-PET Framework Authors. All rights reserved.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may find a copy of the License in the LICENCE file.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  @file JPetBarrelSlotFactory.cpp
+ */
+
+#include "JPetBarrelSlotFactory.h"
+
+#include <exception>
+#include <string>
+#include <tuple>
+#include <boost/lexical_cast.hpp>
+
+std::map<int, JPetBarrelSlot *> & JPetBarrelSlotFactory::getBarrelSlots()
+{
+  if (!fInitialized) {
+    initialize();
+  }
+  return fBarrelSlots;
+}
+
+void JPetBarrelSlotFactory::initialize()
+{
+  ParamObjectsDescriptions descriptions = paramGetter.getAllBasicData(ParamObjectType::kBarrelSlot, runId);
+  if (descriptions.size() == 0) {
+    ERROR(std::string("No barrel slots in run ") + boost::lexical_cast<std::string>(runId));
+  }
+  for (auto description : descriptions) {
+    fBarrelSlots[description.first] = build(description.second);
+  }
+  fInitialized = true;
+  ParamRelationalData relations = paramGetter.getAllRelationalData(ParamObjectType::kBarrelSlot, ParamObjectType::kLayer, runId);
+  for (auto relation : relations) {
+    fBarrelSlots[relation.first]->setLayer(*layerFactory.getLayers().at(relation.second));
+  }
+}
+
+JPetBarrelSlot * JPetBarrelSlotFactory::build(ParamObjectDescription data)
+{
+  try {
+    int id = boost::lexical_cast<int>(data.at("id"));
+    bool active = boost::lexical_cast<bool>(data.at("active"));
+    std::string name = data.at("name");
+    float theta = boost::lexical_cast<float>(data.at("theta1"));
+    int inFrameId = boost::lexical_cast<int>(data.at("frame_id"));
+    return new JPetBarrelSlot(id, active, name, theta, inFrameId);
+  } catch (const std::exception & e) {
+    ERROR(std::string("Failed to build barrelSlot with error: ") + e.what());
+    throw;
+  }
+}

--- a/JPetBarrelSlot/JPetBarrelSlotFactory.h
+++ b/JPetBarrelSlot/JPetBarrelSlotFactory.h
@@ -1,0 +1,52 @@
+/**
+ *  @copyright Copyright 2016 The J-PET Framework Authors. All rights reserved.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may find a copy of the License in the LICENCE file.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  @file JPetBarrelSlotFactory.h
+ */
+
+#ifndef JPET_BARREL_SLOT_FACTORY_H
+#define JPET_BARREL_SLOT_FACTORY_H
+
+#include "../JPetParamGetter/JPetParamGetter.h"
+#include "JPetBarrelSlot.h"
+#include "../JPetLayer/JPetLayerFactory.h"
+
+#include <map>
+
+/**
+ * @brief A factory of JPetBarrelSlot objects.
+ *
+ * This class is able to create those objects using data from the database.
+ */
+class JPetBarrelSlotFactory
+{
+  public:
+    JPetBarrelSlotFactory(JPetParamGetter & paramGetter, int runId, JPetLayerFactory & layerFactory) :
+      paramGetter(paramGetter),
+      runId(runId),
+      layerFactory(layerFactory),
+      fInitialized(false) {}
+
+    std::map<int, JPetBarrelSlot *> & getBarrelSlots();
+  private:
+    JPetParamGetter & paramGetter;
+    const int runId;
+    JPetLayerFactory & layerFactory;
+
+    bool fInitialized;
+    std::map<int, JPetBarrelSlot *> fBarrelSlots;
+
+    void initialize();
+    JPetBarrelSlot * build(ParamObjectDescription data);
+};
+
+#endif // JPET_BARREL_SLOT_FACTORY_H

--- a/JPetBarrelSlot/JPetBarrelSlotTest.cpp
+++ b/JPetBarrelSlot/JPetBarrelSlotTest.cpp
@@ -2,7 +2,8 @@
 #define BOOST_TEST_MODULE JPetBarrelSlotTest
 #include <boost/test/unit_test.hpp>
 
-#include "../JPetBarrelSlot/JPetBarrelSlot.h"
+#include "JPetBarrelSlot.h"
+#include "JPetBarrelSlotFactory.h"
 // JPetBarrelSlot();
 // JPetBarrelSlot(int id, bool isActive, std::string name, float theta);
 // 
@@ -20,13 +21,13 @@
 //   fTRefLayer = &p_layer;
 // }
 
+const float epsilon = 0.0001;
 
 BOOST_AUTO_TEST_SUITE(FirstSuite)
 
 BOOST_AUTO_TEST_CASE( default_constructor )
 {
   JPetBarrelSlot slot;
-  float epsilon = 0.0001;
   BOOST_REQUIRE_EQUAL(slot.getID(), -1);
   BOOST_REQUIRE_CLOSE(slot.getTheta(), -1., epsilon);
   BOOST_REQUIRE(!slot.isActive());
@@ -37,12 +38,228 @@ BOOST_AUTO_TEST_CASE( default_constructor )
 BOOST_AUTO_TEST_CASE( constructor )
 {
   JPetBarrelSlot slot(1, true, "pepe", 5.5, 6);
-  float epsilon = 0.0001;
   BOOST_REQUIRE_EQUAL(slot.getID(), 1);
   BOOST_REQUIRE_CLOSE(slot.getTheta(), 5.5, epsilon);
   BOOST_REQUIRE(slot.isActive());
   BOOST_REQUIRE(slot.getName()=="pepe");
   BOOST_REQUIRE(slot.getInFrameID()==6);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE(FactorySuite)
+
+class TestParamGetter : public JPetParamGetter
+{
+  ParamObjectsDescriptions getAllBasicData(ParamObjectType type, const int runId)
+  {
+    ParamObjectsDescriptions result;
+    switch (type) {
+      case ParamObjectType::kBarrelSlot:
+        switch (runId) {
+          case 0: //No barrelSlots
+            break;
+          case 1: //Simple single object
+          case 5: //Wrong relation
+            result = {
+              {1, {
+                    {"id", "1"},
+                    {"active", "1"},
+                    {"name", "pepe"},
+                    {"theta1", "5.5"},
+                    {"frame_id", "6"}
+                  }
+              }
+            };
+            break;
+          case 2: //Simple two objects
+            result = {
+              {1, {
+                    {"id", "1"},
+                    {"active", "1"},
+                    {"name", "pepe"},
+                    {"theta1", "5.5"},
+                    {"frame_id", "6"}
+                  }
+              },
+              {5, {
+                    {"id", "5"},
+                    {"active", "0"},
+                    {"name", "smoothface"},
+                    {"theta1", "6.5"},
+                    {"frame_id", "7"}
+                  }
+              }
+            };
+            break;
+          case 3: //Object with missing field
+            result = {
+              {1, {
+                    {"id", "1"},
+                    {"active", "1"},
+                    {"theta1", "5.5"},
+                    {"frame_id", "6"}
+                  }
+              }
+            };
+            break;
+          case 4: //Object with wrong field
+            result = {
+              {1, {
+                    {"id", "1"},
+                    {"active", "probably"},
+                    {"name", "pepe"},
+                    {"theta1", "5.5"},
+                    {"frame_id", "6"}
+                  }
+              }
+            };
+            break;
+        }
+        break;
+      case ParamObjectType::kLayer:
+        result = {
+          {1, {
+                {"id", "1"},
+                {"active", "1"},
+                {"name", "ala"},
+                {"radius", "10.5"}
+              }
+          }
+        };
+        break;
+      case ParamObjectType::kFrame:
+        result = {
+          {1, {
+                {"id", "1"},
+                {"active", "1"},
+                {"status", "ok"},
+                {"description", "descr1"},
+                {"version", "2"},
+                {"creator_id", "1"}
+              }
+          }
+        };
+        break;
+      default: //Other cases not needed.
+        break;
+    }
+    return result;
+  }
+  ParamRelationalData getAllRelationalData(ParamObjectType type1, ParamObjectType, const int runId)
+  {
+    ParamRelationalData result;
+    switch (type1) {
+      case ParamObjectType::kBarrelSlot:
+        switch (runId) {
+          case 0: //No relations
+            break;
+          case 1: //Simple single object
+            result = {
+              {1, 1}
+            };
+            break;
+          case 2: //Simple two objects
+            result = {
+              {1, 1},
+              {5, 1}
+            };
+            break;
+          case 5: //Wrong relation
+            result = {
+              {1, 43}
+            };
+            break;
+        }
+        break;
+      case ParamObjectType::kLayer:
+        result = {
+          {1, 1}
+        };
+        break;
+      default: //Other cases not needed.
+        break;
+    }
+    return result;
+  }
+};
+
+TestParamGetter paramGetter;
+
+BOOST_AUTO_TEST_CASE( no_barrelSlots )
+{
+  JPetFrameFactory frameFactory(paramGetter, 0);
+  JPetLayerFactory layerFactory(paramGetter, 0, frameFactory);
+  JPetBarrelSlotFactory factory(paramGetter, 0, layerFactory);
+  auto & barrelSlots = factory.getBarrelSlots();
+  BOOST_REQUIRE_EQUAL(barrelSlots.size(), 0);
+}
+
+BOOST_AUTO_TEST_CASE( single_object )
+{
+  JPetFrameFactory frameFactory(paramGetter, 1);
+  JPetLayerFactory layerFactory(paramGetter, 1, frameFactory);
+  JPetBarrelSlotFactory factory(paramGetter, 1, layerFactory);
+  auto & barrelSlots = factory.getBarrelSlots();
+  BOOST_REQUIRE_EQUAL(barrelSlots.size(), 1);
+  auto barrelSlot = barrelSlots[1];
+  BOOST_REQUIRE_EQUAL(barrelSlot->getID(), 1);
+  BOOST_REQUIRE(barrelSlot->isActive());
+  BOOST_REQUIRE(barrelSlot->getName()=="pepe");
+  BOOST_REQUIRE_CLOSE(barrelSlot->getTheta(), 5.5, epsilon);
+  BOOST_REQUIRE_EQUAL(barrelSlot->getInFrameID(), 6);
+
+  BOOST_REQUIRE_EQUAL(barrelSlot->getLayer().getId(), layerFactory.getLayers().at(1)->getId());
+}
+
+BOOST_AUTO_TEST_CASE( two_objects )
+{
+  JPetFrameFactory frameFactory(paramGetter, 2);
+  JPetLayerFactory layerFactory(paramGetter, 2, frameFactory);
+  JPetBarrelSlotFactory factory(paramGetter, 2, layerFactory);
+  auto & barrelSlots = factory.getBarrelSlots();
+  BOOST_REQUIRE_EQUAL(barrelSlots.size(), 2);
+  auto barrelSlot = barrelSlots[1];
+  BOOST_REQUIRE_EQUAL(barrelSlot->getID(), 1);
+  BOOST_REQUIRE(barrelSlot->isActive());
+  BOOST_REQUIRE(barrelSlot->getName()=="pepe");
+  BOOST_REQUIRE_CLOSE(barrelSlot->getTheta(), 5.5, epsilon);
+  BOOST_REQUIRE_EQUAL(barrelSlot->getInFrameID(), 6);
+
+  BOOST_REQUIRE_EQUAL(barrelSlot->getLayer().getId(), layerFactory.getLayers().at(1)->getId());
+
+  barrelSlot = barrelSlots[5];
+  BOOST_REQUIRE_EQUAL(barrelSlot->getID(), 5);
+  BOOST_REQUIRE(!barrelSlot->isActive());
+  BOOST_REQUIRE(barrelSlot->getName()=="smoothface");
+  BOOST_REQUIRE_CLOSE(barrelSlot->getTheta(), 6.5, epsilon);
+  BOOST_REQUIRE_EQUAL(barrelSlot->getInFrameID(), 7);
+
+  BOOST_REQUIRE_EQUAL(barrelSlot->getLayer().getId(), layerFactory.getLayers().at(1)->getId());
+}
+
+BOOST_AUTO_TEST_CASE( missing_field )
+{
+  JPetFrameFactory frameFactory(paramGetter, 3);
+  JPetLayerFactory layerFactory(paramGetter, 3, frameFactory);
+  JPetBarrelSlotFactory factory(paramGetter, 3, layerFactory);
+  BOOST_REQUIRE_THROW(factory.getBarrelSlots(), std::out_of_range);
+}
+
+BOOST_AUTO_TEST_CASE( wrong_field )
+{
+  JPetFrameFactory frameFactory(paramGetter, 4);
+  JPetLayerFactory layerFactory(paramGetter, 4, frameFactory);
+  JPetBarrelSlotFactory factory(paramGetter, 4, layerFactory);
+  BOOST_REQUIRE_THROW(factory.getBarrelSlots(), std::bad_cast);
+}
+
+BOOST_AUTO_TEST_CASE( wrong_relation )
+{
+  JPetFrameFactory frameFactory(paramGetter, 5);
+  JPetLayerFactory layerFactory(paramGetter, 5, frameFactory);
+  JPetBarrelSlotFactory factory(paramGetter, 5, layerFactory);
+  BOOST_REQUIRE_THROW(factory.getBarrelSlots(), std::out_of_range);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/JPetDBParamGetter/JPetDBParamGetter.cpp
+++ b/JPetDBParamGetter/JPetDBParamGetter.cpp
@@ -19,74 +19,255 @@
 #include "../DBHandler/HeaderFiles/DBHandler.h"
 #include <cstdint>
 
-std::map<int, JPetParamBank*> JPetDBParamGetter::gParamCache;
+const std::map<ParamObjectType, std::map<std::string, std::string>> fieldTranslations{
+  {ParamObjectType::kScintillator,
+    {
+      {"scintillator_id", "id"},
+      {"scintillator_length", "length"},
+      {"scintillator_width", "width"},
+      {"scintillator_height", "height"}
+    }
+  },
+    {ParamObjectType::kPM,
+      {
+        {"photomultiplier_id", "id"},
+        {"hvpmconnection_isrightside", "is_right_side"}
+      }
+    },
+    {ParamObjectType::kPMCalib,
+      {
+        {"pm_calibration_id", "id"},
+        {"pm_calibration_name", "name"},
+        {"pm_calibration_opthv", "opthv"},
+        {"pm_calibration_c2e_1", "c2e1"},
+        {"pm_calibration_c2e_2", "c2e2"},
+        {"pm_calibration_gainalpha", "gain_alpha"},
+        {"pm_calibration_gainbeta", "gain_beta"},
+        {"pm_calibration_assignment_id", "assignment_id"},
+        {"pm_calibration_assignment_photomuliplier_id", "assignment_photomultiplier_id"}
+      }
+    },
+    {ParamObjectType::kBarrelSlot,
+      {
+        {"slot_id", "id"},
+        {"slot_isActive", "active"},
+        {"slot_name", "name"},
+        {"slot_theta1", "theta1"},
+        {"slot_inFrameId", "frame_id"}
+      }
+    },
+    {ParamObjectType::kLayer,
+      {
+        {"layer_id", "id"},
+        {"layer_isActive", "active"},
+        {"layer_name", "name"},
+        {"layer_radius", "radius"}
+      }
+    },
+    {ParamObjectType::kFrame,
+      {
+        {"frame_id", "id"},
+        {"frame_isActive", "active"},
+        {"frame_status", "status"},
+        {"frame_description", "description"},
+        {"frame_version", "version"},
+        {"frame_creator_id", "creator_id"}
+      }
+    },
+    {ParamObjectType::kFEB,
+      {
+        {"konradboard_id", "id"},
+        {"konradboard_isactive", "active"},
+        {"konradboard_status", "status"},
+        {"konradboard_description", "description"},
+        {"konradboard_version", "version"},
+        {"konradboard_creator_id", "creator_id"},
+        {"time_outputs_per_input", "time_outputs_per_input"},
+        {"notime_outputs_per_input", "no_time_outputs_per_input"}
+      }
+    },
+    {ParamObjectType::kTRB,
+      {
+        {"TRB_id", "id"}
+      }
+    },
+    {ParamObjectType::kTOMBChannel,
+      {
+        {"tomb", "channel"},
+        {"thr_num", "local_number"},
+        {"threshold", "threshold"},
+        {"feb_input", "FEB"},
+        {"trb_id", "trb_id"},
+        {"konradboard_id", "konradboard_id"},
+        {"photomultiplier_id", "photomultiplier_id"}
+      }
+    },
+};
+const std::map<ParamObjectType, std::string> dbFunctionName{
+  {ParamObjectType::kScintillator, "getDataFromScintillators"},
+    {ParamObjectType::kPM, "getDataFromPhotoMultipliers"},
+    {ParamObjectType::kPMCalib, "getPmCalibration"},
+    {ParamObjectType::kBarrelSlot, "getBarrelSlot"},
+    {ParamObjectType::kLayer, "getLayer"},
+    {ParamObjectType::kFrame, "getFrame"},
+    {ParamObjectType::kFEB, "getDataFromKonradBoards"},
+    {ParamObjectType::kTRB, "getDataFromTRBs"},
+    {ParamObjectType::kTOMBChannel, "getEverythingVsTOMB"},
+};
+const std::map<ParamObjectType, std::map<ParamObjectType, std::string>> dbRelationFunctionName{
+  {ParamObjectType::kPM, {
+                           {ParamObjectType::kFEB, "getKonradBoardsForPhotoMultiplier"},
+                             {ParamObjectType::kScintillator, "getScintillatorsForPhotoMultiplier"},
+                             {ParamObjectType::kBarrelSlot, "getbarrelslotforphotomultiplier"}
+                         }
+  },
+    {ParamObjectType::kFEB, {
+                              {ParamObjectType::kTRB, "getTRBsForKonradBoard"}
+                            }
+    },
+    {ParamObjectType::kBarrelSlot, {
+                                     {ParamObjectType::kLayer, "getLayerForBarrelSlot"}
+                                   }
+    },
+    {ParamObjectType::kLayer, {
+                                {ParamObjectType::kFrame, "getFrameForLayer"}
+                              }
+    },
+    {ParamObjectType::kScintillator, {
+                                       {ParamObjectType::kBarrelSlot, "getbarrelslotforscintillator"}
+                                     }
+    },
+};
+const std::map<ParamObjectType, std::map<ParamObjectType, std::string>> dbRelationFieldName{
+  {ParamObjectType::kPM, {
+                           {ParamObjectType::kFEB, "KonradBoard_id"},
+                             {ParamObjectType::kScintillator, "Scintillator_id"},
+                             {ParamObjectType::kBarrelSlot, "hvpmconnection_slot_id"}
+                         }
+  },
+    {ParamObjectType::kFEB, {
+                              {ParamObjectType::kTRB, "TRB_id"}
+                            }
+    },
+    {ParamObjectType::kBarrelSlot, {
+                                     {ParamObjectType::kLayer, "layer_id"}
+                                   }
+    },
+    {ParamObjectType::kLayer, {
+                                {ParamObjectType::kFrame, "frame_id"}
+                              }
+    },
+    {ParamObjectType::kScintillator, {
+                                       {ParamObjectType::kBarrelSlot, "slscconnection_slot_id"}
+                                     }
+    },
+};
+
+std::map<int, std::map<ParamObjectType, ParamObjectsDescriptions>> JPetDBParamGetter::gBasicDataCache;
+std::map<int, std::map<ParamObjectType, std::map<ParamObjectType, ParamRelationalData>>> JPetDBParamGetter::gRelationalDataCache;
 
 void JPetDBParamGetter::clearParamCache()
 {
   TThread::Lock();
-  WARNING("JPetDBParamGetter::gParamCache will be cleared");
-  for (auto & pair : JPetDBParamGetter::gParamCache) {
-    if (pair.second) {
-      delete pair.second;
-      pair.second = 0;
-    }
-  }
-  JPetDBParamGetter::gParamCache.clear();
+  WARNING("JPetDBParamGetter cached data will be cleared");
+  JPetDBParamGetter::gBasicDataCache.clear();
+  JPetDBParamGetter::gRelationalDataCache.clear();
   TThread::UnLock();
 }
 
-JPetDBParamGetter::JPetDBParamGetter()
+ParamObjectsDescriptions JPetDBParamGetter::getAllBasicData(ParamObjectType type, const int runId)
 {
-}
-
-JPetDBParamGetter::~JPetDBParamGetter()
-{
-}
-
-JPetParamBank* JPetDBParamGetter::generateParamBank(const int p_run_id)
-{
-  if (p_run_id < 0) {
-    ERROR("Run number is less than 0!! Param bank cannot be generated");
-    return 0;
+  if (runId < 0) {
+    ERROR("Run number is less than 0!");
+    return ParamObjectsDescriptions();
   }
-  TThread::Lock();
-  if (JPetDBParamGetter::gParamCache.find(p_run_id) == gParamCache.end()) {
-    JPetParamBank* pParamBank = new JPetParamBank;
-    fillScintillators(p_run_id, *pParamBank);
-    fillPMs(p_run_id, *pParamBank);
-    fillPMCalibs(p_run_id, *pParamBank);
-    fillBarrelSlot(p_run_id, *pParamBank);
-    fillLayer(p_run_id, *pParamBank);
-    fillFrame(p_run_id, *pParamBank);
-    fillFEBs(p_run_id, *pParamBank);
-    fillTRBs(p_run_id, *pParamBank);
-    fillTOMBChannels(p_run_id, *pParamBank);
-    JPetDBParamGetter::gParamCache[p_run_id] = pParamBank;
-  }
-  JPetParamBank* returnedParamBank = new JPetParamBank(*JPetDBParamGetter::gParamCache[p_run_id]);
-  fillAllTRefs(p_run_id, *returnedParamBank);
-  TThread::UnLock();
-  return returnedParamBank;
-}
-
-void JPetDBParamGetter::fillScintillators(const int p_run_id, JPetParamBank& paramBank)
-{
-  INFO("Start filling Scintillators container.");
-  //"SELECT * FROM getDataFromScintillators(" + l_run_id + ");";
-  std::string l_run_id = boost::lexical_cast<std::string>(p_run_id);
-  pqxx::result l_runDbResults = getDataFromDB("getDataFromScintillators", l_run_id);
-
-
-  size_t l_sizeResultQuerry = l_runDbResults.size();
-
-  if (l_sizeResultQuerry) {
-    for (pqxx::result::const_iterator row = l_runDbResults.begin(); row != l_runDbResults.end(); ++row) {
-      JPetScin l_scin = generateScintillator(row);
-      paramBank.addScintillator(l_scin);
+  auto & thisCache = gBasicDataCache[runId][type];
+  if (thisCache.size() == 0) {
+    TThread::Lock();
+    std::string runIdS = boost::lexical_cast<std::string>(runId);
+    auto dbResult = getDataFromDB(dbFunctionName.at(type), runIdS);
+    if (dbResult.size() == 0) {
+      printErrorMessageDB(dbFunctionName.at(type), runId);
+      return thisCache;
     }
-  } else {
-    printErrorMessageDB("getDataFromScintillators", p_run_id);
+    for (auto row : dbResult) {
+      ParamObjectDescription description;
+      for (auto & translation : fieldTranslations.at(type)) {
+        description[translation.second] = row[translation.first].as<std::string>();
+        // Workaround to fix booleans.
+        if (description[translation.second] == "t") {
+          description[translation.second] = "1";
+        }
+        if (description[translation.second] == "f") {
+          description[translation.second] = "0";
+        }
+      }
+      // Fix id for TOMBChannel
+      if (type == ParamObjectType::kTOMBChannel) {
+        description["id"] = boost::lexical_cast<std::string>(JPetParamGetter::getTOMBChannelFromDescription(description["id"]));
+      }
+      // Workarounds because of missing stuff in DB.
+      // Scintillator -- no attenuation_length
+      if (type == ParamObjectType::kScintillator) {
+        description["attenuation_length"] = "0";
+      }
+      // TRB -- no type and channel
+      if (type == ParamObjectType::kTRB) {
+        description["type"] = "0";
+        description["channel"] = "0";
+      }
+      thisCache[boost::lexical_cast<int>(description["id"])] = description;
+    }
+    TThread::UnLock();
   }
+  return thisCache;
+}
+
+ParamRelationalData JPetDBParamGetter::getAllRelationalData(ParamObjectType type1, ParamObjectType type2, const int runId)
+{
+  if (runId < 0) {
+    ERROR("Run number is less than 0!");
+    return ParamRelationalData();
+  }
+  auto & thisCache = gRelationalDataCache[runId][type1][type2];
+  if (thisCache.size() == 0) {
+    TThread::Lock();
+    std::string runIdS = boost::lexical_cast<std::string>(runId);
+    auto dbResult = getDataFromDB(dbFunctionName.at(type1), runIdS);
+    if (dbResult.size() == 0) {
+      printErrorMessageDB(dbFunctionName.at(type1), runId);
+      return thisCache;
+    }
+    for (auto row : dbResult) {
+      ParamObjectDescription description;
+      for (auto & translation : fieldTranslations.at(type1)) {
+        description[translation.second] = row[translation.first].as<std::string>();
+      }
+      if (type1 == ParamObjectType::kTOMBChannel) {
+        description["id"] = boost::lexical_cast<std::string>(JPetParamGetter::getTOMBChannelFromDescription(description["id"]));
+        switch (type2) {
+          case ParamObjectType::kTRB:
+            thisCache[boost::lexical_cast<int>(description["id"])] = boost::lexical_cast<int>(description["trb_id"]);
+            break;
+          case ParamObjectType::kFEB:
+            thisCache[boost::lexical_cast<int>(description["id"])] = boost::lexical_cast<int>(description["konradboard_id"]);
+            break;
+          case ParamObjectType::kPM:
+            thisCache[boost::lexical_cast<int>(description["id"])] = boost::lexical_cast<int>(description["photomultiplier_id"]);
+            break;
+          default:
+            break;
+        }
+      } else {
+        auto dbRelationResult = getDataFromDB(dbRelationFunctionName.at(type1).at(type2), description["id"] + "," + runIdS);
+        for (auto relationRow : dbRelationResult) {
+          thisCache[boost::lexical_cast<int>(description["id"])] = relationRow[dbRelationFieldName.at(type1).at(type2)].as<int>();
+        }
+      }
+    }
+    TThread::UnLock();
+  }
+  return thisCache;
 }
 
 std::string JPetDBParamGetter::generateSelectQuery(const std::string& sqlFun, const std::string& arguments)
@@ -106,571 +287,10 @@ pqxx::result JPetDBParamGetter::getDataFromDB(const std::string& sqlfunction, co
   return  l_dbHandlerInstance.querry(l_sqlQuerry);
 }
 
-
-void JPetDBParamGetter::printErrorMessageDB(std::string sqlFunction, int p_run_id) {
-    std::string l_error(sqlFunction);
-    l_error += "() querry for run_id = ";
-    l_error += boost::lexical_cast<std::string>(p_run_id) + " return 0 records.";
-    ERROR(l_error.c_str());
-}
-
-
-
-void JPetDBParamGetter::fillPMs(const int p_run_id, JPetParamBank& paramBank)
+void JPetDBParamGetter::printErrorMessageDB(std::string sqlFunction, int p_run_id)
 {
-  INFO("Start filling PMs container.");
-
-  std::string l_run_id = boost::lexical_cast<std::string>(p_run_id);
-  pqxx::result l_runDbResults = getDataFromDB("getDataFromPhotoMultipliers", l_run_id);
-
-  size_t l_sizeResultQuerry = l_runDbResults.size();
-
-  if (l_sizeResultQuerry) {
-    for (pqxx::result::const_iterator row = l_runDbResults.begin(); row != l_runDbResults.end(); ++row) {
-      JPetPM l_pm = generatePM(row);
-      paramBank.addPM(l_pm);
-    }
-  } else {
-    printErrorMessageDB("getDataFromPhotoMultipliers", p_run_id);
-  }
-}
-
-void JPetDBParamGetter::fillPMCalibs(const int p_run_id, JPetParamBank& paramBank)
-{
-  INFO("Start filling PMCalibs container.");
-
-  std::string l_run_id = boost::lexical_cast<std::string>(p_run_id);
-  pqxx::result l_runDbResults = getDataFromDB("getPmCalibration", l_run_id);
-
-  size_t l_sizeResultQuerry = l_runDbResults.size();
-
-  if (l_sizeResultQuerry) {
-    for (pqxx::result::const_iterator row = l_runDbResults.begin(); row != l_runDbResults.end(); ++row) {
-      JPetPMCalib l_pmCalib = generatePMCalib(row);
-      paramBank.addPMCalib(l_pmCalib);
-    }
-  } else {
-    printErrorMessageDB("getPmCalibration", p_run_id);
-  }
-}
-
-void JPetDBParamGetter::fillBarrelSlot(const int p_run_id, JPetParamBank& paramBank)
-{
-  INFO("Start filling BarrelSlot container.");
-
-  std::string l_run_id = boost::lexical_cast<std::string>(p_run_id);
-  pqxx::result l_runDbResults = getDataFromDB("getBarrelSlot", l_run_id);
-
-  size_t l_sizeResultQuerry = l_runDbResults.size();
-
-  if (l_sizeResultQuerry) {
-    for (pqxx::result::const_iterator row = l_runDbResults.begin(); row != l_runDbResults.end(); ++row) {
-      JPetBarrelSlot l_barrelSlot = generateBarrelSlot(row);
-      paramBank.addBarrelSlot(l_barrelSlot);
-    }
-  } else {
-    printErrorMessageDB("getBarrelSlot", p_run_id);
-  }
-}
-
-void JPetDBParamGetter::fillLayer(const int p_run_id, JPetParamBank& paramBank)
-{
-  INFO("Start filling Layer container.");
-
-  std::string l_run_id = boost::lexical_cast<std::string>(p_run_id);
-  pqxx::result l_runDbResults = getDataFromDB("getLayer", l_run_id);
-
-  size_t l_sizeResultQuerry = l_runDbResults.size();
-
-  if (l_sizeResultQuerry) {
-    for (pqxx::result::const_iterator row = l_runDbResults.begin(); row != l_runDbResults.end(); ++row) {
-      JPetLayer l_layer = generateLayer(row);
-      paramBank.addLayer(l_layer);
-    }
-  } else {
-    printErrorMessageDB("getLayer", p_run_id);
-  }
-}
-
-void JPetDBParamGetter::fillFrame(const int p_run_id, JPetParamBank& paramBank)
-{
-  INFO("Start filling Frame container.");
-
-  std::string l_run_id = boost::lexical_cast<std::string>(p_run_id);
-  pqxx::result l_runDbResults = getDataFromDB("getFrame", l_run_id);
-
-  size_t l_sizeResultQuerry = l_runDbResults.size();
-
-  if (l_sizeResultQuerry) {
-    for (pqxx::result::const_iterator row = l_runDbResults.begin(); row != l_runDbResults.end(); ++row) {
-      JPetFrame l_frame = generateFrame(row);
-      paramBank.addFrame(l_frame);
-    }
-  } else {
-    printErrorMessageDB("getFrame", p_run_id);
-  }
-}
-
-void JPetDBParamGetter::fillFEBs(const int p_run_id, JPetParamBank& paramBank)
-{
-  INFO("Start filling FEBs container.");
-
-  std::string l_run_id = boost::lexical_cast<std::string>(p_run_id);
-  pqxx::result l_runDbResults = getDataFromDB("getDataFromKonradBoards", l_run_id);
-
-  size_t l_sizeResultQuerry = l_runDbResults.size();
-
-  if (l_sizeResultQuerry) {
-    for (pqxx::result::const_iterator row = l_runDbResults.begin(); row != l_runDbResults.end(); ++row) {
-      JPetFEB l_FEB = generateFEB(row);
-      paramBank.addFEB(l_FEB);
-    }
-  } else {
-    printErrorMessageDB("getDataFromKonradBoards", p_run_id);
-  }
-}
-
-void JPetDBParamGetter::fillTRBs(const int p_run_id, JPetParamBank& paramBank)
-{
-  INFO("Start filling TRBs container.");
-
-  std::string l_run_id = boost::lexical_cast<std::string>(p_run_id);
-  pqxx::result l_runDbResults = getDataFromDB("getDataFromTRBs", l_run_id);
-
-  size_t l_sizeResultQuerry = l_runDbResults.size();
-
-  if (l_sizeResultQuerry) {
-    for (pqxx::result::const_iterator row = l_runDbResults.begin(); row != l_runDbResults.end(); ++row) {
-      JPetTRB l_TRB = generateTRB(row);
-      paramBank.addTRB(l_TRB);
-    }
-  } else {
-    printErrorMessageDB("getDataFromTRBs", p_run_id);
-  }
-}
-
-
-
-void JPetDBParamGetter::fillTOMBChannels(const int p_run_id, JPetParamBank& paramBank)
-{
-  INFO("Start filling TOMBChannels container.");
-
-  std::string l_run_id = boost::lexical_cast<std::string>(p_run_id);
-  pqxx::result l_runDbResults = getDataFromDB("getEverythingVsTOMB", l_run_id);
-
-  size_t l_sizeResultQuerry = l_runDbResults.size();
-
-  if (l_sizeResultQuerry) {
-    {
-      for (pqxx::result::const_iterator row = l_runDbResults.begin();
-           row != l_runDbResults.end();
-           ++row) {
-        JPetTOMBChannel l_TOMBChannel = generateTOMBChannel(row);
-        paramBank.addTOMBChannel(l_TOMBChannel);
-      }
-
-    }
-  } else {
-    printErrorMessageDB("getDataFromTOMBChannels", p_run_id);
-  }
-}
-
-
-JPetScin JPetDBParamGetter::generateScintillator(pqxx::result::const_iterator row)
-{
-  int l_scintillator_id = row["scintillator_id"].as<int>();
-
-  double l_scintillator_length = row["scintillator_length"].as<double>();
-  double l_scintillator_width = row["scintillator_width"].as<double>();
-  double l_scintillator_height = row["scintillator_height"].as<double>();
-
-  JPetScin l_scin(l_scintillator_id,
-                  0.f,			/// @todo what is attenuation length in database?
-                  l_scintillator_length,
-                  l_scintillator_height,
-                  l_scintillator_width);
-
-  return l_scin;
-}
-
-
-JPetPM JPetDBParamGetter::generatePM(pqxx::result::const_iterator row)
-{
-  bool l_hvpmconnection_isrightside = row["hvpmconnection_isrightside"].as<bool>();
-
-  int l_photomultiplier_id = row["photomultiplier_id"].as<int>();
-
-  JPetPM::Side l_side = (l_hvpmconnection_isrightside) ? JPetPM::Side::SideB : JPetPM::Side::SideA;
-
-  JPetPM l_pm(l_photomultiplier_id);
-  l_pm.setSide(l_side);
-
-  return  l_pm;
-}
-
-JPetPMCalib JPetDBParamGetter::generatePMCalib(pqxx::result::const_iterator row)
-{
-  int l_pm_calibration_id = row["pm_calibration_id"].as<int>();
-  std::string l_pm_calibration_name = row["pm_calibration_name"].as<std::string>();
-  double l_pm_calibration_opthv = row["pm_calibration_opthv"].as<double>();
-  double l_pm_calibration_c2e_1 = row["pm_calibration_c2e_1"].as<double>();
-  double l_pm_calibration_c2e_2 = row["pm_calibration_c2e_2"].as<double>();
-  double l_pm_calibration_gainalpha = row["pm_calibration_gainalpha"].as<double>();
-  double l_pm_calibration_gainbeta = row["pm_calibration_gainbeta"].as<double>();
-  int l_pm_calibration_assignment_id = row["pm_calibration_assignment_id"].as<int>();
-  int l_pm_calibration_assignment_photomuliplier_id = row["pm_calibration_assignment_photomuliplier_id"].as<int>();
-
-  JPetPMCalib l_PMCalib(l_pm_calibration_id,
-                        l_pm_calibration_name,
-                        l_pm_calibration_opthv,
-                        l_pm_calibration_c2e_1,
-                        l_pm_calibration_c2e_2,
-                        l_pm_calibration_gainalpha,
-                        l_pm_calibration_gainbeta,
-                        l_pm_calibration_assignment_id,
-                        l_pm_calibration_assignment_photomuliplier_id);
-
-  return l_PMCalib;
-}
-
-JPetBarrelSlot JPetDBParamGetter::generateBarrelSlot(pqxx::result::const_iterator row)
-{
-  int l_slot_id = row["slot_id"].as<int>();
-  bool l_slot_isActive = row["slot_isActive"].as<bool>();
-  std::string l_slot_name = row["slot_name"].as<std::string>();
-  double l_slot_theta1 = row["slot_theta1"].as<double>();
-  int l_slot_inFrameId = row["slot_inFrameId"].as<int>();
-
-  JPetBarrelSlot l_barrelSlot(l_slot_id,
-                              l_slot_isActive,
-                              l_slot_name,
-                              l_slot_theta1,
-                              l_slot_inFrameId);
-//  JPetBarrelSlot l_barrelSlot(l_slot_id,
-//			      l_slot_isActive,
-//			      l_slot_name,
-//			      l_slot_theta1,
-//			      l_slot_inFrameId,
-//			      l_layer_id);
-//
-  return l_barrelSlot;
-}
-
-JPetLayer JPetDBParamGetter::generateLayer(pqxx::result::const_iterator row)
-{
-  int l_layer_id = row["layer_id"].as<int>();
-  bool l_layer_isActive = row["layer_isActive"].as<bool>();
-  std::string l_layer_name = row["layer_name"].as<std::string>();
-  double l_layer_radius = row["layer_radius"].as<double>();
-  JPetLayer l_layer(l_layer_id,
-                    l_layer_isActive,
-                    l_layer_name,
-                    l_layer_radius);
-
-  //JPetLayer l_layer(l_layer_id,
-  //      	    l_layer_isActive,
-  //      	    l_layer_name,
-  //      	    l_layer_radius,
-  //      	    l_frame_id);
-  //
-  return l_layer;
-}
-
-JPetFrame JPetDBParamGetter::generateFrame(pqxx::result::const_iterator row)
-{
-  int l_frame_id = row["frame_id"].as<int>();
-  bool l_frame_isActive = row["frame_isActive"].as<bool>();
-  std::string l_frame_status = row["frame_status"].as<std::string>();
-  std::string l_frame_description = row["frame_description"].as<std::string>();
-  int l_frame_version = row["frame_version"].as<int>();
-  int l_frame_creator_id = row["frame_creator_id"].as<int>();
-
-  JPetFrame l_frame(l_frame_id,
-                    l_frame_isActive,
-                    l_frame_status,
-                    l_frame_description,
-                    l_frame_version,
-                    l_frame_creator_id);
-
-  return l_frame;
-}
-
-JPetFEB JPetDBParamGetter::generateFEB(pqxx::result::const_iterator row)
-{
-  int l_konradboard_id = row["konradboard_id"].as<int>();
-  bool l_konradboard_isactive = row["konradboard_isactive"].as<bool>();
-  std::string l_konradboard_status = row["konradboard_status"].as<std::string>();
-  std::string l_konradboard_description = row["konradboard_description"].as<std::string>();
-  int l_konradboard_version = row["konradboard_version"].as<int>();
-  int l_konradboard_creator_id = row["konradboard_creator_id"].as<int>();
-  int l_time_outputs_per_input = row["time_outputs_per_input"].as<int>();
-  int l_notime_outputs_per_input = row["notime_outputs_per_input"].as<int>();
-
-  JPetFEB l_FEB(l_konradboard_id,
-                l_konradboard_isactive,
-                l_konradboard_status,
-                l_konradboard_description,
-                l_konradboard_version,
-                l_konradboard_creator_id,
-                l_time_outputs_per_input,
-                l_notime_outputs_per_input);
-  return l_FEB;
-}
-
-JPetTRB JPetDBParamGetter::generateTRB(pqxx::result::const_iterator row)
-{
-  int l_TRB_id = row["TRB_id"].as<int>();
-
-  JPetTRB l_TRB(l_TRB_id,
-                0,		/// @todo what is type in database
-                0);		/// @todo what is channel in database
-  return l_TRB;
-}
-
-JPetTOMBChannel JPetDBParamGetter::generateTOMBChannel(pqxx::result::const_iterator row) {
-  
-     std::string l_TOMB_description = row["tomb"].as<std::string>();
-     int l_TOMB_no = JPetParamBank::getTOMBChannelFromDescription( l_TOMB_description );
-
-  JPetTOMBChannel l_TOMBChannel(l_TOMB_no);
-  l_TOMBChannel.setLocalChannelNumber(row["thr_num"].as<int>());
-  l_TOMBChannel.setFEBInputNumber(row["feb_input"].as<int>());
-  return l_TOMBChannel;
-}
-
-
-
-
-void JPetDBParamGetter::fillPMsTRefs(const int p_run_id, JPetParamBank& paramBank)
-{
-  INFO("Start filling PMs TRefs.");
-
-		std::string runId = boost::lexical_cast<std::string>(p_run_id);
-  int l_PMsSize = paramBank.getPMsSize();
-  int l_FEBsSize = paramBank.getFEBsSize();
-  int l_ScinsSize = paramBank.getScintillatorsSize();
-  int l_BarrelSlotSize = paramBank.getBarrelSlotsSize();
-
-  if (l_PMsSize > 0 && l_FEBsSize > 0 && l_ScinsSize > 0 && l_BarrelSlotSize > 0) {
-
-    for (auto & content : paramBank.getPMs()) {
-						JPetPM & pm = *content.second;
-						std::string pmId = boost::lexical_cast<std::string>(pm.getID());
-						std::string args = pmId + "," + runId;
-
-      pqxx::result l_runDbResults = getDataFromDB("getKonradBoardsForPhotoMultiplier", args);
-						for (auto row : l_runDbResults) {
-								int relatedId = row["KonradBoard_id"].as<int>();
-
-								pm.setFEB(paramBank.getFEB(relatedId));
-						}
-
-      l_runDbResults = getDataFromDB("getScintillatorsForPhotoMultiplier", args);
-						for (auto row : l_runDbResults) {
-								int relatedId = row["Scintillator_id"].as<int>();
-
-								pm.setScin(paramBank.getScintillator(relatedId));
-						}
-
-      l_runDbResults = getDataFromDB("getbarrelslotforphotomultiplier", args);
-						for (auto row : l_runDbResults) {
-								int relatedId = row["hvpmconnection_slot_id"].as<int>();
-
-								pm.setBarrelSlot(paramBank.getBarrelSlot(relatedId));
-						}
-    }
-  } else {
-    if (l_PMsSize == 0)
-      ERROR("PMs container is empty.");
-    if (l_FEBsSize == 0)
-      ERROR("FEBs container is empty.");
-    if (l_ScinsSize == 0)
-      ERROR("Scintillators container is empty.");
-    if(l_BarrelSlotSize == 0)
-						ERROR("Barrelslot container is empty.");
-  }
-}
-
-void JPetDBParamGetter::fillFEBsTRefs(const int p_run_id, JPetParamBank& paramBank)
-{
-  INFO("Start filling FEBs TRefs.");
-
-		std::string runId = boost::lexical_cast<std::string>(p_run_id);
-  int l_FEBsSize = paramBank.getFEBsSize();
-  int l_TRBsSize = paramBank.getTRBsSize();
-
-  if (l_FEBsSize > 0 && l_TRBsSize > 0) {
-    for (auto & content : paramBank.getFEBs()) {
-						JPetFEB & feb = *content.second;
-						std::string febId = boost::lexical_cast<std::string>(feb.getID());
-						std::string args = febId + "," + runId;
-
-      pqxx::result l_runDbResults = getDataFromDB("getTRBsForKonradBoard",args);
-						for (auto row : l_runDbResults) {
-								int relatedId = row["TRB_id"].as<int>();
-
-								feb.setTRB(paramBank.getTRB(relatedId));
-						}
-    }
-  } else {
-    if (l_FEBsSize == 0)
-      ERROR("FEBs container is empty.");
-    if (l_TRBsSize == 0)
-      ERROR("TRBs container is empty.");
-  }
-}
-
-void JPetDBParamGetter::fillTOMBChannelsTRefs(const int p_run_id, JPetParamBank& paramBank)
-{
-  INFO("Start filling TOMBChannels TRefs.");
-
-		std::string runId = boost::lexical_cast<std::string>(p_run_id);
-  pqxx::result l_runDbResults = getDataFromDB("getEverythingVsTOMB", runId);
-  
-		if (l_runDbResults.size() == 0) {
-				printErrorMessageDB("getDataFromTOMBChannels", p_run_id);
-		}
-
-		for (auto row : l_runDbResults) {
-				int TOMBId = JPetParamBank::getTOMBChannelFromDescription(row["tomb"].as<std::string>());
-				int TRBId = row["trb_id"].as<int>();
-				int FEBId = row["konradboard_id"].as<int>();
-				int PMId = row["photomultiplier_id"].as<int>();
-				float threshold = row["threshold"].as<float>();
-
-				paramBank.getTOMBChannel(TOMBId).setTRB(paramBank.getTRB(TRBId));
-				paramBank.getTOMBChannel(TOMBId).setFEB(paramBank.getFEB(FEBId));
-				paramBank.getTOMBChannel(TOMBId).setPM(paramBank.getPM(PMId));
-				paramBank.getTOMBChannel(TOMBId).setThreshold(threshold);
-		}
-}
-
-void JPetDBParamGetter::fillBarrelSlotTRefs(const int p_run_id, JPetParamBank& paramBank)
-{
-  INFO("Start filling slot TRefs.");
-  
-		std::string runId = boost::lexical_cast<std::string>(p_run_id);
-  int l_barrelSlotsSize = paramBank.getBarrelSlotsSize();
-  int l_layersSize = paramBank.getLayersSize();
-
-  if(l_barrelSlotsSize > 0 && l_layersSize > 0) {
-    for (auto & content : paramBank.getBarrelSlots()) {
-						JPetBarrelSlot & slot = *content.second;
-						std::string slotId = boost::lexical_cast<std::string>(slot.getID());
-						std::string args = slotId + "," + runId;
-
-      pqxx::result l_runDbResults = getDataFromDB("getLayerForBarrelSlot", args);
-      if (l_runDbResults.size() == 0) {
-								std::string querry = "getLayerForBarrelSlot(" + args + ")";
-								ERROR("0 result from querry = " + querry);
-      }
-						for (auto row : l_runDbResults) {
-								int relatedId = row["layer_id"].as<int>();
-
-								slot.setLayer(paramBank.getLayer(relatedId));
-						}
-    }
-  } else {
-    if(l_barrelSlotsSize == 0) {
-      ERROR("BarrelSlot container is empty.");
-    }
-    if(l_layersSize == 0) {
-      ERROR("Layer container is empty.");
-    }
-  }
-}
-
-void JPetDBParamGetter::fillLayerTRefs(const int p_run_id, JPetParamBank& paramBank)
-{
-  INFO("Start filling layer TRefs.");
-  
-		std::string runId = boost::lexical_cast<std::string>(p_run_id);
-  int l_layersSize = paramBank.getLayersSize();
-  int l_framesSize = paramBank.getFramesSize();
-  
-  if(l_layersSize > 0 && l_framesSize > 0) {
-    for (auto & content : paramBank.getLayers()) {
-						JPetLayer & layer = *content.second;
-						std::string layerId = boost::lexical_cast<std::string>(layer.getId());
-						std::string args = layerId + "," + runId;
-
-      pqxx::result l_runDbResults = getDataFromDB("getFrameForLayer", args);
-      if (l_runDbResults.size() == 0) {
-								std::string querry = "getFrameForLayer(" + args + ")";
-								ERROR("0 result from querry = " + querry);
-      }
-						for (auto row : l_runDbResults) {
-								int relatedId = row["frame_id"].as<int>();
-
-								layer.setFrame(paramBank.getFrame(relatedId));
-						}
-    }
-  } else {
-    if(l_layersSize == 0) {
-      ERROR("Layer container is empty.");
-    }
-    if(l_framesSize == 0) {
-      ERROR("Frame container is empty.");
-    }
-  }
-}
-
-void JPetDBParamGetter::fillScinTRef(const int p_run_id, JPetParamBank& paramBank)
-{
-  INFO("Start filling Scintillator TRef.");
-  
-		std::string runId = boost::lexical_cast<std::string>(p_run_id);
-  int l_scintillatorSize = paramBank.getScintillatorsSize();
-  int l_barrelSlotSize = paramBank.getBarrelSlotsSize();
-  
-  if(l_scintillatorSize > 0 && l_barrelSlotSize > 0) {
-    for (auto & content : paramBank.getScintillators()) {
-						JPetScin & scin = *content.second;
-						std::string scinId = boost::lexical_cast<std::string>(scin.getID());
-						std::string args = scinId + "," + runId;
-
-      pqxx::result l_runDbResults = getDataFromDB("getbarrelslotforscintillator", args);
-      if (l_runDbResults.size() == 0) {
-								std::string querry = "getbarrelslotforscintillator(" + args + ")";
-								ERROR("0 result from querry = " + querry);
-      }
-						for (auto row : l_runDbResults) {
-								int relatedId = row["slscconnection_slot_id"].as<int>();
-
-								scin.setBarrelSlot(paramBank.getBarrelSlot(relatedId));
-						}
-    }
-  } 
-  else
-  {
-    if(l_scintillatorSize == 0) {
-						ERROR("Scintillator container is empty.");
-				}
-    if(l_barrelSlotSize == 0) {
-						ERROR("Barrelslot container is empty.");
-				}
-  }
-}
-
-void JPetDBParamGetter::fillAllTRefs(const int p_run_id, JPetParamBank& paramBank)
-{
-  if (paramBank.getScintillatorsSize() > 0
-      && paramBank.getPMsSize() > 0
-      && paramBank.getFEBsSize() > 0
-      && paramBank.getTRBsSize() > 0
-      && paramBank.getBarrelSlotsSize() > 0
-      && paramBank.getLayersSize() > 0
-      && paramBank.getFramesSize() > 0
-     ) {
-    fillPMsTRefs(p_run_id, paramBank);
-    fillFEBsTRefs(p_run_id, paramBank);
-    //fillTRBsTRefs(p_run_id, paramBank);
-    fillTOMBChannelsTRefs(p_run_id, paramBank);
-
-    fillBarrelSlotTRefs(p_run_id, paramBank);
-    fillLayerTRefs(p_run_id, paramBank);
-    fillScinTRef(p_run_id, paramBank);
-  } else {
-    ERROR("Containers are empty.");
-  }
+  std::string l_error(sqlFunction);
+  l_error += "() query with run_id = ";
+  l_error += boost::lexical_cast<std::string>(p_run_id) + " returned 0 records.";
+  ERROR(l_error.c_str());
 }

--- a/JPetDBParamGetter/JPetDBParamGetter.h
+++ b/JPetDBParamGetter/JPetDBParamGetter.h
@@ -16,7 +16,7 @@
 #ifndef JPETDBPARAMGETTER_H
 #define JPETDBPARAMGETTER_H
 
-#include "../JPetParamBank/JPetParamBank.h"
+#include "../JPetParamGetter/JPetParamGetter.h"
 #ifndef __CINT__
 #include <pqxx/pqxx>
 #else
@@ -25,56 +25,24 @@ class pqxx::result;
 class pqxx::result::const_iterator;
 #endif /* __CINT __ */
 
-class JPetParamManager;
-
 class JPetDBParamGetter : public JPetParamGetter
 {
 public:
-  JPetDBParamGetter();
-  ~JPetDBParamGetter();
-  JPetParamBank* generateParamBank(const int p_run_id);
-  static void clearParamCache(); ///Dangerous cause it is shared by all threads
+  JPetDBParamGetter() {}
+  ~JPetDBParamGetter() {}
+  ParamObjectsDescriptions getAllBasicData(ParamObjectType type, const int runId);
+  ParamRelationalData getAllRelationalData(ParamObjectType type1, ParamObjectType type2, const int runId);
+  static void clearParamCache();
   
 private:
   JPetDBParamGetter(const JPetDBParamGetter &DBParamGetter);
   JPetDBParamGetter& operator=(const JPetDBParamGetter &DBParamGetter);
   
-private:
   pqxx::result getDataFromDB(const std::string& sqlFunction, const std::string& args);
   std::string generateSelectQuery(const std::string& sqlFunction, const std::string& args);
   void printErrorMessageDB(std::string sqlFunction, int p_run_id);
-  JPetScin generateScintillator(pqxx::result::const_iterator row);
-  JPetPM generatePM(pqxx::result::const_iterator row);
-  JPetPMCalib generatePMCalib(pqxx::result::const_iterator row);
-  JPetBarrelSlot generateBarrelSlot(pqxx::result::const_iterator row);
-  JPetLayer generateLayer(pqxx::result::const_iterator row);
-  JPetFrame generateFrame(pqxx::result::const_iterator row);
-  JPetFEB generateFEB(pqxx::result::const_iterator row);
-  JPetTRB generateTRB(pqxx::result::const_iterator row);
-  JPetTOMBChannel generateTOMBChannel(pqxx::result::const_iterator row);
 
-  void fillScintillators(const int p_run_id, JPetParamBank& paramBank);
-  void fillParamContainer(JPetParamBank::ParamObjectType type, const int p_run_id, JPetParamBank& paramBank);
-
-  void fillPMs(const int p_run_id, JPetParamBank& paramBank);
-  void fillPMCalibs(const int p_run_id, JPetParamBank& paramBank);
-  void fillBarrelSlot(const int p_run_id, JPetParamBank& paramBank);
-  void fillLayer(const int p_run_id, JPetParamBank& paramBank);
-  void fillFrame(const int p_run_id, JPetParamBank& paramBank);
-  void fillFEBs(const int p_run_id, JPetParamBank& paramBank);
-  void fillTOMBChannels(const int p_run_id, JPetParamBank& paramBank);
-  void fillTRBs(const int p_run_id, JPetParamBank& paramBank);
-  void fillPMsTRefs(const int p_run_id, JPetParamBank& paramBank);
-  void fillFEBsTRefs(const int p_run_id, JPetParamBank& paramBank);
-  void fillTOMBChannelsTRefs(const int p_run_id, JPetParamBank& paramBank);
-  void fillBarrelSlotTRefs(const int p_run_id, JPetParamBank& paramBank);
-  void fillLayerTRefs(const int p_run_id, JPetParamBank& paramBank);
-  void fillScinTRef(const int p_run_id, JPetParamBank& paramBank);
-  void fillAllTRefs(const int p_run_id, JPetParamBank& paramBank);
-
-  
-  friend class JPetParamManager;
-
-  static std::map<int, JPetParamBank*> gParamCache;
+  static std::map<int, std::map<ParamObjectType, ParamObjectsDescriptions>> gBasicDataCache;
+  static std::map<int, std::map<ParamObjectType, std::map<ParamObjectType, ParamRelationalData>>> gRelationalDataCache;
 };
 #endif /*  !JPETDBPARAMGETTER_H */

--- a/JPetFEB/JPetFEBFactory.cpp
+++ b/JPetFEB/JPetFEBFactory.cpp
@@ -1,0 +1,63 @@
+/**
+ *  @copyright Copyright 2016 The J-PET Framework Authors. All rights reserved.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may find a copy of the License in the LICENCE file.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  @file JPetFEBFactory.cpp
+ */
+
+#include "JPetFEBFactory.h"
+
+#include <exception>
+#include <string>
+#include <tuple>
+#include <boost/lexical_cast.hpp>
+
+std::map<int, JPetFEB *> & JPetFEBFactory::getFEBs()
+{
+  if (!fInitialized) {
+    initialize();
+  }
+  return fFEBs;
+}
+
+void JPetFEBFactory::initialize()
+{
+  ParamObjectsDescriptions descriptions = paramGetter.getAllBasicData(ParamObjectType::kFEB, runId);
+  if (descriptions.size() == 0) {
+    ERROR(std::string("No FEBs in run ") + boost::lexical_cast<std::string>(runId));
+  }
+  for (auto description : descriptions) {
+    fFEBs[description.first] = build(description.second);
+  }
+  fInitialized = true;
+  ParamRelationalData relations = paramGetter.getAllRelationalData(ParamObjectType::kFEB, ParamObjectType::kTRB, runId);
+  for (auto relation : relations) {
+    fFEBs[relation.first]->setTRB(*trbFactory.getTRBs().at(relation.second));
+  }
+}
+
+JPetFEB * JPetFEBFactory::build(ParamObjectDescription data)
+{
+  try {
+    int id = boost::lexical_cast<int>(data.at("id"));
+    bool active = boost::lexical_cast<bool>(data.at("active"));
+    std::string status = data.at("status");
+    std::string description = data.at("description");
+    int version = boost::lexical_cast<int>(data.at("version"));
+    int creatorId = boost::lexical_cast<int>(data.at("creator_id"));
+    int timeOutputsPerInput = boost::lexical_cast<int>(data.at("time_outputs_per_input"));
+    int noTimeOutputsPerInput = boost::lexical_cast<int>(data.at("no_time_outputs_per_input"));
+    return new JPetFEB(id, active, status, description, version, creatorId, timeOutputsPerInput, noTimeOutputsPerInput);
+  } catch (const std::exception & e) {
+    ERROR(std::string("Failed to build FEB with error: ") + e.what());
+    throw;
+  }
+}

--- a/JPetFEB/JPetFEBFactory.h
+++ b/JPetFEB/JPetFEBFactory.h
@@ -1,0 +1,52 @@
+/**
+ *  @copyright Copyright 2016 The J-PET Framework Authors. All rights reserved.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may find a copy of the License in the LICENCE file.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  @file JPetFEBFactory.h
+ */
+
+#ifndef JPET_FEB_FACTORY_H
+#define JPET_FEB_FACTORY_H
+
+#include "../JPetParamGetter/JPetParamGetter.h"
+#include "JPetFEB.h"
+#include "../JPetTRB/JPetTRBFactory.h"
+
+#include <map>
+
+/**
+ * @brief A factory of JPetFEB objects.
+ *
+ * This class is able to create those objects using data from the database.
+ */
+class JPetFEBFactory
+{
+  public:
+    JPetFEBFactory(JPetParamGetter & paramGetter, int runId, JPetTRBFactory & trbFactory) :
+      paramGetter(paramGetter),
+      runId(runId),
+      trbFactory(trbFactory),
+      fInitialized(false) {}
+
+    std::map<int, JPetFEB *> & getFEBs();
+  private:
+    JPetParamGetter & paramGetter;
+    const int runId;
+    JPetTRBFactory & trbFactory;
+
+    bool fInitialized;
+    std::map<int, JPetFEB *> fFEBs;
+
+    void initialize();
+    JPetFEB * build(ParamObjectDescription data);
+};
+
+#endif // JPET_FEB_FACTORY_H

--- a/JPetFEB/JPetFEBTest.cpp
+++ b/JPetFEB/JPetFEBTest.cpp
@@ -1,0 +1,231 @@
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE JPetFEBTest
+#include <boost/test/unit_test.hpp>
+#include "JPetFEB.h"
+#include "JPetFEBFactory.h"
+
+BOOST_AUTO_TEST_SUITE(FirstSuite)
+
+BOOST_AUTO_TEST_CASE( parametrized_constructor )
+{
+  JPetFEB feb(1, true, "healthy", "tall", 27, 44, 2, 3);
+  BOOST_REQUIRE_EQUAL(feb.getID(), 1);
+  BOOST_REQUIRE(feb.isActive());
+  BOOST_REQUIRE(feb.status()=="healthy");
+  BOOST_REQUIRE(feb.description()=="tall");
+  BOOST_REQUIRE_EQUAL(feb.version(), 27);
+  BOOST_REQUIRE_EQUAL(feb.getCreator(), 44);
+  BOOST_REQUIRE_EQUAL(feb.getNtimeOutsPerInput(), 2);
+  BOOST_REQUIRE_EQUAL(feb.getNnotimeOutsPerInput(), 3);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE(FactorySuite)
+
+class TestParamGetter : public JPetParamGetter
+{
+  ParamObjectsDescriptions getAllBasicData(ParamObjectType type, const int runId)
+  {
+    ParamObjectsDescriptions result;
+    switch (type) {
+      case ParamObjectType::kFEB:
+        switch (runId) {
+          case 0: //No febs
+            break;
+          case 1: //Simple single object
+          case 5: //Wrong relation
+            result = {
+              {1, {
+                    {"id", "1"},
+                    {"active", "1"},
+                    {"status", "healthy"},
+                    {"description", "tall"},
+                    {"version", "27"},
+                    {"creator_id", "44"},
+                    {"time_outputs_per_input", "2"},
+                    {"no_time_outputs_per_input", "3"}
+                  }
+              }
+            };
+            break;
+          case 2: //Simple two objects
+            result = {
+              {1, {
+                    {"id", "1"},
+                    {"active", "1"},
+                    {"status", "healthy"},
+                    {"description", "tall"},
+                    {"version", "27"},
+                    {"creator_id", "44"},
+                    {"time_outputs_per_input", "2"},
+                    {"no_time_outputs_per_input", "3"}
+                  }
+              },
+              {5, {
+                    {"id", "5"},
+                    {"active", "0"},
+                    {"status", "fainted"},
+                    {"description", "scrawny"},
+                    {"version", "271"},
+                    {"creator_id", "616"},
+                    {"time_outputs_per_input", "3"},
+                    {"no_time_outputs_per_input", "4"}
+                  }
+              }
+            };
+            break;
+          case 3: //Object with missing field
+            result = {
+              {1, {
+                    {"id", "1"},
+                    {"active", "1"},
+                    {"status", "healthy"},
+                    {"version", "27"},
+                    {"creator_id", "44"},
+                    {"time_outputs_per_input", "2"},
+                    {"no_time_outputs_per_input", "3"}
+                  }
+              }
+            };
+            break;
+          case 4: //Object with wrong field
+            result = {
+              {1, {
+                    {"id", "1"},
+                    {"active", "probably"},
+                    {"status", "healthy"},
+                    {"version", "27"},
+                    {"creator_id", "44"},
+                    {"time_outputs_per_input", "2"},
+                    {"no_time_outputs_per_input", "3"}
+                  }
+              }
+            };
+            break;
+        }
+        break;
+      case ParamObjectType::kTRB:
+        result = {
+          {1, {
+                {"id", "1"},
+                {"type", "1"},
+                {"channel", "224"}
+              }
+          }
+        };
+        break;
+      default: //Other cases not needed.
+        break;
+    }
+    return result;
+  }
+  ParamRelationalData getAllRelationalData(ParamObjectType, ParamObjectType, const int runId)
+  {
+    ParamRelationalData result;
+    switch (runId) {
+      case 0: //No relations
+        break;
+      case 1: //Simple single object
+        result = {
+          {1, 1}
+        };
+        break;
+      case 2: //Simple two objects
+        result = {
+          {1, 1},
+          {5, 1}
+        };
+        break;
+      case 5: //Wrong relation
+        result = {
+          {1, 43}
+        };
+        break;
+    }
+    return result;
+  }
+};
+
+TestParamGetter paramGetter;
+
+BOOST_AUTO_TEST_CASE( no_febs )
+{
+  JPetTRBFactory trbFactory(paramGetter, 0);
+  JPetFEBFactory factory(paramGetter, 0, trbFactory);
+  auto & febs = factory.getFEBs();
+  BOOST_REQUIRE_EQUAL(febs.size(), 0);
+}
+
+BOOST_AUTO_TEST_CASE( single_object )
+{
+  JPetTRBFactory trbFactory(paramGetter, 1);
+  JPetFEBFactory factory(paramGetter, 1, trbFactory);
+  auto & febs = factory.getFEBs();
+  BOOST_REQUIRE_EQUAL(febs.size(), 1);
+  auto feb = febs[1];
+  BOOST_REQUIRE_EQUAL(feb->getID(), 1);
+  BOOST_REQUIRE(feb->isActive());
+  BOOST_REQUIRE(feb->status()=="healthy");
+  BOOST_REQUIRE(feb->description()=="tall");
+  BOOST_REQUIRE_EQUAL(feb->version(), 27);
+  BOOST_REQUIRE_EQUAL(feb->getCreator(), 44);
+  BOOST_REQUIRE_EQUAL(feb->getNtimeOutsPerInput(), 2);
+  BOOST_REQUIRE_EQUAL(feb->getNnotimeOutsPerInput(), 3);
+
+  BOOST_REQUIRE_EQUAL(feb->getTRB().getID(), trbFactory.getTRBs().at(1)->getID());
+}
+
+BOOST_AUTO_TEST_CASE( two_objects )
+{
+  JPetTRBFactory trbFactory(paramGetter, 2);
+  JPetFEBFactory factory(paramGetter, 2, trbFactory);
+  auto & febs = factory.getFEBs();
+  BOOST_REQUIRE_EQUAL(febs.size(), 2);
+  auto feb = febs[1];
+  BOOST_REQUIRE_EQUAL(feb->getID(), 1);
+  BOOST_REQUIRE(feb->isActive());
+  BOOST_REQUIRE(feb->status()=="healthy");
+  BOOST_REQUIRE(feb->description()=="tall");
+  BOOST_REQUIRE_EQUAL(feb->version(), 27);
+  BOOST_REQUIRE_EQUAL(feb->getCreator(), 44);
+  BOOST_REQUIRE_EQUAL(feb->getNtimeOutsPerInput(), 2);
+  BOOST_REQUIRE_EQUAL(feb->getNnotimeOutsPerInput(), 3);
+
+  BOOST_REQUIRE_EQUAL(feb->getTRB().getID(), trbFactory.getTRBs().at(1)->getID());
+
+  feb = febs[5];
+  BOOST_REQUIRE_EQUAL(feb->getID(), 5);
+  BOOST_REQUIRE(!feb->isActive());
+  BOOST_REQUIRE(feb->status()=="fainted");
+  BOOST_REQUIRE(feb->description()=="scrawny");
+  BOOST_REQUIRE_EQUAL(feb->version(), 271);
+  BOOST_REQUIRE_EQUAL(feb->getCreator(), 616);
+  BOOST_REQUIRE_EQUAL(feb->getNtimeOutsPerInput(), 3);
+  BOOST_REQUIRE_EQUAL(feb->getNnotimeOutsPerInput(), 4);
+
+  BOOST_REQUIRE_EQUAL(feb->getTRB().getID(), trbFactory.getTRBs().at(1)->getID());
+}
+
+BOOST_AUTO_TEST_CASE( missing_field )
+{
+  JPetTRBFactory trbFactory(paramGetter, 3);
+  JPetFEBFactory factory(paramGetter, 3, trbFactory);
+  BOOST_REQUIRE_THROW(factory.getFEBs(), std::out_of_range);
+}
+
+BOOST_AUTO_TEST_CASE( wrong_field )
+{
+  JPetTRBFactory trbFactory(paramGetter, 4);
+  JPetFEBFactory factory(paramGetter, 4, trbFactory);
+  BOOST_REQUIRE_THROW(factory.getFEBs(), std::bad_cast);
+}
+
+BOOST_AUTO_TEST_CASE( wrong_relation )
+{
+  JPetTRBFactory trbFactory(paramGetter, 5);
+  JPetFEBFactory factory(paramGetter, 5, trbFactory);
+  BOOST_REQUIRE_THROW(factory.getFEBs(), std::out_of_range);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/JPetFrame/JPetFrameFactory.cpp
+++ b/JPetFrame/JPetFrameFactory.cpp
@@ -1,0 +1,57 @@
+/**
+ *  @copyright Copyright 2016 The J-PET Framework Authors. All rights reserved.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may find a copy of the License in the LICENCE file.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  @file JPetFrameFactory.cpp
+ */
+
+#include "JPetFrameFactory.h"
+
+#include <exception>
+#include <string>
+#include <tuple>
+#include <boost/lexical_cast.hpp>
+
+std::map<int, JPetFrame *> & JPetFrameFactory::getFrames()
+{
+  if (!fInitialized) {
+    initialize();
+  }
+  return fFrames;
+}
+
+void JPetFrameFactory::initialize()
+{
+  ParamObjectsDescriptions descriptions = paramGetter.getAllBasicData(ParamObjectType::kFrame, runId);
+  if (descriptions.size() == 0) {
+    ERROR(std::string("No frames in run ") + boost::lexical_cast<std::string>(runId));
+  }
+  for (auto description : descriptions) {
+    fFrames[description.first] = build(description.second);
+  }
+  fInitialized = true;
+}
+
+JPetFrame * JPetFrameFactory::build(ParamObjectDescription data)
+{
+  try {
+    int id = boost::lexical_cast<int>(data.at("id"));
+    bool active = boost::lexical_cast<bool>(data.at("active"));
+    std::string status = data.at("status");
+    std::string description = data.at("description");
+    int version = boost::lexical_cast<int>(data.at("version"));
+    int creatorId = boost::lexical_cast<int>(data.at("creator_id"));
+    return new JPetFrame(id, active, status, description, version, creatorId);
+  } catch (const std::exception & e) {
+    ERROR(std::string("Failed to build frame with error: ") + e.what());
+    throw;
+  }
+}

--- a/JPetFrame/JPetFrameFactory.h
+++ b/JPetFrame/JPetFrameFactory.h
@@ -1,0 +1,49 @@
+/**
+ *  @copyright Copyright 2016 The J-PET Framework Authors. All rights reserved.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may find a copy of the License in the LICENCE file.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  @file JPetFrameFactory.h
+ */
+
+#ifndef JPET_FRAME_FACTORY_H
+#define JPET_FRAME_FACTORY_H
+
+#include "../JPetParamGetter/JPetParamGetter.h"
+#include "JPetFrame.h"
+
+#include <map>
+
+/**
+ * @brief A factory of JPetFrame objects.
+ *
+ * This class is able to create those objects using data from the database.
+ */
+class JPetFrameFactory
+{
+  public:
+    JPetFrameFactory(JPetParamGetter & paramGetter, int runId) :
+      paramGetter(paramGetter),
+      runId(runId),
+      fInitialized(false) {}
+
+    std::map<int, JPetFrame *> & getFrames();
+  private:
+    JPetParamGetter & paramGetter;
+    const int runId;
+
+    bool fInitialized;
+    std::map<int, JPetFrame *> fFrames;
+
+    void initialize();
+    JPetFrame * build(ParamObjectDescription data);
+};
+
+#endif // JPET_FRAME_FACTORY_H

--- a/JPetFrame/JPetFrameTest.cpp
+++ b/JPetFrame/JPetFrameTest.cpp
@@ -3,6 +3,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include "../JPetFrame/JPetFrame.h"
+#include "../JPetFrame/JPetFrameFactory.h"
 
 // JPetFrame();
 // JPetFrame(int id, bool isActive, std::string status, std::string description, int version, int creator_id);
@@ -32,13 +33,147 @@ BOOST_AUTO_TEST_CASE( default_constructor )
 
 BOOST_AUTO_TEST_CASE( second_constructor )
 {
-  JPetFrame frame(1, true, "ok", "descr1", 2.0, 1);
+  JPetFrame frame(1, true, "ok", "descr1", 2, 1);
   BOOST_REQUIRE_EQUAL(frame.getId(), 1);
   BOOST_REQUIRE(frame.getIsActive());
   BOOST_REQUIRE(frame.getStatus()=="ok");
   BOOST_REQUIRE(frame.getDescription()== "descr1");
-  BOOST_REQUIRE_EQUAL(frame.getVersion(), 2.0);
+  BOOST_REQUIRE_EQUAL(frame.getVersion(), 2);
   BOOST_REQUIRE_EQUAL(frame.getCreator(), 1);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE(FactorySuite)
+
+class TestParamGetter : public JPetParamGetter
+{
+  ParamObjectsDescriptions getAllBasicData(ParamObjectType, const int runId)
+  {
+    ParamObjectsDescriptions result;
+    switch (runId) {
+      case 0: //No frames
+        break;
+      case 1: //Simple single object
+        result = {
+          {1, {
+                {"id", "1"},
+                {"active", "1"},
+                {"status", "ok"},
+                {"description", "descr1"},
+                {"version", "2"},
+                {"creator_id", "1"}
+              }
+          }
+        };
+        break;
+      case 2: //Simple two objects
+        result = {
+          {1, {
+                {"id", "1"},
+                {"active", "1"},
+                {"status", "ok"},
+                {"description", "descr1"},
+                {"version", "2"},
+                {"creator_id", "1"}
+              }
+          },
+          {5, {
+                {"id", "5"},
+                {"active", "0"},
+                {"status", "fainted"},
+                {"description", "looks like a fish"},
+                {"version", "1"},
+                {"creator_id", "99"}
+              }
+          }
+        };
+        break;
+      case 3: //Object with missing field
+        result = {
+          {1, {
+                {"id", "1"},
+                {"active", "1"},
+                {"status", "ok"},
+                {"version", "2"},
+                {"creator_id", "1"}
+              }
+          }
+        };
+        break;
+      case 4: //Object with wrong field
+        result = {
+          {1, {
+                {"id", "1"},
+                {"active", "probably"},
+                {"status", "ok"},
+                {"description", "descr1"},
+                {"version", "2"},
+                {"creator_id", "1"}
+              }
+          }
+        };
+        break;
+    }
+    return result;
+  }
+  ParamRelationalData getAllRelationalData(ParamObjectType, ParamObjectType, const int) {return ParamRelationalData();} //Irrelevant for this test.
+};
+
+TestParamGetter paramGetter;
+
+BOOST_AUTO_TEST_CASE( no_frames )
+{
+  JPetFrameFactory factory(paramGetter, 0);
+  auto & frames = factory.getFrames();
+  BOOST_REQUIRE_EQUAL(frames.size(), 0);
+}
+
+BOOST_AUTO_TEST_CASE( single_object )
+{
+  JPetFrameFactory factory(paramGetter, 1);
+  auto & frames = factory.getFrames();
+  BOOST_REQUIRE_EQUAL(frames.size(), 1);
+  auto frame = frames[1];
+  BOOST_REQUIRE_EQUAL(frame->getId(), 1);
+  BOOST_REQUIRE(frame->getIsActive());
+  BOOST_REQUIRE(frame->getStatus()=="ok");
+  BOOST_REQUIRE(frame->getDescription()== "descr1");
+  BOOST_REQUIRE_EQUAL(frame->getVersion(), 2);
+  BOOST_REQUIRE_EQUAL(frame->getCreator(), 1);
+}
+
+BOOST_AUTO_TEST_CASE( two_objects )
+{
+  JPetFrameFactory factory(paramGetter, 2);
+  auto & frames = factory.getFrames();
+  BOOST_REQUIRE_EQUAL(frames.size(), 2);
+  auto frame = frames[1];
+  BOOST_REQUIRE_EQUAL(frame->getId(), 1);
+  BOOST_REQUIRE(frame->getIsActive());
+  BOOST_REQUIRE(frame->getStatus()=="ok");
+  BOOST_REQUIRE(frame->getDescription()== "descr1");
+  BOOST_REQUIRE_EQUAL(frame->getVersion(), 2);
+  BOOST_REQUIRE_EQUAL(frame->getCreator(), 1);
+  frame = frames[5];
+  BOOST_REQUIRE_EQUAL(frame->getId(), 5);
+  BOOST_REQUIRE(!frame->getIsActive());
+  BOOST_REQUIRE(frame->getStatus()=="fainted");
+  BOOST_REQUIRE(frame->getDescription()== "looks like a fish");
+  BOOST_REQUIRE_EQUAL(frame->getVersion(), 1);
+  BOOST_REQUIRE_EQUAL(frame->getCreator(), 99);
+}
+
+BOOST_AUTO_TEST_CASE( missing_field )
+{
+  JPetFrameFactory factory(paramGetter, 3);
+  BOOST_REQUIRE_THROW(factory.getFrames(), std::out_of_range);
+}
+
+BOOST_AUTO_TEST_CASE( wrong_field )
+{
+  JPetFrameFactory factory(paramGetter, 4);
+  BOOST_REQUIRE_THROW(factory.getFrames(), std::bad_cast);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/JPetLayer/JPetLayerFactory.cpp
+++ b/JPetLayer/JPetLayerFactory.cpp
@@ -1,0 +1,59 @@
+/**
+ *  @copyright Copyright 2016 The J-PET Framework Authors. All rights reserved.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may find a copy of the License in the LICENCE file.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  @file JPetLayerFactory.cpp
+ */
+
+#include "JPetLayerFactory.h"
+
+#include <exception>
+#include <string>
+#include <tuple>
+#include <boost/lexical_cast.hpp>
+
+std::map<int, JPetLayer *> & JPetLayerFactory::getLayers()
+{
+  if (!fInitialized) {
+    initialize();
+  }
+  return fLayers;
+}
+
+void JPetLayerFactory::initialize()
+{
+  ParamObjectsDescriptions descriptions = paramGetter.getAllBasicData(ParamObjectType::kLayer, runId);
+  if (descriptions.size() == 0) {
+    ERROR(std::string("No layers in run ") + boost::lexical_cast<std::string>(runId));
+  }
+  for (auto description : descriptions) {
+    fLayers[description.first] = build(description.second);
+  }
+  fInitialized = true;
+  ParamRelationalData relations = paramGetter.getAllRelationalData(ParamObjectType::kLayer, ParamObjectType::kFrame, runId);
+  for (auto relation : relations) {
+    fLayers[relation.first]->setFrame(*frameFactory.getFrames().at(relation.second));
+  }
+}
+
+JPetLayer * JPetLayerFactory::build(ParamObjectDescription data)
+{
+  try {
+    int id = boost::lexical_cast<int>(data.at("id"));
+    bool active = boost::lexical_cast<bool>(data.at("active"));
+    std::string name = data.at("name");
+    float radius = boost::lexical_cast<float>(data.at("radius"));
+    return new JPetLayer(id, active, name, radius);
+  } catch (const std::exception & e) {
+    ERROR(std::string("Failed to build layer with error: ") + e.what());
+    throw;
+  }
+}

--- a/JPetLayer/JPetLayerFactory.h
+++ b/JPetLayer/JPetLayerFactory.h
@@ -1,0 +1,52 @@
+/**
+ *  @copyright Copyright 2016 The J-PET Framework Authors. All rights reserved.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may find a copy of the License in the LICENCE file.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  @file JPetLayerFactory.h
+ */
+
+#ifndef JPET_LAYER_FACTORY_H
+#define JPET_LAYER_FACTORY_H
+
+#include "../JPetParamGetter/JPetParamGetter.h"
+#include "JPetLayer.h"
+#include "../JPetFrame/JPetFrameFactory.h"
+
+#include <map>
+
+/**
+ * @brief A factory of JPetLayer objects.
+ *
+ * This class is able to create those objects using data from the database.
+ */
+class JPetLayerFactory
+{
+  public:
+    JPetLayerFactory(JPetParamGetter & paramGetter, int runId, JPetFrameFactory & frameFactory) :
+      paramGetter(paramGetter),
+      runId(runId),
+      frameFactory(frameFactory),
+      fInitialized(false) {}
+
+    std::map<int, JPetLayer *> & getLayers();
+  private:
+    JPetParamGetter & paramGetter;
+    const int runId;
+    JPetFrameFactory & frameFactory;
+
+    bool fInitialized;
+    std::map<int, JPetLayer *> fLayers;
+
+    void initialize();
+    JPetLayer * build(ParamObjectDescription data);
+};
+
+#endif // JPET_LAYER_FACTORY_H

--- a/JPetLayer/JPetLayerTest.cpp
+++ b/JPetLayer/JPetLayerTest.cpp
@@ -1,7 +1,8 @@
 #define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MODULE JPetLayerTest
 #include <boost/test/unit_test.hpp>
-#include "../JPetLayer/JPetLayer.h"
+#include "JPetLayer.h"
+#include "JPetLayerFactory.h"
 
 
 // JPetLayer();
@@ -17,12 +18,13 @@
 // inline const JPetFrame& getFrame() { return static_cast<JPetFrame&>(*(fTRefFrame.GetObject())); }
 // inline void setFrame(JPetFrame &frame) { fTRefFrame = &frame; }
 
+const double epsilon =0.00001;
+
 BOOST_AUTO_TEST_SUITE(FirstSuite)
 
 BOOST_AUTO_TEST_CASE( default_constructor )
 {
   JPetLayer layer;
-  double epsilon =0.00001;
   BOOST_REQUIRE_EQUAL(layer.getId(), -1);
   BOOST_REQUIRE(!layer.getIsActive());
   BOOST_REQUIRE(layer.getName().empty());
@@ -32,11 +34,191 @@ BOOST_AUTO_TEST_CASE( default_constructor )
 BOOST_AUTO_TEST_CASE( second_constructor )
 {
   JPetLayer layer(1, true, "ala", 10.5);
-  double epsilon =0.00001;
   BOOST_REQUIRE_EQUAL(layer.getId(), 1);
   BOOST_REQUIRE(layer.getIsActive());
   BOOST_REQUIRE(layer.getName()=="ala");
   BOOST_REQUIRE_CLOSE(layer.getRadius(), 10.5, epsilon);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE(FactorySuite)
+
+class TestParamGetter : public JPetParamGetter
+{
+  ParamObjectsDescriptions getAllBasicData(ParamObjectType type, const int runId)
+  {
+    ParamObjectsDescriptions result;
+    switch (type) {
+      case ParamObjectType::kLayer:
+        switch (runId) {
+          case 0: //No layers
+            break;
+          case 1: //Simple single object
+          case 5: //Wrong relation
+            result = {
+              {1, {
+                    {"id", "1"},
+                    {"active", "1"},
+                    {"name", "ala"},
+                    {"radius", "10.5"}
+                  }
+              }
+            };
+            break;
+          case 2: //Simple two objects
+            result = {
+              {1, {
+                    {"id", "1"},
+                    {"active", "1"},
+                    {"name", "ala"},
+                    {"radius", "10.5"}
+                  }
+              },
+              {5, {
+                    {"id", "5"},
+                    {"active", "0"},
+                    {"name", "alfred"},
+                    {"radius", "11.5"}
+                  }
+              }
+            };
+            break;
+          case 3: //Object with missing field
+            result = {
+              {1, {
+                    {"id", "1"},
+                    {"active", "1"},
+                    {"radius", "10.5"}
+                  }
+              }
+            };
+            break;
+          case 4: //Object with wrong field
+            result = {
+              {1, {
+                    {"id", "1"},
+                    {"active", "probably"},
+                    {"name", "ala"},
+                    {"radius", "10.5"}
+                  }
+              }
+            };
+            break;
+        }
+        break;
+      case ParamObjectType::kFrame:
+        result = {
+          {1, {
+                {"id", "1"},
+                {"active", "1"},
+                {"status", "ok"},
+                {"description", "descr1"},
+                {"version", "2"},
+                {"creator_id", "1"}
+              }
+          }
+        };
+        break;
+      default: //Other cases not needed.
+        break;
+    }
+    return result;
+  }
+  ParamRelationalData getAllRelationalData(ParamObjectType, ParamObjectType, const int runId)
+  {
+    ParamRelationalData result;
+    switch (runId) {
+      case 0: //No relations
+        break;
+      case 1: //Simple single object
+        result = {
+          {1, 1}
+        };
+        break;
+      case 2: //Simple two objects
+        result = {
+          {1, 1},
+          {5, 1}
+        };
+        break;
+      case 5: //Wrong relation
+        result = {
+          {1, 43}
+        };
+        break;
+    }
+    return result;
+  }
+};
+
+TestParamGetter paramGetter;
+
+BOOST_AUTO_TEST_CASE( no_layers )
+{
+  JPetFrameFactory frameFactory(paramGetter, 0);
+  JPetLayerFactory factory(paramGetter, 0, frameFactory);
+  auto & layers = factory.getLayers();
+  BOOST_REQUIRE_EQUAL(layers.size(), 0);
+}
+
+BOOST_AUTO_TEST_CASE( single_object )
+{
+  JPetFrameFactory frameFactory(paramGetter, 1);
+  JPetLayerFactory factory(paramGetter, 1, frameFactory);
+  auto & layers = factory.getLayers();
+  BOOST_REQUIRE_EQUAL(layers.size(), 1);
+  auto layer = layers[1];
+  BOOST_REQUIRE_EQUAL(layer->getId(), 1);
+  BOOST_REQUIRE(layer->getIsActive());
+  BOOST_REQUIRE(layer->getName()=="ala");
+  BOOST_REQUIRE_CLOSE(layer->getRadius(), 10.5, epsilon);
+
+  BOOST_REQUIRE_EQUAL(layer->getFrame().getId(), frameFactory.getFrames().at(1)->getId());
+}
+
+BOOST_AUTO_TEST_CASE( two_objects )
+{
+  JPetFrameFactory frameFactory(paramGetter, 2);
+  JPetLayerFactory factory(paramGetter, 2, frameFactory);
+  auto & layers = factory.getLayers();
+  BOOST_REQUIRE_EQUAL(layers.size(), 2);
+  auto layer = layers[1];
+  BOOST_REQUIRE_EQUAL(layer->getId(), 1);
+  BOOST_REQUIRE(layer->getIsActive());
+  BOOST_REQUIRE(layer->getName()=="ala");
+  BOOST_REQUIRE_CLOSE(layer->getRadius(), 10.5, epsilon);
+
+  BOOST_REQUIRE_EQUAL(layer->getFrame().getId(), frameFactory.getFrames().at(1)->getId());
+
+  layer = layers[5];
+  BOOST_REQUIRE_EQUAL(layer->getId(), 5);
+  BOOST_REQUIRE(!layer->getIsActive());
+  BOOST_REQUIRE(layer->getName()=="alfred");
+  BOOST_REQUIRE_CLOSE(layer->getRadius(), 11.5, epsilon);
+
+  BOOST_REQUIRE_EQUAL(layer->getFrame().getId(), frameFactory.getFrames().at(1)->getId());
+}
+
+BOOST_AUTO_TEST_CASE( missing_field )
+{
+  JPetFrameFactory frameFactory(paramGetter, 3);
+  JPetLayerFactory factory(paramGetter, 3, frameFactory);
+  BOOST_REQUIRE_THROW(factory.getLayers(), std::out_of_range);
+}
+
+BOOST_AUTO_TEST_CASE( wrong_field )
+{
+  JPetFrameFactory frameFactory(paramGetter, 4);
+  JPetLayerFactory factory(paramGetter, 4, frameFactory);
+  BOOST_REQUIRE_THROW(factory.getLayers(), std::bad_cast);
+}
+
+BOOST_AUTO_TEST_CASE( wrong_relation )
+{
+  JPetFrameFactory frameFactory(paramGetter, 5);
+  JPetLayerFactory factory(paramGetter, 5, frameFactory);
+  BOOST_REQUIRE_THROW(factory.getLayers(), std::out_of_range);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/JPetPM/JPetPMFactory.cpp
+++ b/JPetPM/JPetPMFactory.cpp
@@ -1,0 +1,67 @@
+/**
+ *  @copyright Copyright 2016 The J-PET Framework Authors. All rights reserved.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may find a copy of the License in the LICENCE file.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  @file JPetPMFactory.cpp
+ */
+
+#include "JPetPMFactory.h"
+
+#include <exception>
+#include <string>
+#include <tuple>
+#include <boost/lexical_cast.hpp>
+
+std::map<int, JPetPM *> & JPetPMFactory::getPMs()
+{
+  if (!fInitialized) {
+    initialize();
+  }
+  return fPMs;
+}
+
+void JPetPMFactory::initialize()
+{
+  ParamObjectsDescriptions descriptions = paramGetter.getAllBasicData(ParamObjectType::kPM, runId);
+  if (descriptions.size() == 0) {
+    ERROR(std::string("No PMs in run ") + boost::lexical_cast<std::string>(runId));
+  }
+  for (auto description : descriptions) {
+    fPMs[description.first] = build(description.second);
+  }
+  fInitialized = true;
+  ParamRelationalData relations = paramGetter.getAllRelationalData(ParamObjectType::kPM, ParamObjectType::kFEB, runId);
+  for (auto relation : relations) {
+    fPMs[relation.first]->setFEB(*febFactory.getFEBs().at(relation.second));
+  }
+  relations = paramGetter.getAllRelationalData(ParamObjectType::kPM, ParamObjectType::kScintillator, runId);
+  for (auto relation : relations) {
+    fPMs[relation.first]->setScin(*scinFactory.getScins().at(relation.second));
+  }
+  relations = paramGetter.getAllRelationalData(ParamObjectType::kPM, ParamObjectType::kBarrelSlot, runId);
+  for (auto relation : relations) {
+    fPMs[relation.first]->setBarrelSlot(*barrelSlotFactory.getBarrelSlots().at(relation.second));
+  }
+}
+
+JPetPM * JPetPMFactory::build(ParamObjectDescription data)
+{
+  try {
+    int id = boost::lexical_cast<int>(data.at("id"));
+    JPetPM::Side side = boost::lexical_cast<bool>(data.at("is_right_side")) ? JPetPM::Side::SideB : JPetPM::Side::SideA;
+    JPetPM * result = new JPetPM(id);
+    result->setSide(side);
+    return result;
+  } catch (const std::exception & e) {
+    ERROR(std::string("Failed to build PM with error: ") + e.what());
+    throw;
+  }
+}

--- a/JPetPM/JPetPMFactory.h
+++ b/JPetPM/JPetPMFactory.h
@@ -1,0 +1,58 @@
+/**
+ *  @copyright Copyright 2016 The J-PET Framework Authors. All rights reserved.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may find a copy of the License in the LICENCE file.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  @file JPetPMFactory.h
+ */
+
+#ifndef JPET_PM_FACTORY_H
+#define JPET_PM_FACTORY_H
+
+#include "../JPetParamGetter/JPetParamGetter.h"
+#include "JPetPM.h"
+#include "../JPetFEB/JPetFEBFactory.h"
+#include "../JPetScin/JPetScinFactory.h"
+#include "../JPetBarrelSlot/JPetBarrelSlotFactory.h"
+
+#include <map>
+
+/**
+ * @brief A factory of JPetPM objects.
+ *
+ * This class is able to create those objects using data from the database.
+ */
+class JPetPMFactory
+{
+  public:
+    JPetPMFactory(JPetParamGetter & paramGetter, int runId, JPetFEBFactory & febFactory, JPetScinFactory & scinFactory, JPetBarrelSlotFactory & barrelSlotFactory) :
+      paramGetter(paramGetter),
+      runId(runId),
+      febFactory(febFactory),
+      scinFactory(scinFactory),
+      barrelSlotFactory(barrelSlotFactory),
+      fInitialized(false) {}
+
+    std::map<int, JPetPM *> & getPMs();
+  private:
+    JPetParamGetter & paramGetter;
+    const int runId;
+    JPetFEBFactory & febFactory;
+    JPetScinFactory & scinFactory;
+    JPetBarrelSlotFactory & barrelSlotFactory;
+
+    bool fInitialized;
+    std::map<int, JPetPM *> fPMs;
+
+    void initialize();
+    JPetPM * build(ParamObjectDescription data);
+};
+
+#endif // JPET_PM_FACTORY_H

--- a/JPetPMCalib/JPetPMCalibFactory.cpp
+++ b/JPetPMCalib/JPetPMCalibFactory.cpp
@@ -1,0 +1,60 @@
+/**
+ *  @copyright Copyright 2016 The J-PET Framework Authors. All rights reserved.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may find a copy of the License in the LICENCE file.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  @file JPetPMCalibFactory.cpp
+ */
+
+#include "JPetPMCalibFactory.h"
+
+#include <exception>
+#include <string>
+#include <tuple>
+#include <boost/lexical_cast.hpp>
+
+std::map<int, JPetPMCalib *> & JPetPMCalibFactory::getPMCalibs()
+{
+  if (!fInitialized) {
+    initialize();
+  }
+  return fPMCalibs;
+}
+
+void JPetPMCalibFactory::initialize()
+{
+  ParamObjectsDescriptions descriptions = paramGetter.getAllBasicData(ParamObjectType::kPMCalib, runId);
+  if (descriptions.size() == 0) {
+    ERROR(std::string("No pmCalibs in run ") + boost::lexical_cast<std::string>(runId));
+  }
+  for (auto description : descriptions) {
+    fPMCalibs[description.first] = build(description.second);
+  }
+  fInitialized = true;
+}
+
+JPetPMCalib * JPetPMCalibFactory::build(ParamObjectDescription data)
+{
+  try {
+    int id = boost::lexical_cast<int>(data.at("id"));
+    std::string name = data.at("name");
+    double opthv = boost::lexical_cast<double>(data.at("opthv"));
+    double c2e1 = boost::lexical_cast<double>(data.at("c2e1"));
+    double c2e2 = boost::lexical_cast<double>(data.at("c2e2"));
+    double gainAlpha = boost::lexical_cast<double>(data.at("gain_alpha"));
+    double gainBeta = boost::lexical_cast<double>(data.at("gain_beta"));
+    int assignmentId = boost::lexical_cast<int>(data.at("assignment_id"));
+    int assignmentPMId = boost::lexical_cast<int>(data.at("assignment_photomultiplier_id"));
+    return new JPetPMCalib(id, name, opthv, c2e1, c2e2, gainAlpha, gainBeta, assignmentId, assignmentPMId);
+  } catch (const std::exception & e) {
+    ERROR(std::string("Failed to build pmCalib with error: ") + e.what());
+    throw;
+  }
+}

--- a/JPetPMCalib/JPetPMCalibFactory.h
+++ b/JPetPMCalib/JPetPMCalibFactory.h
@@ -1,0 +1,49 @@
+/**
+ *  @copyright Copyright 2016 The J-PET Framework Authors. All rights reserved.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may find a copy of the License in the LICENCE file.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  @file JPetPMCalibFactory.h
+ */
+
+#ifndef JPET_PM_CALIB_FACTORY_H
+#define JPET_PM_CALIB_FACTORY_H
+
+#include "../JPetParamGetter/JPetParamGetter.h"
+#include "JPetPMCalib.h"
+
+#include <map>
+
+/**
+ * @brief A factory of JPetPMCalib objects.
+ *
+ * This class is able to create those objects using data from the database.
+ */
+class JPetPMCalibFactory
+{
+  public:
+    JPetPMCalibFactory(JPetParamGetter & paramGetter, int runId) :
+      paramGetter(paramGetter),
+      runId(runId),
+      fInitialized(false) {}
+
+    std::map<int, JPetPMCalib *> & getPMCalibs();
+  private:
+    JPetParamGetter & paramGetter;
+    const int runId;
+
+    bool fInitialized;
+    std::map<int, JPetPMCalib *> fPMCalibs;
+
+    void initialize();
+    JPetPMCalib * build(ParamObjectDescription data);
+};
+
+#endif // JPET_PM_CALIB_FACTORY_H

--- a/JPetPMCalib/JPetPMCalibTest.cpp
+++ b/JPetPMCalib/JPetPMCalibTest.cpp
@@ -1,16 +1,17 @@
 #define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MODULE JPetPMCalibTest
 #include <boost/test/unit_test.hpp>
-#include "../JPetPMCalib/JPetPMCalib.h"
+#include "JPetPMCalib.h"
+#include "JPetPMCalibFactory.h"
 
 
+const float epsilon = 0.0001f;
 
 BOOST_AUTO_TEST_SUITE(JPetPMCalibTestSuite)
 
 BOOST_AUTO_TEST_CASE(DefaultConstructorTest)
 {
   JPetPMCalib pmCalib(256, "PMCalib", 2.f, 4.f, 8.f, 16.f, 32.f, 64, 128);
-  float epsilon = 0.0001f;
   BOOST_REQUIRE_EQUAL(pmCalib.GetId(), 256);
   BOOST_REQUIRE_EQUAL(pmCalib.GetNamePM(), "PMCalib");
   BOOST_REQUIRE_CLOSE(pmCalib.GetOpthv(), 2.f, epsilon);
@@ -20,6 +21,164 @@ BOOST_AUTO_TEST_CASE(DefaultConstructorTest)
   BOOST_REQUIRE_CLOSE(pmCalib.GetGainbeta(), 32.f, epsilon);
   BOOST_REQUIRE_EQUAL(pmCalib.GetPMCalibAssignment().id, 64);
   BOOST_REQUIRE_EQUAL(pmCalib.GetPMCalibAssignment().photomultiplier_id, 128);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE(FactorySuite)
+
+class TestParamGetter : public JPetParamGetter
+{
+  ParamObjectsDescriptions getAllBasicData(ParamObjectType, const int runId)
+  {
+    ParamObjectsDescriptions result;
+    switch (runId) {
+      case 0: //No pmCalibs
+        break;
+      case 1: //Simple single object
+        result = {
+          {1, {
+                {"id", "1"},
+                {"name", "PMCalib"},
+                {"opthv", "2"},
+                {"c2e1", "4"},
+                {"c2e2", "8"},
+                {"gain_alpha", "16"},
+                {"gain_beta", "32"},
+                {"assignment_id", "64"},
+                {"assignment_photomultiplier_id", "128"}
+              }
+          }
+        };
+        break;
+      case 2: //Simple two objects
+        result = {
+          {1, {
+                {"id", "1"},
+                {"name", "PMCalib"},
+                {"opthv", "2"},
+                {"c2e1", "4"},
+                {"c2e2", "8"},
+                {"gain_alpha", "16"},
+                {"gain_beta", "32"},
+                {"assignment_id", "64"},
+                {"assignment_photomultiplier_id", "128"}
+              }
+          },
+          {5, {
+                {"id", "5"},
+                {"name", "PMMorab"},
+                {"opthv", "3"},
+                {"c2e1", "5"},
+                {"c2e2", "9"},
+                {"gain_alpha", "17"},
+                {"gain_beta", "33"},
+                {"assignment_id", "65"},
+                {"assignment_photomultiplier_id", "129"}
+              }
+          }
+        };
+        break;
+      case 3: //Object with missing field
+        result = {
+          {1, {
+                {"id", "1"},
+                {"opthv", "2"},
+                {"c2e1", "4"},
+                {"c2e2", "8"},
+                {"gain_alpha", "16"},
+                {"gain_beta", "32"},
+                {"assignment_id", "64"},
+                {"assignment_photomultiplier_id", "128"}
+              }
+          }
+        };
+        break;
+      case 4: //Object with wrong field
+        result = {
+          {1, {
+                {"id", "1"},
+                {"name", "PMCalib"},
+                {"opthv", "whatisthis"},
+                {"c2e1", "4"},
+                {"c2e2", "8"},
+                {"gain_alpha", "16"},
+                {"gain_beta", "32"},
+                {"assignment_id", "64"},
+                {"assignment_photomultiplier_id", "128"}
+              }
+          }
+        };
+        break;
+    }
+    return result;
+  }
+  ParamRelationalData getAllRelationalData(ParamObjectType, ParamObjectType, const int) {return ParamRelationalData();} //Irrelevant for this test.
+};
+
+TestParamGetter paramGetter;
+
+BOOST_AUTO_TEST_CASE( no_pmCalibs )
+{
+  JPetPMCalibFactory factory(paramGetter, 0);
+  auto & pmCalibs = factory.getPMCalibs();
+  BOOST_REQUIRE_EQUAL(pmCalibs.size(), 0);
+}
+
+BOOST_AUTO_TEST_CASE( single_object )
+{
+  JPetPMCalibFactory factory(paramGetter, 1);
+  auto & pmCalibs = factory.getPMCalibs();
+  BOOST_REQUIRE_EQUAL(pmCalibs.size(), 1);
+  auto pmCalib = pmCalibs[1];
+  BOOST_REQUIRE_EQUAL(pmCalib->GetId(), 1);
+  BOOST_REQUIRE_EQUAL(pmCalib->GetNamePM(), "PMCalib");
+  BOOST_REQUIRE_CLOSE(pmCalib->GetOpthv(), 2.f, epsilon);
+  BOOST_REQUIRE_CLOSE(pmCalib->GetECalConst1(), 4.f, epsilon);
+  BOOST_REQUIRE_CLOSE(pmCalib->GetECalConst2(), 8.f, epsilon);
+  BOOST_REQUIRE_CLOSE(pmCalib->GetGainalpha(), 16.f, epsilon);
+  BOOST_REQUIRE_CLOSE(pmCalib->GetGainbeta(), 32.f, epsilon);
+  BOOST_REQUIRE_EQUAL(pmCalib->GetPMCalibAssignment().id, 64);
+  BOOST_REQUIRE_EQUAL(pmCalib->GetPMCalibAssignment().photomultiplier_id, 128);
+}
+
+BOOST_AUTO_TEST_CASE( two_objects )
+{
+  JPetPMCalibFactory factory(paramGetter, 2);
+  auto & pmCalibs = factory.getPMCalibs();
+  BOOST_REQUIRE_EQUAL(pmCalibs.size(), 2);
+  auto pmCalib = pmCalibs[1];
+  BOOST_REQUIRE_EQUAL(pmCalib->GetId(), 1);
+  BOOST_REQUIRE_EQUAL(pmCalib->GetNamePM(), "PMCalib");
+  BOOST_REQUIRE_CLOSE(pmCalib->GetOpthv(), 2.f, epsilon);
+  BOOST_REQUIRE_CLOSE(pmCalib->GetECalConst1(), 4.f, epsilon);
+  BOOST_REQUIRE_CLOSE(pmCalib->GetECalConst2(), 8.f, epsilon);
+  BOOST_REQUIRE_CLOSE(pmCalib->GetGainalpha(), 16.f, epsilon);
+  BOOST_REQUIRE_CLOSE(pmCalib->GetGainbeta(), 32.f, epsilon);
+  BOOST_REQUIRE_EQUAL(pmCalib->GetPMCalibAssignment().id, 64);
+  BOOST_REQUIRE_EQUAL(pmCalib->GetPMCalibAssignment().photomultiplier_id, 128);
+  pmCalib = pmCalibs[5];
+  BOOST_REQUIRE_EQUAL(pmCalib->GetId(), 5);
+  BOOST_REQUIRE_EQUAL(pmCalib->GetNamePM(), "PMMorab");
+  BOOST_REQUIRE_CLOSE(pmCalib->GetOpthv(), 3.f, epsilon);
+  BOOST_REQUIRE_CLOSE(pmCalib->GetECalConst1(), 5.f, epsilon);
+  BOOST_REQUIRE_CLOSE(pmCalib->GetECalConst2(), 9.f, epsilon);
+  BOOST_REQUIRE_CLOSE(pmCalib->GetGainalpha(), 17.f, epsilon);
+  BOOST_REQUIRE_CLOSE(pmCalib->GetGainbeta(), 33.f, epsilon);
+  BOOST_REQUIRE_EQUAL(pmCalib->GetPMCalibAssignment().id, 65);
+  BOOST_REQUIRE_EQUAL(pmCalib->GetPMCalibAssignment().photomultiplier_id, 129);
+}
+
+BOOST_AUTO_TEST_CASE( missing_field )
+{
+  JPetPMCalibFactory factory(paramGetter, 3);
+  BOOST_REQUIRE_THROW(factory.getPMCalibs(), std::out_of_range);
+}
+
+BOOST_AUTO_TEST_CASE( wrong_field )
+{
+  JPetPMCalibFactory factory(paramGetter, 4);
+  BOOST_REQUIRE_THROW(factory.getPMCalibs(), std::bad_cast);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/JPetParamBank/JPetParamBank.cpp
+++ b/JPetParamBank/JPetParamBank.cpp
@@ -14,10 +14,6 @@
  */
 
 #include "./JPetParamBank.h"
-#include <boost/lexical_cast.hpp>
-#include <boost/regex.hpp>
-#include <algorithm>
-#include <memory>
 
 ClassImp (JPetParamBank);
 
@@ -25,7 +21,6 @@ JPetParamBank::JPetParamBank():fDummy(false){}
 JPetParamBank::JPetParamBank(const bool d):fDummy(d){}
 const bool JPetParamBank::isDummy()const{return fDummy;}
 JPetParamBank::JPetParamBank(const JPetParamBank& paramBank):fDummy(false){
-
   copyMapValues(fScintillators, paramBank.fScintillators);
   copyMapValues(fPMs, paramBank.fPMs);
   copyMapValues(fPMCalibs, paramBank.fPMCalibs);
@@ -39,16 +34,6 @@ JPetParamBank::JPetParamBank(const JPetParamBank& paramBank):fDummy(false){
 
 JPetParamBank::~JPetParamBank()
 {
-  DEBUG("destructor of JPetParamBank");
-  //std::for_each(fScintillators.begin(), fScintillators.end(), std::default_delete<JPetScin>());
-  //std::for_each(fPMs.begin(), fPMs.end(), std::default_delete<JPetPM>());
-  //std::for_each(fPMCalibs.begin(), fPMCalibs.end(), std::default_delete<JPetPMCalib>());
-  //std::for_each(fFEBs.begin(), fFEBs.end(), std::default_delete<JPetFEB>());
-  //std::for_each(fBarrelSlots.begin(), fBarrelSlots.end(), std::default_delete<JPetBarrelSlot>());
-  //std::for_each(fLayers.begin(), fLayers.end(), std::default_delete<JPetLayer>());
-  //std::for_each(fFrames.begin(), fFrames.end(), std::default_delete<JPetFrame>());
-  //std::for_each(fTOMBChannels.begin(), fTOMBChannels.end(), std::default_delete<JPetTOMBChannel>());
-  //clear();
 }
 
 void JPetParamBank::clear()
@@ -65,61 +50,40 @@ void JPetParamBank::clear()
 }
 
 
-int JPetParamBank::getSize(JPetParamBank::ParamObjectType type) const
+int JPetParamBank::getSize(ParamObjectType type) const
 {
   int size = -1;
   switch (type) {
-  case kScintillator:
-    size = getScintillatorsSize();
-    break;
-  case kPM:
-    size = getPMsSize();
-    break;
-  case kPMCalib:
-    size = getPMCalibsSize();
-    break;
-  case kBarrelSlot:
-    size = getBarrelSlotsSize();
-    break;
-  case kLayer:
-    size = getLayersSize();
-    break;
-  case kFrame:
-    size = getFramesSize();
-    break;
-  case kFEB:
-    size = getFEBsSize();
-    break;
-  case kTRB:
-    size = getTRBsSize();
-    break;
-  case kTOMBChannel:
-    size = getTOMBChannelsSize();
-    break;
-  default:
-    ERROR("bad type");
-    break;
+    case kScintillator:
+      size = getScintillatorsSize();
+      break;
+    case kPM:
+      size = getPMsSize();
+      break;
+    case kPMCalib:
+      size = getPMCalibsSize();
+      break;
+    case kBarrelSlot:
+      size = getBarrelSlotsSize();
+      break;
+    case kLayer:
+      size = getLayersSize();
+      break;
+    case kFrame:
+      size = getFramesSize();
+      break;
+    case kFEB:
+      size = getFEBsSize();
+      break;
+    case kTRB:
+      size = getTRBsSize();
+      break;
+    case kTOMBChannel:
+      size = getTOMBChannelsSize();
+      break;
+    default:
+      ERROR("bad type");
+      break;
   }
   return size;
-}
-
-int JPetParamBank::getTOMBChannelFromDescription(std::string p_desc)
-{
-  // parsing the string description of a TOMB channel to extract the channel number
-  // convention: tast 4 characters of the description represent the number
-  const char * l_pattern = ".*\\s(\\d{1,4}).*";
-  boost::regex l_regex(l_pattern);
-  boost::smatch l_matches;
-
-  int l_TOMB_no = -1;
-
-  if (boost::regex_match(p_desc, l_matches, l_regex))
-  {
-    l_TOMB_no = boost::lexical_cast<int>( l_matches[1] );
-  } else
-  {
-    // @todo: handle parsing error somehow
-    ERROR( "Unable to parse TOMBInput description to get channel number." );
-  }
-  return l_TOMB_no;
 }

--- a/JPetParamBank/JPetParamBank.h
+++ b/JPetParamBank/JPetParamBank.h
@@ -25,17 +25,15 @@
 #include "../JPetLayer/JPetLayer.h"
 #include "../JPetFrame/JPetFrame.h"
 #include "../JPetTOMBChannel/JPetTOMBChannel.h"
+
+#include "../JPetParamGetter/JPetParamConstants.h"
 #include "../JPetLoggerInclude.h"
 #include <map>
 #include <cassert>
-#include <algorithm> //for_each
-#include <memory> //std::default
 
 class JPetParamBank: public TObject
 {
-public:
-  enum ParamObjectType {kScintillator, kPM, kPMCalib, kFEB, kTRB, kTOMBChannel, kBarrelSlot, kLayer, kFrame, SIZE};
-
+ public:
   JPetParamBank();
   JPetParamBank(const JPetParamBank& paramBank);
   ~JPetParamBank();
@@ -172,8 +170,6 @@ public:
     return fTOMBChannels.size();
   }
 
-  static int getTOMBChannelFromDescription(std::string p_desc);
-
  private:
   void operator=(const JPetParamBank&);
   bool fDummy;
@@ -195,16 +191,6 @@ public:
           target[c.first] = new T(*c.second);
       }
   }
-};
-
-/**
- * @brief An interface classes can implement to return JPetParamBank objects.
- */
-class JPetParamGetter
-{
-public:
-  virtual JPetParamBank* generateParamBank(const int p_run_id) = 0;
-  virtual ~JPetParamGetter(){}
 };
 
 #endif /*  !JPETPARAMBANK_H */

--- a/JPetParamBank/JPetParamBankTest.cpp
+++ b/JPetParamBank/JPetParamBankTest.cpp
@@ -204,15 +204,15 @@ BOOST_AUTO_TEST_CASE(getSizeTest)
   bank.addTRB(trb);
   bank.addTOMBChannel(TOMBChannel);
   
-  BOOST_REQUIRE(bank.getSize(JPetParamBank::kScintillator) == 1);
-  BOOST_REQUIRE(bank.getSize(JPetParamBank::kPM) == 1);
-  BOOST_REQUIRE(bank.getSize(JPetParamBank::kPMCalib) == 1);
-  BOOST_REQUIRE(bank.getSize(JPetParamBank::kBarrelSlot) == 1);
-  BOOST_REQUIRE(bank.getSize(JPetParamBank::kLayer) == 1);
-  BOOST_REQUIRE(bank.getSize(JPetParamBank::kFrame) == 1);
-  BOOST_REQUIRE(bank.getSize(JPetParamBank::kFEB) == 1);
-  BOOST_REQUIRE(bank.getSize(JPetParamBank::kTRB) == 1);
-  BOOST_REQUIRE(bank.getSize(JPetParamBank::kTOMBChannel) == 1);
+  BOOST_REQUIRE(bank.getSize(kScintillator) == 1);
+  BOOST_REQUIRE(bank.getSize(kPM) == 1);
+  BOOST_REQUIRE(bank.getSize(kPMCalib) == 1);
+  BOOST_REQUIRE(bank.getSize(kBarrelSlot) == 1);
+  BOOST_REQUIRE(bank.getSize(kLayer) == 1);
+  BOOST_REQUIRE(bank.getSize(kFrame) == 1);
+  BOOST_REQUIRE(bank.getSize(kFEB) == 1);
+  BOOST_REQUIRE(bank.getSize(kTRB) == 1);
+  BOOST_REQUIRE(bank.getSize(kTOMBChannel) == 1);
 }
 
 BOOST_AUTO_TEST_CASE( saving_reading_file )

--- a/JPetParamGetter/JPetParamConstants.h
+++ b/JPetParamGetter/JPetParamConstants.h
@@ -1,0 +1,21 @@
+/**
+ *  @copyright Copyright 2016 The J-PET Framework Authors. All rights reserved.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may find a copy of the License in the LICENCE file.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  @file JPetParamConstants.h
+ */
+
+#ifndef JPET_PARAM_CONSTANTS_H
+#define JPET_PARAM_CONSTANTS_H
+
+enum ParamObjectType {kScintillator, kPM, kPMCalib, kFEB, kTRB, kTOMBChannel, kBarrelSlot, kLayer, kFrame, SIZE};
+
+#endif /*  !JPET_PARAM_CONSTANTS_H */

--- a/JPetParamGetter/JPetParamGetter.cpp
+++ b/JPetParamGetter/JPetParamGetter.cpp
@@ -1,0 +1,40 @@
+/**
+ *  @copyright Copyright 2016 The J-PET Framework Authors. All rights reserved.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may find a copy of the License in the LICENCE file.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  @file JPetParamGetter.cpp
+ */
+
+#include "JPetParamGetter.h"
+
+#include <boost/lexical_cast.hpp>
+#include <boost/regex.hpp>
+
+int JPetParamGetter::getTOMBChannelFromDescription(std::string p_desc)
+{
+  // parsing the string description of a TOMB channel to extract the channel number
+  // convention: tast 4 characters of the description represent the number
+  const char * l_pattern = ".*\\s(\\d{1,4}).*";
+  boost::regex l_regex(l_pattern);
+  boost::smatch l_matches;
+
+  int l_TOMB_no = -1;
+
+  if (boost::regex_match(p_desc, l_matches, l_regex))
+  {
+    l_TOMB_no = boost::lexical_cast<int>( l_matches[1] );
+  } else
+  {
+    // @todo: handle parsing error somehow
+    ERROR( "Unable to parse TOMBInput description to get channel number." );
+  }
+  return l_TOMB_no;
+}

--- a/JPetParamGetter/JPetParamGetter.h
+++ b/JPetParamGetter/JPetParamGetter.h
@@ -1,0 +1,44 @@
+/**
+ *  @copyright Copyright 2016 The J-PET Framework Authors. All rights reserved.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may find a copy of the License in the LICENCE file.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  @file JPetParamGetter.h
+ */
+
+#ifndef JPET_PARAM_GETTER_H
+#define JPET_PARAM_GETTER_H
+
+#include "../JPetLoggerInclude.h"
+#include "JPetParamConstants.h"
+
+#include <map>
+#include <string>
+
+//typedefs are ugly, if you are reading this and we upgraded to ROOT 6 please change to using
+typedef std::map<std::string, std::string> ParamObjectDescription;
+typedef std::map<int, ParamObjectDescription> ParamObjectsDescriptions;
+typedef std::map<int, int> ParamRelationalData;
+
+/**
+ * @brief An interface classes can implement to return JPetParamBank objects.
+ */
+class JPetParamGetter
+{
+public:
+  virtual ParamObjectsDescriptions getAllBasicData(ParamObjectType type, const int runId) = 0;
+  virtual ParamRelationalData getAllRelationalData(ParamObjectType type1, ParamObjectType type2, const int runId) = 0;
+
+  virtual ~JPetParamGetter() {};
+
+  static int getTOMBChannelFromDescription(std::string p_desc);
+};
+
+#endif /*  !JPET_PARAM_GETTER_H */

--- a/JPetParamGetterAscii/JPetParamAsciiConstants.h
+++ b/JPetParamGetterAscii/JPetParamAsciiConstants.h
@@ -1,21 +1,27 @@
 /**
-  *  @copyright Copyright (c) 2016, J-PET collaboration
-  *  @file JPetParamAsciiConstants.h
-  *  @author Tomasz Kisielewski, tymorl@gmail.com
-  *  @brief Constants for names in the json file format
-  */
+ *  @copyright Copyright (c) 2016, J-PET collaboration
+ *  @file JPetParamAsciiConstants.h
+ *  @author Tomasz Kisielewski, tymorl@gmail.com
+ *  @brief Constants for names in the json file format
+ */
 
 #ifndef JPETPARAMASCIICONSTANTS_H
 #define JPETPARAMASCIICONSTANTS_H
 
-const std::string scintillatorsName = "scintillators";
-const std::string PMsName = "PMs";
-const std::string PMCalibsName = "PMCalibs";
-const std::string barrelSlotsName = "barrelSlots";
-const std::string layersName = "layers";
-const std::string framesName = "frames";
-const std::string FEBsName = "FEBs";
-const std::string TRBsName = "TRBs";
-const std::string TOMBChannelsName = "TOMBChannels";
+#include <map>
+
+#include "../JPetParamGetter/JPetParamConstants.h"
+
+const std::map<ParamObjectType, std::string> objectsNames{
+  {ParamObjectType::kScintillator, "scintillators"},
+  {ParamObjectType::kPM, "PMs"},
+  {ParamObjectType::kPMCalib, "PMCalibs"},
+  {ParamObjectType::kBarrelSlot, "barrelSlots"},
+  {ParamObjectType::kLayer, "layers"},
+  {ParamObjectType::kFrame, "frames"},
+  {ParamObjectType::kFEB, "FEBs"},
+  {ParamObjectType::kTRB, "TRBs"},
+  {ParamObjectType::kTOMBChannel, "TOMBChannels"}
+};
 
 #endif /*  !JPETPARAMASCIICONSTANTS_H */

--- a/JPetParamGetterAscii/JPetParamGetterAscii.cpp
+++ b/JPetParamGetterAscii/JPetParamGetterAscii.cpp
@@ -1,5 +1,5 @@
 /**
-	*  @copyright Copyright 2016 The J-PET Framework Authors. All rights reserved.
+ *  @copyright Copyright 2016 The J-PET Framework Authors. All rights reserved.
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may find a copy of the License in the LICENCE file.
@@ -20,357 +20,91 @@
 #include <boost/lexical_cast.hpp>
 #include <boost/property_tree/json_parser.hpp>
 
-JPetParamBank* JPetParamGetterAscii::generateParamBank(const int runNumber)
+ParamObjectsDescriptions JPetParamGetterAscii::getAllBasicData(ParamObjectType type, const int runId)
 {
-				return loadFileContent(runNumber);
-}
-
-/// assuming that file is in json format
-//
-JPetParamBank* JPetParamGetterAscii::loadFileContent(int runNumber)
-{
-		std::string runNumberS = boost::lexical_cast<std::string>(runNumber);
-  JPetParamBank* bank = 0;
+  std::string runNumberS = boost::lexical_cast<std::string>(runId);
+  std::string objectsName = objectsNames.at(type);
+  ParamObjectsDescriptions result;
   if (boost::filesystem::exists(filename)) {
     boost::property_tree::ptree dataFromFile;
     boost::property_tree::read_json(filename, dataFromFile);
-				if (auto possibleRunContents = dataFromFile.get_child_optional(runNumberS)) {
-						auto runContents = *possibleRunContents;
-						bank = new JPetParamBank();
-						fillScintillators(runContents, *bank);
-						fillPMs(runContents, *bank);
-						fillPMCalibs(runContents, *bank);
-						fillBarrelSlots(runContents, *bank);
-						fillLayers(runContents, *bank);
-						fillFrames(runContents, *bank);
-						fillFEBs(runContents, *bank);
-						fillTRBs(runContents, *bank);
-						fillTOMBChannels(runContents, *bank);
-						//TRefs need to be filled after creating everything.
-						//The IDs in the bank don't match the ids in the DB, so we need a translation.
-						fillScintillatorTRefs(runContents, *bank);
-						fillPMTRefs(runContents, *bank);
-						fillBarrelSlotTRefs(runContents, *bank);
-						fillLayerTRefs(runContents, *bank);
-						fillFEBTRefs(runContents, *bank);
-						fillTOMBChannelTRefs(runContents, *bank);
-				} else {
-						ERROR(std::string("No run with such id:") + runNumberS);
-				}
+    if (auto possibleRunContents = dataFromFile.get_child_optional(runNumberS)) {
+      auto runContents = *possibleRunContents;
+      if (auto possibleInfos = runContents.get_child_optional(objectsName)) {
+        auto infos = * possibleInfos;
+        for (auto infoRaw : infos) {
+          auto info = infoRaw.second;
+          ParamObjectDescription description = toDescription(info);
+          int id;
+          if (type == kTOMBChannel) {
+            id = boost::lexical_cast<int>(description["channel"]);
+          } else {
+            id = boost::lexical_cast<int>(description["id"]);
+          }
+          result[id] = description;
+        }
+      }  else {
+        ERROR(std::string("No ")+objectsName+" in the specified run.");
+      }
+    } else {
+      ERROR(std::string("No run with such id:") + runNumberS);
+    }
   } else {
     ERROR(std::string("Input file does not exist:") + filename);
   }
-  return bank;
+  return result;
 }
 
-
-void JPetParamGetterAscii::fillScintillators(boost::property_tree::ptree & runContents, JPetParamBank & bank)
+ParamRelationalData JPetParamGetterAscii::getAllRelationalData(ParamObjectType type1, ParamObjectType type2, const int runId)
 {
-		if (auto possibleInfos = runContents.get_child_optional(scintillatorsName)) {
-				auto infos = * possibleInfos;
-				for (auto info : infos) {
-						bank.addScintillator(scintillatorFromInfo(info.second));
-				}
-		} else {
-				ERROR("No scintillators in the specified run.");
-		}
+  std::string runNumberS = boost::lexical_cast<std::string>(runId);
+  std::string objectsName = objectsNames.at(type1);
+  std::string fieldName = objectsNames.at(type2)+"_id";
+  ParamRelationalData result;
+  if (boost::filesystem::exists(filename)) {
+    boost::property_tree::ptree dataFromFile;
+    boost::property_tree::read_json(filename, dataFromFile);
+    if (auto possibleRunContents = dataFromFile.get_child_optional(runNumberS)) {
+      auto runContents = *possibleRunContents;
+      if (auto possibleInfos = runContents.get_child_optional(objectsName)) {
+        auto infos = * possibleInfos;
+        for (auto infoRaw : infos) {
+          auto info = infoRaw.second;
+          ParamObjectDescription description = toDescription(info);
+          int id;
+          if (type1 == kTOMBChannel) {
+            id = boost::lexical_cast<int>(description["channel"]);
+          } else {
+            id = boost::lexical_cast<int>(description["id"]);
+          }
+          int otherId = boost::lexical_cast<int>(description[fieldName]);
+          result[id] = otherId;
+        }
+      }  else {
+        ERROR(std::string("No ")+objectsName+" in the specified run.");
+      }
+    } else {
+      ERROR(std::string("No run with such id:") + runNumberS);
+    }
+  } else {
+    ERROR(std::string("Input file does not exist:") + filename);
+  }
+  return result;
 }
 
-void JPetParamGetterAscii::fillScintillatorTRefs(boost::property_tree::ptree & runContents, JPetParamBank & bank)
+ParamObjectDescription JPetParamGetterAscii::toDescription(boost::property_tree::ptree & info)
 {
-		if (auto possibleInfos = runContents.get_child_optional(scintillatorsName)) {
-				auto infos = * possibleInfos;
-				for (auto infoRaw : infos) {
-						auto info = infoRaw.second;
-						int id = info.get<int>("id");
-						int relId = info.get<int>(barrelSlotsName+"_id");
-						bank.getScintillator(id).setBarrelSlot(bank.getBarrelSlot(relId));
-				}
-		} else {
-				ERROR("No scintillators in the specified run.");
-		}
-}
-
-JPetScin JPetParamGetterAscii::scintillatorFromInfo(boost::property_tree::ptree & info)
-{
-		int id = info.get<int>("id");
-		double attenuationLength = info.get<double>("attenuation_length");
-		double length = info.get<double>("length");
-		double width = info.get<double>("width");
-		double height = info.get<double>("height");
-		return JPetScin(id, attenuationLength, length, height, width);
-}
-
-
-void JPetParamGetterAscii::fillPMs(boost::property_tree::ptree & runContents, JPetParamBank & bank)
-{
-		if (auto possibleInfos = runContents.get_child_optional(PMsName)) {
-				auto infos = * possibleInfos;
-				for (auto info : infos) {
-						bank.addPM(PMFromInfo(info.second));
-				}
-		} else {
-				ERROR("No PMs in the specified run.");
-		}
-}
-
-void JPetParamGetterAscii::fillPMTRefs(boost::property_tree::ptree & runContents, JPetParamBank & bank)
-{
-		if (auto possibleInfos = runContents.get_child_optional(PMsName)) {
-				auto infos = * possibleInfos;
-				for (auto infoRaw : infos) {
-						auto info = infoRaw.second;
-						int id = info.get<int>("id");
-						int relId = info.get<int>(barrelSlotsName+"_id");
-						bank.getPM(id).setBarrelSlot(bank.getBarrelSlot(relId));
-						relId = info.get<int>(FEBsName+"_id");
-						bank.getPM(id).setFEB(bank.getFEB(relId));
-						relId = info.get<int>(scintillatorsName+"_id");
-						bank.getPM(id).setScin(bank.getScintillator(relId));
-				}
-		} else {
-				ERROR("No PMs in the specified run.");
-		}
-}
-
-JPetPM JPetParamGetterAscii::PMFromInfo(boost::property_tree::ptree & info)
-{
-		int id = info.get<int>("id");
-		JPetPM::Side side = info.get<bool>("is_right_side") ? JPetPM::Side::SideB : JPetPM::Side::SideA;
-		JPetPM result(id);
-		result.setSide(side);
-		return result;
-}
-
-
-void JPetParamGetterAscii::fillPMCalibs(boost::property_tree::ptree & runContents, JPetParamBank & bank)
-{
-		if (auto possibleInfos = runContents.get_child_optional(PMCalibsName)) {
-				auto infos = * possibleInfos;
-				for (auto info : infos) {
-						bank.addPMCalib(PMCalibFromInfo(info.second));
-				}
-		} else {
-				ERROR("No PMCalibs in the specified run.");
-		}
-}
-
-JPetPMCalib JPetParamGetterAscii::PMCalibFromInfo(boost::property_tree::ptree & info)
-{
-		int id = info.get<int>("id");
-		std::string name = info.get<std::string>("name");
-		double opthv = info.get<double>("opthv");
-		double c2e1 = info.get<double>("c2e1");
-		double c2e2 = info.get<double>("c2e2");
-		double gainAlpha = info.get<double>("gain_alpha");
-		double gainBeta = info.get<double>("gain_beta");
-		int assignmentId = info.get<int>("assignment_id");
-		int assignmentPMId = info.get<int>("assignment_photomultiplier_id");
-		return JPetPMCalib(id, name, opthv, c2e1, c2e2, gainAlpha, gainBeta, assignmentId, assignmentPMId);
-}
-
-
-void JPetParamGetterAscii::fillBarrelSlots(boost::property_tree::ptree & runContents, JPetParamBank & bank)
-{
-		if (auto possibleInfos = runContents.get_child_optional(barrelSlotsName)) {
-				auto infos = * possibleInfos;
-				for (auto info : infos) {
-						bank.addBarrelSlot(barrelSlotFromInfo(info.second));
-				}
-		} else {
-				ERROR("No barrel slots in the specified run.");
-		}
-}
-
-void JPetParamGetterAscii::fillBarrelSlotTRefs(boost::property_tree::ptree & runContents, JPetParamBank & bank)
-{
-		if (auto possibleInfos = runContents.get_child_optional(barrelSlotsName)) {
-				auto infos = * possibleInfos;
-				for (auto infoRaw : infos) {
-						auto info = infoRaw.second;
-						int id = info.get<int>("id");
-						int relId = info.get<int>(layersName+"_id");
-						bank.getBarrelSlot(id).setLayer(bank.getLayer(relId));
-				}
-		} else {
-				ERROR("No barrel slots in the specified run.");
-		}
-}
-
-JPetBarrelSlot JPetParamGetterAscii::barrelSlotFromInfo(boost::property_tree::ptree & info)
-{
-		int id = info.get<int>("id");
-		bool active = info.get<bool>("active");
-		std::string name = info.get<std::string>("name");
-		double theta1 = info.get<double>("theta1");
-		int frameId = info.get<int>("frame_id");
-		return JPetBarrelSlot(id, active, name, theta1, frameId);
-}
-
-
-void JPetParamGetterAscii::fillLayers(boost::property_tree::ptree & runContents, JPetParamBank & bank)
-{
-		if (auto possibleInfos = runContents.get_child_optional(layersName)) {
-				auto infos = * possibleInfos;
-				for (auto info : infos) {
-						bank.addLayer(layerFromInfo(info.second));
-				}
-		} else {
-				ERROR("No layers in the specified run.");
-		}
-}
-
-void JPetParamGetterAscii::fillLayerTRefs(boost::property_tree::ptree & runContents, JPetParamBank & bank)
-{
-		if (auto possibleInfos = runContents.get_child_optional(layersName)) {
-				auto infos = * possibleInfos;
-				for (auto infoRaw : infos) {
-						auto info = infoRaw.second;
-						int id = info.get<int>("id");
-						int relId = info.get<int>(framesName+"_id");
-						bank.getLayer(id).setFrame(bank.getFrame(relId));
-				}
-		} else {
-				ERROR("No layers in the specified run.");
-		}
-}
-
-JPetLayer JPetParamGetterAscii::layerFromInfo(boost::property_tree::ptree & info)
-{
-		int id = info.get<int>("id");
-		bool active = info.get<bool>("active");
-		std::string name = info.get<std::string>("name");
-		double radius = info.get<double>("radius");
-		return JPetLayer(id, active, name, radius);
-}
-
-
-void JPetParamGetterAscii::fillFrames(boost::property_tree::ptree & runContents, JPetParamBank & bank)
-{
-		if (auto possibleInfos = runContents.get_child_optional(framesName)) {
-				auto infos = * possibleInfos;
-				for (auto info : infos) {
-						bank.addFrame(frameFromInfo(info.second));
-				}
-		} else {
-				ERROR("No frames in the specified run.");
-		}
-}
-
-JPetFrame JPetParamGetterAscii::frameFromInfo(boost::property_tree::ptree & info)
-{
-		int id = info.get<int>("id");
-		bool active = info.get<bool>("active");
-		std::string status = info.get<std::string>("status");
-		std::string description = info.get<std::string>("description");
-		int version = info.get<int>("version");
-		int creatorId = info.get<int>("creator_id");
-		return JPetFrame(id, active, status, description, version, creatorId);
-}
-
-
-void JPetParamGetterAscii::fillFEBs(boost::property_tree::ptree & runContents, JPetParamBank & bank)
-{
-		if (auto possibleInfos = runContents.get_child_optional(FEBsName)) {
-				auto infos = * possibleInfos;
-				for (auto info : infos) {
-						bank.addFEB(FEBFromInfo(info.second));
-				}
-		} else {
-				ERROR("No FEBs in the specified run.");
-		}
-}
-
-void JPetParamGetterAscii::fillFEBTRefs(boost::property_tree::ptree & runContents, JPetParamBank & bank)
-{
-		if (auto possibleInfos = runContents.get_child_optional(FEBsName)) {
-				auto infos = * possibleInfos;
-				for (auto infoRaw : infos) {
-						auto info = infoRaw.second;
-						int id = info.get<int>("id");
-						int relId = info.get<int>(TRBsName+"_id");
-						bank.getFEB(id).setTRB(bank.getTRB(relId));
-				}
-		} else {
-				ERROR("No FEBs in the specified run.");
-		}
-}
-
-JPetFEB JPetParamGetterAscii::FEBFromInfo(boost::property_tree::ptree & info)
-{
-		int id = info.get<int>("id");
-		bool active = info.get<bool>("active");
-		std::string status = info.get<std::string>("status");
-		std::string description = info.get<std::string>("description");
-		int version = info.get<int>("version");
-		int creatorId = info.get<int>("creator_id");
-		int timeOutputsPerInput = info.get<int>("time_outputs_per_input");
-		int noTimeOutputsPerInput = info.get<int>("no_time_outputs_per_input");
-		return JPetFEB(id, active, status, description, version, creatorId, timeOutputsPerInput, noTimeOutputsPerInput);
-}
-
-
-void JPetParamGetterAscii::fillTRBs(boost::property_tree::ptree & runContents, JPetParamBank & bank)
-{
-		if (auto possibleInfos = runContents.get_child_optional(TRBsName)) {
-				auto infos = * possibleInfos;
-				for (auto info : infos) {
-						bank.addTRB(TRBFromInfo(info.second));
-				}
-		} else {
-				ERROR("No TRBs in the specified run.");
-		}
-}
-
-JPetTRB JPetParamGetterAscii::TRBFromInfo(boost::property_tree::ptree & info)
-{
-		int id = info.get<int>("id");
-		int type = info.get<int>("type");
-		int channel = info.get<int>("channel");
-		return JPetTRB(id, type, channel);
-}
-
-
-void JPetParamGetterAscii::fillTOMBChannels(boost::property_tree::ptree & runContents, JPetParamBank & bank)
-{
-		if (auto possibleInfos = runContents.get_child_optional(TOMBChannelsName)) {
-				auto infos = * possibleInfos;
-				for (auto info : infos) {
-						bank.addTOMBChannel(TOMBChannelFromInfo(info.second));
-				}
-		} else {
-				ERROR("No TOMBChannels in the specified run.");
-		}
-}
-
-void JPetParamGetterAscii::fillTOMBChannelTRefs(boost::property_tree::ptree & runContents, JPetParamBank & bank)
-{
-		if (auto possibleInfos = runContents.get_child_optional(TOMBChannelsName)) {
-				auto infos = * possibleInfos;
-				for (auto infoRaw : infos) {
-						auto info = infoRaw.second;
-						int channel = info.get<int>("channel");
-						int relId = info.get<int>(TRBsName+"_id");
-						bank.getTOMBChannel(channel).setTRB(bank.getTRB(relId));
-						relId = info.get<int>(FEBsName+"_id");
-						bank.getTOMBChannel(channel).setFEB(bank.getFEB(relId));
-						relId = info.get<int>(PMsName+"_id");
-						bank.getTOMBChannel(channel).setPM(bank.getPM(relId));
-				}
-		} else {
-				ERROR("No TOMB channels in the specified run.");
-		}
-}
-
-JPetTOMBChannel JPetParamGetterAscii::TOMBChannelFromInfo(boost::property_tree::ptree & info)
-{
-		unsigned int local_number = info.get<unsigned int>("local_number");
-		unsigned int channel = info.get<unsigned int>("channel");
-		unsigned int FEB = info.get<unsigned int>("FEB");
-		float threshold = info.get<float>("threshold");
-		JPetTOMBChannel result(channel);
-		result.setLocalChannelNumber(local_number);
-		result.setFEBInputNumber(FEB);
-		result.setThreshold(threshold);
-		return result;
+  ParamObjectDescription description;
+  for (auto value : info) {
+    std::string val = value.second.get_value<std::string>();
+    // Ugly hack since boost::lexical_cast does not understand booleans properly.
+    if (val == "true") {
+      val = "1";
+    }
+    if (val == "false") {
+      val = "0";
+    }
+    description[value.first] = val;
+  }
+  return description;
 }

--- a/JPetParamGetterAscii/JPetParamGetterAscii.h
+++ b/JPetParamGetterAscii/JPetParamGetterAscii.h
@@ -1,5 +1,5 @@
 /**
-	*  @copyright Copyright 2016 The J-PET Framework Authors. All rights reserved.
+ *  @copyright Copyright 2016 The J-PET Framework Authors. All rights reserved.
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may find a copy of the License in the LICENCE file.
@@ -19,56 +19,23 @@
 #include <map>
 #include <string>
 #include <boost/property_tree/ptree.hpp>
-#include "../JPetParamBank/JPetParamBank.h"
+#include "../JPetParamGetter/JPetParamGetter.h"
 
-class JPetParamGetterAscii : public JPetParamGetter {
-public:
-  JPetParamGetterAscii(std::string filename) : filename(filename) {}
-  JPetParamBank* generateParamBank(const int runNumber);
+class JPetParamGetterAscii : public JPetParamGetter
+{
+  public:
+    JPetParamGetterAscii(std::string filename) : filename(filename) {}
+    ~JPetParamGetterAscii() {}
+    ParamObjectsDescriptions getAllBasicData(ParamObjectType type, const int runId);
+    ParamRelationalData getAllRelationalData(ParamObjectType type1, ParamObjectType type2, const int runId);
 
-private:
-  JPetParamGetterAscii(const JPetParamGetterAscii &paramGetterAscii);
-  JPetParamGetterAscii& operator=(const JPetParamGetterAscii &paramGetterAscii);
+  private:
+    JPetParamGetterAscii(const JPetParamGetterAscii &paramGetterAscii);
+    JPetParamGetterAscii& operator=(const JPetParamGetterAscii &paramGetterAscii);
 
-  JPetParamBank* loadFileContent(int runNumber);
+    ParamObjectDescription toDescription(boost::property_tree::ptree & info);
 
-		void fillScintillators(boost::property_tree::ptree & runContents, JPetParamBank & bank);
-		void fillPMs(boost::property_tree::ptree & runContents, JPetParamBank & bank);
-		void fillPMCalibs(boost::property_tree::ptree & runContents, JPetParamBank & bank);
-		void fillBarrelSlots(boost::property_tree::ptree & runContents, JPetParamBank & bank);
-		void fillLayers(boost::property_tree::ptree & runContents, JPetParamBank & bank);
-		void fillFrames(boost::property_tree::ptree & runContents, JPetParamBank & bank);
-		void fillFEBs(boost::property_tree::ptree & runContents, JPetParamBank & bank);
-		void fillTRBs(boost::property_tree::ptree & runContents, JPetParamBank & bank);
-		void fillTOMBChannels(boost::property_tree::ptree & runContents, JPetParamBank & bank);
-
-		JPetScin scintillatorFromInfo(boost::property_tree::ptree & info);
-		JPetPM PMFromInfo(boost::property_tree::ptree & info);
-		JPetPMCalib PMCalibFromInfo(boost::property_tree::ptree & info);
-		JPetBarrelSlot barrelSlotFromInfo(boost::property_tree::ptree & info);
-		JPetLayer layerFromInfo(boost::property_tree::ptree & info);
-		JPetFrame frameFromInfo(boost::property_tree::ptree & info);
-		JPetFEB FEBFromInfo(boost::property_tree::ptree & info);
-		JPetTRB TRBFromInfo(boost::property_tree::ptree & info);
-		JPetTOMBChannel TOMBChannelFromInfo(boost::property_tree::ptree & info);
-
-		std::map<int, int> scintillatorIdTranslation(JPetParamBank & bank);
-		std::map<int, int> PMIdTranslation(JPetParamBank & bank);
-		std::map<int, int> barrelSlotIdTranslation(JPetParamBank & bank);
-		std::map<int, int> layerIdTranslation(JPetParamBank & bank);
-		std::map<int, int> frameIdTranslation(JPetParamBank & bank);
-		std::map<int, int> FEBIdTranslation(JPetParamBank & bank);
-		std::map<int, int> TRBIdTranslation(JPetParamBank & bank);
-		std::map<int, int> TOMBChannelIdTranslation(JPetParamBank & bank);
-
-		void fillScintillatorTRefs(boost::property_tree::ptree & runContents, JPetParamBank & bank);
-		void fillPMTRefs(boost::property_tree::ptree & runContents, JPetParamBank & bank);
-		void fillBarrelSlotTRefs(boost::property_tree::ptree & runContents, JPetParamBank & bank);
-		void fillLayerTRefs(boost::property_tree::ptree & runContents, JPetParamBank & bank);
-		void fillFEBTRefs(boost::property_tree::ptree & runContents, JPetParamBank & bank);
-		void fillTOMBChannelTRefs(boost::property_tree::ptree & runContents, JPetParamBank & bank);
-
-  std::string filename;
+    std::string filename;
 
 };
 

--- a/JPetParamGetterAscii/JPetParamGetterAsciiTest.cpp
+++ b/JPetParamGetterAscii/JPetParamGetterAsciiTest.cpp
@@ -4,6 +4,7 @@
 
 #include "../JPetParamGetterAscii/JPetParamGetterAscii.h"
 #include "../JPetParamGetterAscii/JPetParamSaverAscii.h"
+#include "../JPetParamManager/JPetParamManager.h"
 #include <boost/filesystem.hpp>
 
 const std::string dataDir = "unitTestData/JPetParamGetterAsciiTest/";
@@ -13,214 +14,136 @@ BOOST_AUTO_TEST_SUITE(FirstSuite)
 BOOST_AUTO_TEST_CASE( noExisting_file_read )
 {
   JPetParamGetterAscii getter(dataDir+"noExisting.json");
-  BOOST_REQUIRE(getter.generateParamBank(1) == 0);
+  BOOST_REQUIRE_EQUAL(getter.getAllBasicData(ParamObjectType::kPM, 1).size(), 0);
 }
 
 BOOST_AUTO_TEST_CASE( empty_file_read )
 {
   JPetParamGetterAscii getter(dataDir+"empty.json");
-  BOOST_REQUIRE(getter.generateParamBank(1) == 0);
+  BOOST_REQUIRE_EQUAL(getter.getAllBasicData(ParamObjectType::kPM, 1).size(), 0);
 }
 
-BOOST_AUTO_TEST_CASE( minimal_example_read )
+BOOST_AUTO_TEST_CASE( minimal_basic_data_read )
 {
   JPetParamGetterAscii getter(dataDir+"DB1.json");
-		JPetParamBank * bank = getter.generateParamBank(1);
-		BOOST_REQUIRE(bank != 0);
-		JPetParamBank & paramBank = *bank;
-		BOOST_REQUIRE(paramBank.getScintillatorsSize() == 1);
-		BOOST_REQUIRE(paramBank.getBarrelSlotsSize() == 1);
-		BOOST_REQUIRE(paramBank.getPMsSize() == 1);
-		BOOST_REQUIRE(paramBank.getFEBsSize() == 1);
-		BOOST_REQUIRE(paramBank.getPMCalibsSize() == 1);
-		BOOST_REQUIRE(paramBank.getLayersSize() == 1);
-		BOOST_REQUIRE(paramBank.getFramesSize() == 1);
-		BOOST_REQUIRE(paramBank.getTOMBChannelsSize() == 1);
-		BOOST_REQUIRE(paramBank.getTRBsSize() == 1);
+  ParamObjectsDescriptions descriptions = getter.getAllBasicData(ParamObjectType::kPM, 1);
+  BOOST_REQUIRE_EQUAL(descriptions.size(), 1);
+  ParamObjectDescription & description = descriptions[1];
 
-		JPetScin & scintillator = paramBank.getScintillator(1);
-		BOOST_REQUIRE(scintillator.getID() == 1);
-		BOOST_REQUIRE(scintillator.getAttenLen() == 1.0);
-		BOOST_REQUIRE(scintillator.getScinSize().fLength == 1.0);
-		BOOST_REQUIRE(scintillator.getScinSize().fHeight == 1.0);
-		BOOST_REQUIRE(scintillator.getScinSize().fWidth == 1.0);
+  BOOST_REQUIRE_EQUAL(description["id"], "1");
+  BOOST_REQUIRE_EQUAL(description["is_right_side"], "1");
+}
 
-		JPetBarrelSlot & barrelSlot = paramBank.getBarrelSlot(1);
-		BOOST_REQUIRE(barrelSlot.getID() == 1);
-		BOOST_REQUIRE(barrelSlot.isActive());
-		BOOST_REQUIRE(barrelSlot.getName() == "Azathoth");
-		BOOST_REQUIRE(barrelSlot.getTheta() == 1.0);
-		BOOST_REQUIRE(barrelSlot.getInFrameID() == 1);
+BOOST_AUTO_TEST_CASE( minimal_relational_data_read )
+{
+  JPetParamGetterAscii getter(dataDir+"DB1.json");
+  ParamRelationalData relations = getter.getAllRelationalData(ParamObjectType::kPM, ParamObjectType::kBarrelSlot, 1);
+  BOOST_REQUIRE_EQUAL(relations.size(), 1);
 
-		JPetPM & pm = paramBank.getPM(1);
-		BOOST_REQUIRE(pm.getID() == 1);
-		BOOST_REQUIRE(pm.getSide() == JPetPM::Side::SideB);
-
-		JPetFEB & feb = paramBank.getFEB(1);
-		BOOST_REQUIRE(feb.getID() == 1);
-		BOOST_REQUIRE(feb.isActive());
-		BOOST_REQUIRE(feb.status() == std::string("fine"));
-		BOOST_REQUIRE(feb.description() == std::string("tall and dark-haired"));
-		BOOST_REQUIRE(feb.version() == 1);
-		BOOST_REQUIRE(feb.getNtimeOutsPerInput() == 1);
-		BOOST_REQUIRE(feb.getNnotimeOutsPerInput() == 1);
-
-		JPetPMCalib & pmCalib = paramBank.getPMCalib(1);
-		BOOST_REQUIRE(pmCalib.GetId() == 1);
-		BOOST_REQUIRE(pmCalib.GetNamePM() == std::string("Eris"));
-		BOOST_REQUIRE(pmCalib.GetOpthv() == 1.0);
-		BOOST_REQUIRE(pmCalib.GetECalConst1() == 1.0);
-		BOOST_REQUIRE(pmCalib.GetECalConst2() == 1.0);
-		BOOST_REQUIRE(pmCalib.GetGainalpha() == 1.0);
-		BOOST_REQUIRE(pmCalib.GetGainbeta() == 1.0);
-
-		JPetLayer & layer = paramBank.getLayer(1);
-		BOOST_REQUIRE(layer.getId() == 1);
-		BOOST_REQUIRE(layer.getIsActive());
-		BOOST_REQUIRE(layer.getName() == std::string("Krzesimir"));
-		BOOST_REQUIRE(layer.getRadius() == 1.0);
-
-		JPetFrame & frame = paramBank.getFrame(1);
-		BOOST_REQUIRE(frame.getId() == 1);
-		BOOST_REQUIRE(frame.getIsActive());
-		BOOST_REQUIRE(frame.getStatus() == std::string("fine"));
-		BOOST_REQUIRE(frame.getDescription() == std::string("tall and dark-haired"));
-		BOOST_REQUIRE(frame.getVersion() == 1);
-		BOOST_REQUIRE(frame.getCreator() == 1);
-
-		JPetTOMBChannel & tomb = paramBank.getTOMBChannel(1);
-		BOOST_REQUIRE(tomb.getThreshold() == 1.0);
-
-		JPetTRB & trb = paramBank.getTRB(1);
-		BOOST_REQUIRE(trb.getID() == 1);
-		BOOST_REQUIRE(trb.getType() == 1);
-		BOOST_REQUIRE(trb.getChannel() == 1);
-
-		BOOST_REQUIRE(barrelSlot == scintillator.getBarrelSlot());
-		BOOST_REQUIRE(barrelSlot == pm.getBarrelSlot());
-		BOOST_REQUIRE(scintillator == pm.getScin());
-		BOOST_REQUIRE(feb == pm.getFEB());
-		BOOST_REQUIRE(layer == barrelSlot.getLayer());
-		BOOST_REQUIRE(frame == layer.getFrame());
-		BOOST_REQUIRE(trb == feb.getTRB());
-		BOOST_REQUIRE(trb == tomb.getTRB());
-		BOOST_REQUIRE(feb == tomb.getFEB());
-		BOOST_REQUIRE(pm == tomb.getPM());
+  BOOST_REQUIRE_EQUAL(relations[1], 1);
 }
 
 BOOST_AUTO_TEST_CASE( minimal_example_write )
 {
-  JPetParamGetterAscii getter(dataDir+"DB1.json");
-		JPetParamBank * bank = getter.generateParamBank(1);
-		BOOST_REQUIRE(bank != 0);
-		JPetParamSaverAscii saver;
-		std::string writtenFileName(dataDir+"writtenDB1.json");
-		saver.saveParamBank(*bank, 1, writtenFileName);
-  JPetParamGetterAscii regetter(writtenFileName.c_str());
-		JPetParamBank * rebank = regetter.generateParamBank(1);
-		BOOST_REQUIRE(rebank != 0);
-		JPetParamBank & paramBank = *bank;
-		JPetParamBank & reparamBank = *rebank;
-		BOOST_REQUIRE(paramBank.getScintillatorsSize() == reparamBank.getScintillatorsSize());
-		BOOST_REQUIRE(paramBank.getBarrelSlotsSize() == reparamBank.getBarrelSlotsSize());
-		BOOST_REQUIRE(paramBank.getPMsSize() == reparamBank.getPMsSize());
-		BOOST_REQUIRE(paramBank.getFEBsSize() == reparamBank.getFEBsSize());
-		BOOST_REQUIRE(paramBank.getPMCalibsSize() == reparamBank.getPMCalibsSize());
-		BOOST_REQUIRE(paramBank.getLayersSize() == reparamBank.getLayersSize());
-		BOOST_REQUIRE(paramBank.getFramesSize() == reparamBank.getFramesSize());
-		BOOST_REQUIRE(paramBank.getTOMBChannelsSize() == reparamBank.getTOMBChannelsSize());
-		BOOST_REQUIRE(paramBank.getTRBsSize() == reparamBank.getTRBsSize());
+  JPetParamManager paramManager(new JPetParamGetterAscii(dataDir+"DB1.json"));
+  paramManager.fillParameterBank(1);
+  const JPetParamBank & paramBank = paramManager.getParamBank();
+  JPetParamSaverAscii saver;
+  std::string writtenFileName(dataDir+"writtenDB1.json");
+  saver.saveParamBank(paramBank, 1, writtenFileName);
+  JPetParamManager reparamManager(new JPetParamGetterAscii(writtenFileName.c_str()));
+  reparamManager.fillParameterBank(1);
+  const JPetParamBank & reparamBank = reparamManager.getParamBank();
+  BOOST_REQUIRE(paramBank.getScintillatorsSize() == reparamBank.getScintillatorsSize());
+  BOOST_REQUIRE(paramBank.getBarrelSlotsSize() == reparamBank.getBarrelSlotsSize());
+  BOOST_REQUIRE(paramBank.getPMsSize() == reparamBank.getPMsSize());
+  BOOST_REQUIRE(paramBank.getFEBsSize() == reparamBank.getFEBsSize());
+  BOOST_REQUIRE(paramBank.getPMCalibsSize() == reparamBank.getPMCalibsSize());
+  BOOST_REQUIRE(paramBank.getLayersSize() == reparamBank.getLayersSize());
+  BOOST_REQUIRE(paramBank.getFramesSize() == reparamBank.getFramesSize());
+  BOOST_REQUIRE(paramBank.getTOMBChannelsSize() == reparamBank.getTOMBChannelsSize());
+  BOOST_REQUIRE(paramBank.getTRBsSize() == reparamBank.getTRBsSize());
 
-		JPetScin & scintillator = paramBank.getScintillator(1);
-		JPetScin & rescintillator = reparamBank.getScintillator(1);
-		BOOST_REQUIRE(scintillator.getID() == rescintillator.getID());
-		BOOST_REQUIRE(scintillator.getAttenLen() == rescintillator.getAttenLen());
-		BOOST_REQUIRE(scintillator.getScinSize().fLength == rescintillator.getScinSize().fLength);
-		BOOST_REQUIRE(scintillator.getScinSize().fHeight == rescintillator.getScinSize().fHeight);
-		BOOST_REQUIRE(scintillator.getScinSize().fWidth == rescintillator.getScinSize().fWidth);
+  JPetScin & scintillator = paramBank.getScintillator(1);
+  JPetScin & rescintillator = reparamBank.getScintillator(1);
+  BOOST_REQUIRE(scintillator.getID() == rescintillator.getID());
+  BOOST_REQUIRE(scintillator.getAttenLen() == rescintillator.getAttenLen());
+  BOOST_REQUIRE(scintillator.getScinSize().fLength == rescintillator.getScinSize().fLength);
+  BOOST_REQUIRE(scintillator.getScinSize().fHeight == rescintillator.getScinSize().fHeight);
+  BOOST_REQUIRE(scintillator.getScinSize().fWidth == rescintillator.getScinSize().fWidth);
 
-		JPetBarrelSlot & barrelSlot = paramBank.getBarrelSlot(1);
-		JPetBarrelSlot & rebarrelSlot = reparamBank.getBarrelSlot(1);
-		BOOST_REQUIRE(barrelSlot.getID() == rebarrelSlot.getID());
-		BOOST_REQUIRE(barrelSlot.isActive() == rebarrelSlot.isActive());
-		BOOST_REQUIRE(barrelSlot.getName() == rebarrelSlot.getName());
-		BOOST_REQUIRE(barrelSlot.getTheta() == rebarrelSlot.getTheta());
-		BOOST_REQUIRE(barrelSlot.getInFrameID() == rebarrelSlot.getInFrameID());
+  JPetBarrelSlot & barrelSlot = paramBank.getBarrelSlot(1);
+  JPetBarrelSlot & rebarrelSlot = reparamBank.getBarrelSlot(1);
+  BOOST_REQUIRE(barrelSlot.getID() == rebarrelSlot.getID());
+  BOOST_REQUIRE(barrelSlot.isActive() == rebarrelSlot.isActive());
+  BOOST_REQUIRE(barrelSlot.getName() == rebarrelSlot.getName());
+  BOOST_REQUIRE(barrelSlot.getTheta() == rebarrelSlot.getTheta());
+  BOOST_REQUIRE(barrelSlot.getInFrameID() == rebarrelSlot.getInFrameID());
 
-		JPetPM & pm = paramBank.getPM(1);
-		JPetPM & repm = reparamBank.getPM(1);
-		BOOST_REQUIRE(pm.getID() == repm.getID());
-		BOOST_REQUIRE(pm.getSide() == repm.getSide());
+  JPetPM & pm = paramBank.getPM(1);
+  JPetPM & repm = reparamBank.getPM(1);
+  BOOST_REQUIRE(pm.getID() == repm.getID());
+  BOOST_REQUIRE(pm.getSide() == repm.getSide());
 
-		JPetFEB & feb = paramBank.getFEB(1);
-		JPetFEB & refeb = reparamBank.getFEB(1);
-		BOOST_REQUIRE(feb.getID() == refeb.getID());
-		BOOST_REQUIRE(feb.isActive() == refeb.isActive());
-		BOOST_REQUIRE(feb.status() == refeb.status());
-		BOOST_REQUIRE(feb.description() == refeb.description());
-		BOOST_REQUIRE(feb.version() == refeb.version());
-		BOOST_REQUIRE(feb.getNtimeOutsPerInput() == refeb.getNtimeOutsPerInput());
-		BOOST_REQUIRE(feb.getNnotimeOutsPerInput() == refeb.getNnotimeOutsPerInput());
+  JPetFEB & feb = paramBank.getFEB(1);
+  JPetFEB & refeb = reparamBank.getFEB(1);
+  BOOST_REQUIRE(feb.getID() == refeb.getID());
+  BOOST_REQUIRE(feb.isActive() == refeb.isActive());
+  BOOST_REQUIRE(feb.status() == refeb.status());
+  BOOST_REQUIRE(feb.description() == refeb.description());
+  BOOST_REQUIRE(feb.version() == refeb.version());
+  BOOST_REQUIRE(feb.getNtimeOutsPerInput() == refeb.getNtimeOutsPerInput());
+  BOOST_REQUIRE(feb.getNnotimeOutsPerInput() == refeb.getNnotimeOutsPerInput());
 
-		JPetPMCalib & pmCalib = paramBank.getPMCalib(1);
-		JPetPMCalib & repmCalib = reparamBank.getPMCalib(1);
-		BOOST_REQUIRE(pmCalib.GetId() == repmCalib.GetId());
-		BOOST_REQUIRE(pmCalib.GetNamePM() == repmCalib.GetNamePM());
-		BOOST_REQUIRE(pmCalib.GetOpthv() == repmCalib.GetOpthv());
-		BOOST_REQUIRE(pmCalib.GetECalConst1() == repmCalib.GetECalConst1());
-		BOOST_REQUIRE(pmCalib.GetECalConst2() == repmCalib.GetECalConst2());
-		BOOST_REQUIRE(pmCalib.GetGainalpha() == repmCalib.GetGainalpha());
-		BOOST_REQUIRE(pmCalib.GetGainbeta() == repmCalib.GetGainbeta());
+  JPetLayer & layer = paramBank.getLayer(1);
+  JPetLayer & relayer = reparamBank.getLayer(1);
+  BOOST_REQUIRE(layer.getId() == relayer.getId());
+  BOOST_REQUIRE(layer.getIsActive() == relayer.getIsActive());
+  BOOST_REQUIRE(layer.getName() == relayer.getName());
+  BOOST_REQUIRE(layer.getRadius() == relayer.getRadius());
 
-		JPetLayer & layer = paramBank.getLayer(1);
-		JPetLayer & relayer = reparamBank.getLayer(1);
-		BOOST_REQUIRE(layer.getId() == relayer.getId());
-		BOOST_REQUIRE(layer.getIsActive() == relayer.getIsActive());
-		BOOST_REQUIRE(layer.getName() == relayer.getName());
-		BOOST_REQUIRE(layer.getRadius() == relayer.getRadius());
+  JPetFrame & frame = paramBank.getFrame(1);
+  JPetFrame & reframe = reparamBank.getFrame(1);
+  BOOST_REQUIRE(frame.getId() == reframe.getId());
+  BOOST_REQUIRE(frame.getIsActive() == reframe.getIsActive());
+  BOOST_REQUIRE(frame.getStatus() == reframe.getStatus());
+  BOOST_REQUIRE(frame.getDescription() == reframe.getDescription());
+  BOOST_REQUIRE(frame.getVersion() == reframe.getVersion());
+  BOOST_REQUIRE(frame.getCreator() == reframe.getCreator());
 
-		JPetFrame & frame = paramBank.getFrame(1);
-		JPetFrame & reframe = reparamBank.getFrame(1);
-		BOOST_REQUIRE(frame.getId() == reframe.getId());
-		BOOST_REQUIRE(frame.getIsActive() == reframe.getIsActive());
-		BOOST_REQUIRE(frame.getStatus() == reframe.getStatus());
-		BOOST_REQUIRE(frame.getDescription() == reframe.getDescription());
-		BOOST_REQUIRE(frame.getVersion() == reframe.getVersion());
-		BOOST_REQUIRE(frame.getCreator() == reframe.getCreator());
+  JPetTOMBChannel & tomb = paramBank.getTOMBChannel(1);
+  JPetTOMBChannel & retomb = reparamBank.getTOMBChannel(1);
+  BOOST_REQUIRE(tomb.getThreshold() == retomb.getThreshold());
 
-		JPetTOMBChannel & tomb = paramBank.getTOMBChannel(1);
-		JPetTOMBChannel & retomb = reparamBank.getTOMBChannel(1);
-		BOOST_REQUIRE(tomb.getThreshold() == retomb.getThreshold());
+  JPetTRB & trb = paramBank.getTRB(1);
+  JPetTRB & retrb = reparamBank.getTRB(1);
+  BOOST_REQUIRE(trb.getID() == retrb.getID());
+  BOOST_REQUIRE(trb.getType() == retrb.getType());
+  BOOST_REQUIRE(trb.getChannel() == retrb.getChannel());
 
-		JPetTRB & trb = paramBank.getTRB(1);
-		JPetTRB & retrb = reparamBank.getTRB(1);
-		BOOST_REQUIRE(trb.getID() == retrb.getID());
-		BOOST_REQUIRE(trb.getType() == retrb.getType());
-		BOOST_REQUIRE(trb.getChannel() == retrb.getChannel());
+  BOOST_REQUIRE(barrelSlot == scintillator.getBarrelSlot());
+  BOOST_REQUIRE(barrelSlot == pm.getBarrelSlot());
+  BOOST_REQUIRE(scintillator == pm.getScin());
+  BOOST_REQUIRE(feb == pm.getFEB());
+  BOOST_REQUIRE(layer == barrelSlot.getLayer());
+  BOOST_REQUIRE(frame == layer.getFrame());
+  BOOST_REQUIRE(trb == feb.getTRB());
+  BOOST_REQUIRE(trb == tomb.getTRB());
+  BOOST_REQUIRE(feb == tomb.getFEB());
+  BOOST_REQUIRE(pm == tomb.getPM());
 
-		BOOST_REQUIRE(barrelSlot == scintillator.getBarrelSlot());
-		BOOST_REQUIRE(barrelSlot == pm.getBarrelSlot());
-		BOOST_REQUIRE(scintillator == pm.getScin());
-		BOOST_REQUIRE(feb == pm.getFEB());
-		BOOST_REQUIRE(layer == barrelSlot.getLayer());
-		BOOST_REQUIRE(frame == layer.getFrame());
-		BOOST_REQUIRE(trb == feb.getTRB());
-		BOOST_REQUIRE(trb == tomb.getTRB());
-		BOOST_REQUIRE(feb == tomb.getFEB());
-		BOOST_REQUIRE(pm == tomb.getPM());
+  BOOST_REQUIRE(rebarrelSlot == rescintillator.getBarrelSlot());
+  BOOST_REQUIRE(rebarrelSlot == repm.getBarrelSlot());
+  BOOST_REQUIRE(rescintillator == repm.getScin());
+  BOOST_REQUIRE(refeb == repm.getFEB());
+  BOOST_REQUIRE(relayer == rebarrelSlot.getLayer());
+  BOOST_REQUIRE(reframe == relayer.getFrame());
+  BOOST_REQUIRE(retrb == refeb.getTRB());
+  BOOST_REQUIRE(retrb == retomb.getTRB());
+  BOOST_REQUIRE(refeb == retomb.getFEB());
+  BOOST_REQUIRE(repm == retomb.getPM());
 
-		BOOST_REQUIRE(rebarrelSlot == rescintillator.getBarrelSlot());
-		BOOST_REQUIRE(rebarrelSlot == repm.getBarrelSlot());
-		BOOST_REQUIRE(rescintillator == repm.getScin());
-		BOOST_REQUIRE(refeb == repm.getFEB());
-		BOOST_REQUIRE(relayer == rebarrelSlot.getLayer());
-		BOOST_REQUIRE(reframe == relayer.getFrame());
-		BOOST_REQUIRE(retrb == refeb.getTRB());
-		BOOST_REQUIRE(retrb == retomb.getTRB());
-		BOOST_REQUIRE(refeb == retomb.getFEB());
-		BOOST_REQUIRE(repm == retomb.getPM());
-
-		boost::filesystem::remove(writtenFileName);
+  boost::filesystem::remove(writtenFileName);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/JPetParamGetterAscii/JPetParamSaverAscii.cpp
+++ b/JPetParamGetterAscii/JPetParamSaverAscii.cpp
@@ -1,5 +1,5 @@
 /**
-	*  @copyright Copyright 2016 The J-PET Framework Authors. All rights reserved.
+ *  @copyright Copyright 2016 The J-PET Framework Authors. All rights reserved.
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may find a copy of the License in the LICENCE file.
@@ -11,8 +11,8 @@
  *  limitations under the License.
  *
 
-		*  @file JPetParamSaverAscii.cpp
-		*/
+ *  @file JPetParamSaverAscii.cpp
+ */
 
 #include "./JPetParamSaverAscii.h"
 #include "./JPetParamAsciiConstants.h"
@@ -23,246 +23,246 @@
 
 void JPetParamSaverAscii::saveParamBank(const JPetParamBank & bank, const int runNumber, const std::string & filename)
 {
-	std::string runNumberS = boost::lexical_cast<std::string>(runNumber);
-	auto fileTree = getTreeFromFile(filename);
-	addToTree(fileTree, bank, runNumberS);
-	write_json(filename, fileTree);
+  std::string runNumberS = boost::lexical_cast<std::string>(runNumber);
+  auto fileTree = getTreeFromFile(filename);
+  addToTree(fileTree, bank, runNumberS);
+  write_json(filename, fileTree);
 }
 
 boost::property_tree::ptree JPetParamSaverAscii::getTreeFromFile(const std::string & filename)
 {
-	boost::property_tree::ptree result;
-	if (boost::filesystem::exists(filename)) {
-		boost::property_tree::read_json(filename, result);
-	}
-	return result;
+  boost::property_tree::ptree result;
+  if (boost::filesystem::exists(filename)) {
+    boost::property_tree::read_json(filename, result);
+  }
+  return result;
 }
 
 void JPetParamSaverAscii::addToTree(boost::property_tree::ptree & tree, const JPetParamBank & bank, const std::string & runNumber)
 {
-	if (tree.count(runNumber) != 0) {
-		WARNING("Overwriting parameters in run number " + runNumber + ". I hope you wanted to do that.");
-		tree.erase(runNumber);
-	}
-	boost::property_tree::ptree runContents;
+  if (tree.count(runNumber) != 0) {
+    WARNING("Overwriting parameters in run number " + runNumber + ". I hope you wanted to do that.");
+    tree.erase(runNumber);
+  }
+  boost::property_tree::ptree runContents;
 
-	fillScintillators(runContents, bank);
-	fillPMs(runContents, bank);
-	fillPMCalibs(runContents, bank);
-	fillBarrelSlots(runContents, bank);
-	fillLayers(runContents, bank);
-	fillFrames(runContents, bank);
-	fillFEBs(runContents, bank);
-	fillTRBs(runContents, bank);
-	fillTOMBChannels(runContents, bank);
+  fillScintillators(runContents, bank);
+  fillPMs(runContents, bank);
+  fillPMCalibs(runContents, bank);
+  fillBarrelSlots(runContents, bank);
+  fillLayers(runContents, bank);
+  fillFrames(runContents, bank);
+  fillFEBs(runContents, bank);
+  fillTRBs(runContents, bank);
+  fillTOMBChannels(runContents, bank);
 
-	tree.add_child(runNumber, runContents);
+  tree.add_child(runNumber, runContents);
 }
 
 
 void JPetParamSaverAscii::fillScintillators(boost::property_tree::ptree & runContents, const JPetParamBank & bank)
 {
-	boost::property_tree::ptree infos;
-	for (auto scin : bank.getScintillators()) {
-		infos.push_back(std::make_pair("", scintillatorToInfo(*scin.second)));
-	}
-	runContents.add_child(scintillatorsName, infos);
+  boost::property_tree::ptree infos;
+  for (auto scin : bank.getScintillators()) {
+    infos.push_back(std::make_pair("", scintillatorToInfo(*scin.second)));
+  }
+  runContents.add_child(objectsNames.at(ParamObjectType::kScintillator), infos);
 }
 
 boost::property_tree::ptree JPetParamSaverAscii::scintillatorToInfo(const JPetScin & scin)
 {
-	boost::property_tree::ptree info;
-	info.put("id", scin.getID());
-	info.put("attenuation_length", scin.getAttenLen());
-	auto dimensions = scin.getScinSize();
-	info.put("length", dimensions.fLength);
-	info.put("width", dimensions.fWidth);
-	info.put("height", dimensions.fHeight);
+  boost::property_tree::ptree info;
+  info.put("id", scin.getID());
+  info.put("attenuation_length", scin.getAttenLen());
+  auto dimensions = scin.getScinSize();
+  info.put("length", dimensions.fLength);
+  info.put("width", dimensions.fWidth);
+  info.put("height", dimensions.fHeight);
 
-	info.put(barrelSlotsName+"_id", scin.getBarrelSlot().getID());
-	return info;
+  info.put(objectsNames.at(ParamObjectType::kBarrelSlot)+"_id", scin.getBarrelSlot().getID());
+  return info;
 }
 
 
 void JPetParamSaverAscii::fillPMs(boost::property_tree::ptree & runContents, const JPetParamBank & bank)
 {
-	boost::property_tree::ptree infos;
-	for (auto pm : bank.getPMs()) {
-		infos.push_back(std::make_pair("", PMToInfo(*pm.second)));
-	}
-	runContents.add_child(PMsName, infos);
+  boost::property_tree::ptree infos;
+  for (auto pm : bank.getPMs()) {
+    infos.push_back(std::make_pair("", PMToInfo(*pm.second)));
+  }
+  runContents.add_child(objectsNames.at(ParamObjectType::kPM), infos);
 }
 
 boost::property_tree::ptree JPetParamSaverAscii::PMToInfo(const JPetPM & pm)
 {
-	boost::property_tree::ptree info;
-	info.put("id", pm.getID());
-	info.put("is_right_side", (pm.getSide() == JPetPM::Side::SideB));
+  boost::property_tree::ptree info;
+  info.put("id", pm.getID());
+  info.put("is_right_side", (pm.getSide() == JPetPM::Side::SideB));
 
-	info.put(barrelSlotsName+"_id", pm.getBarrelSlot().getID());
-	info.put(FEBsName+"_id", pm.getFEB().getID());
-	info.put(scintillatorsName+"_id", pm.getScin().getID());
-	return info;
+  info.put(objectsNames.at(ParamObjectType::kBarrelSlot)+"_id", pm.getBarrelSlot().getID());
+  info.put(objectsNames.at(ParamObjectType::kFEB)+"_id", pm.getFEB().getID());
+  info.put(objectsNames.at(ParamObjectType::kScintillator)+"_id", pm.getScin().getID());
+  return info;
 }
 
 
 void JPetParamSaverAscii::fillPMCalibs(boost::property_tree::ptree & runContents, const JPetParamBank & bank)
 {
-	boost::property_tree::ptree infos;
-	for (auto pmCalib : bank.getPMCalibs()) {
-		infos.push_back(std::make_pair("", PMCalibToInfo(*pmCalib.second)));
-	}
-	runContents.add_child(PMCalibsName, infos);
+  boost::property_tree::ptree infos;
+  for (auto pmCalib : bank.getPMCalibs()) {
+    infos.push_back(std::make_pair("", PMCalibToInfo(*pmCalib.second)));
+  }
+  runContents.add_child(objectsNames.at(ParamObjectType::kPMCalib), infos);
 }
 
 boost::property_tree::ptree JPetParamSaverAscii::PMCalibToInfo(const JPetPMCalib & pmCalib)
 {
-	boost::property_tree::ptree info;
-	info.put("id", pmCalib.GetId());
-	info.put("name", pmCalib.GetNamePM());
-	info.put("opthv", pmCalib.GetOpthv());
-	info.put("c2e1", pmCalib.GetECalConst1());
-	info.put("c2e2", pmCalib.GetECalConst2());
-	info.put("gain_alpha", pmCalib.GetGainalpha());
-	info.put("gain_beta", pmCalib.GetGainbeta());
-	auto assignment = pmCalib.GetPMCalibAssignment();
-	info.put("assignment_id", assignment.id);
-	info.put("assignment_photomultiplier_id", assignment.photomultiplier_id);
-	return info;
+  boost::property_tree::ptree info;
+  info.put("id", pmCalib.GetId());
+  info.put("name", pmCalib.GetNamePM());
+  info.put("opthv", pmCalib.GetOpthv());
+  info.put("c2e1", pmCalib.GetECalConst1());
+  info.put("c2e2", pmCalib.GetECalConst2());
+  info.put("gain_alpha", pmCalib.GetGainalpha());
+  info.put("gain_beta", pmCalib.GetGainbeta());
+  auto assignment = pmCalib.GetPMCalibAssignment();
+  info.put("assignment_id", assignment.id);
+  info.put("assignment_photomultiplier_id", assignment.photomultiplier_id);
+  return info;
 }
 
 
 void JPetParamSaverAscii::fillBarrelSlots(boost::property_tree::ptree & runContents, const JPetParamBank & bank)
 {
-	boost::property_tree::ptree infos;
-	for (auto bs : bank.getBarrelSlots()) {
-		infos.push_back(std::make_pair("", barrelSlotToInfo(*bs.second)));
-	}
-	runContents.add_child(barrelSlotsName, infos);
+  boost::property_tree::ptree infos;
+  for (auto bs : bank.getBarrelSlots()) {
+    infos.push_back(std::make_pair("", barrelSlotToInfo(*bs.second)));
+  }
+  runContents.add_child(objectsNames.at(ParamObjectType::kBarrelSlot), infos);
 }
 
 boost::property_tree::ptree JPetParamSaverAscii::barrelSlotToInfo(const JPetBarrelSlot & bs)
 {
-	boost::property_tree::ptree info;
-	info.put("id", bs.getID());
-	info.put("active", bs.isActive());
-	info.put("name", bs.getName());
-	info.put("theta1", bs.getTheta());
-	info.put("frame_id", bs.getInFrameID());
+  boost::property_tree::ptree info;
+  info.put("id", bs.getID());
+  info.put("active", bs.isActive());
+  info.put("name", bs.getName());
+  info.put("theta1", bs.getTheta());
+  info.put("frame_id", bs.getInFrameID());
 
-	info.put(layersName+"_id", bs.getLayer().getId());
-	return info;
+  info.put(objectsNames.at(ParamObjectType::kLayer)+"_id", bs.getLayer().getId());
+  return info;
 }
 
 
 void JPetParamSaverAscii::fillLayers(boost::property_tree::ptree & runContents, const JPetParamBank & bank)
 {
-	boost::property_tree::ptree infos;
-	for (auto layer : bank.getLayers()) {
-		infos.push_back(std::make_pair("", layerToInfo(*layer.second)));
-	}
-	runContents.add_child(layersName, infos);
+  boost::property_tree::ptree infos;
+  for (auto layer : bank.getLayers()) {
+    infos.push_back(std::make_pair("", layerToInfo(*layer.second)));
+  }
+  runContents.add_child(objectsNames.at(ParamObjectType::kLayer), infos);
 }
 
 boost::property_tree::ptree JPetParamSaverAscii::layerToInfo(const JPetLayer & layer)
 {
-	boost::property_tree::ptree info;
-	info.put("id", layer.getId());
-	info.put("active", layer.getIsActive());
-	info.put("name", layer.getName());
-	info.put("radius", layer.getRadius());
+  boost::property_tree::ptree info;
+  info.put("id", layer.getId());
+  info.put("active", layer.getIsActive());
+  info.put("name", layer.getName());
+  info.put("radius", layer.getRadius());
 
-	info.put(framesName+"_id", layer.getFrame().getId());
-	return info;
+  info.put(objectsNames.at(ParamObjectType::kFrame)+"_id", layer.getFrame().getId());
+  return info;
 }
 
 
 void JPetParamSaverAscii::fillFrames(boost::property_tree::ptree & runContents, const JPetParamBank & bank)
 {
-	boost::property_tree::ptree infos;
-	for (auto frame : bank.getFrames()) {
-		infos.push_back(std::make_pair("", frameToInfo(*frame.second)));
-	}
-	runContents.add_child(framesName, infos);
+  boost::property_tree::ptree infos;
+  for (auto frame : bank.getFrames()) {
+    infos.push_back(std::make_pair("", frameToInfo(*frame.second)));
+  }
+  runContents.add_child(objectsNames.at(ParamObjectType::kFrame), infos);
 }
 
 boost::property_tree::ptree JPetParamSaverAscii::frameToInfo(const JPetFrame & frame)
 {
-	boost::property_tree::ptree info;
-	info.put("id", frame.getId());
-	info.put("active", frame.getIsActive());
-	info.put("status", frame.getStatus());
-	info.put("description", frame.getDescription());
-	info.put("version", frame.getVersion());
-	info.put("creator_id", frame.getCreator());
-	return info;
+  boost::property_tree::ptree info;
+  info.put("id", frame.getId());
+  info.put("active", frame.getIsActive());
+  info.put("status", frame.getStatus());
+  info.put("description", frame.getDescription());
+  info.put("version", frame.getVersion());
+  info.put("creator_id", frame.getCreator());
+  return info;
 }
 
 
 void JPetParamSaverAscii::fillFEBs(boost::property_tree::ptree & runContents, const JPetParamBank & bank)
 {
-	boost::property_tree::ptree infos;
-	for (auto feb : bank.getFEBs()) {
-		infos.push_back(std::make_pair("", FEBToInfo(*feb.second)));
-	}
-	runContents.add_child(FEBsName, infos);
+  boost::property_tree::ptree infos;
+  for (auto feb : bank.getFEBs()) {
+    infos.push_back(std::make_pair("", FEBToInfo(*feb.second)));
+  }
+  runContents.add_child(objectsNames.at(ParamObjectType::kFEB), infos);
 }
 
 boost::property_tree::ptree JPetParamSaverAscii::FEBToInfo(const JPetFEB & feb)
 {
-	boost::property_tree::ptree info;
-	info.put("id", feb.getID());
-	info.put("active", feb.isActive());
-	info.put("status", feb.status());
-	info.put("description", feb.description());
-	info.put("version", feb.version());
-	info.put("creator_id", feb.getCreator());
-	info.put("time_outputs_per_input", feb.getNtimeOutsPerInput());
-	info.put("no_time_outputs_per_input", feb.getNnotimeOutsPerInput());
+  boost::property_tree::ptree info;
+  info.put("id", feb.getID());
+  info.put("active", feb.isActive());
+  info.put("status", feb.status());
+  info.put("description", feb.description());
+  info.put("version", feb.version());
+  info.put("creator_id", feb.getCreator());
+  info.put("time_outputs_per_input", feb.getNtimeOutsPerInput());
+  info.put("no_time_outputs_per_input", feb.getNnotimeOutsPerInput());
 
-	info.put(TRBsName+"_id", feb.getTRB().getID());
-	return info;
+  info.put(objectsNames.at(ParamObjectType::kTRB)+"_id", feb.getTRB().getID());
+  return info;
 }
 
 
 void JPetParamSaverAscii::fillTRBs(boost::property_tree::ptree & runContents, const JPetParamBank & bank)
 {
-	boost::property_tree::ptree infos;
-	for (auto trb : bank.getTRBs()) {
-		infos.push_back(std::make_pair("", TRBToInfo(*trb.second)));
-	}
-	runContents.add_child(TRBsName, infos);
+  boost::property_tree::ptree infos;
+  for (auto trb : bank.getTRBs()) {
+    infos.push_back(std::make_pair("", TRBToInfo(*trb.second)));
+  }
+  runContents.add_child(objectsNames.at(ParamObjectType::kTRB), infos);
 }
 
 boost::property_tree::ptree JPetParamSaverAscii::TRBToInfo(const JPetTRB & trb)
 {
-	boost::property_tree::ptree info;
-	info.put("id", trb.getID());
-	info.put("type", trb.getType());
-	info.put("channel", trb.getChannel());
-	return info;
+  boost::property_tree::ptree info;
+  info.put("id", trb.getID());
+  info.put("type", trb.getType());
+  info.put("channel", trb.getChannel());
+  return info;
 }
 
 
 void JPetParamSaverAscii::fillTOMBChannels(boost::property_tree::ptree & runContents, const JPetParamBank & bank)
 {
-	boost::property_tree::ptree infos;
-	for (auto tomb : bank.getTOMBChannels()) {
-		infos.push_back(std::make_pair("", TOMBChannelToInfo(*tomb.second)));
-	}
-	runContents.add_child(TOMBChannelsName, infos);
+  boost::property_tree::ptree infos;
+  for (auto tomb : bank.getTOMBChannels()) {
+    infos.push_back(std::make_pair("", TOMBChannelToInfo(*tomb.second)));
+  }
+  runContents.add_child(objectsNames.at(ParamObjectType::kTOMBChannel), infos);
 }
 
 boost::property_tree::ptree JPetParamSaverAscii::TOMBChannelToInfo(const JPetTOMBChannel & tomb)
 {
-	boost::property_tree::ptree info;
-	info.put("local_number", tomb.getLocalChannelNumber());
-	info.put("channel", tomb.getChannel());
-	info.put("FEB", tomb.getFEBInputNumber());
-	info.put("threshold", tomb.getThreshold());
+  boost::property_tree::ptree info;
+  info.put("local_number", tomb.getLocalChannelNumber());
+  info.put("channel", tomb.getChannel());
+  info.put("FEB", tomb.getFEBInputNumber());
+  info.put("threshold", tomb.getThreshold());
 
-	info.put(TRBsName+"_id", tomb.getTRB().getID());
-	info.put(FEBsName+"_id", tomb.getFEB().getID());
-	info.put(PMsName+"_id", tomb.getPM().getID());
-	return info;
+  info.put(objectsNames.at(ParamObjectType::kTRB)+"_id", tomb.getTRB().getID());
+  info.put(objectsNames.at(ParamObjectType::kFEB)+"_id", tomb.getFEB().getID());
+  info.put(objectsNames.at(ParamObjectType::kPM)+"_id", tomb.getPM().getID());
+  return info;
 }

--- a/JPetParamGetterAscii/JPetParamSaverAscii.h
+++ b/JPetParamGetterAscii/JPetParamSaverAscii.h
@@ -21,37 +21,38 @@
 #include <boost/property_tree/ptree.hpp>
 #include "../JPetParamBank/JPetParamBank.h"
 
-class JPetParamSaverAscii {
-public:
-		JPetParamSaverAscii() {}
-  void saveParamBank(const JPetParamBank & bank, const int runNumber, const std::string & filename);
+class JPetParamSaverAscii
+{
+  public:
+    JPetParamSaverAscii() {}
+    void saveParamBank(const JPetParamBank & bank, const int runNumber, const std::string & filename);
 
-private:
-  JPetParamSaverAscii(const JPetParamSaverAscii &paramSaver);
-  JPetParamSaverAscii& operator=(const JPetParamSaverAscii &paramSaver);
+  private:
+    JPetParamSaverAscii(const JPetParamSaverAscii &paramSaver);
+    JPetParamSaverAscii& operator=(const JPetParamSaverAscii &paramSaver);
 
-		boost::property_tree::ptree getTreeFromFile(const std::string & filename);
-		void addToTree(boost::property_tree::ptree & tree, const JPetParamBank & bank, const std::string & runNumber);
+    boost::property_tree::ptree getTreeFromFile(const std::string & filename);
+    void addToTree(boost::property_tree::ptree & tree, const JPetParamBank & bank, const std::string & runNumber);
 
-		void fillScintillators(boost::property_tree::ptree & runContents, const JPetParamBank & bank);
-		void fillPMs(boost::property_tree::ptree & runContents, const JPetParamBank & bank);
-		void fillPMCalibs(boost::property_tree::ptree & runContents, const JPetParamBank & bank);
-		void fillBarrelSlots(boost::property_tree::ptree & runContents, const JPetParamBank & bank);
-		void fillLayers(boost::property_tree::ptree & runContents, const JPetParamBank & bank);
-		void fillFrames(boost::property_tree::ptree & runContents, const JPetParamBank & bank);
-		void fillFEBs(boost::property_tree::ptree & runContents, const JPetParamBank & bank);
-		void fillTRBs(boost::property_tree::ptree & runContents, const JPetParamBank & bank);
-		void fillTOMBChannels(boost::property_tree::ptree & runContents, const JPetParamBank & bank);
+    void fillScintillators(boost::property_tree::ptree & runContents, const JPetParamBank & bank);
+    void fillPMs(boost::property_tree::ptree & runContents, const JPetParamBank & bank);
+    void fillPMCalibs(boost::property_tree::ptree & runContents, const JPetParamBank & bank);
+    void fillBarrelSlots(boost::property_tree::ptree & runContents, const JPetParamBank & bank);
+    void fillLayers(boost::property_tree::ptree & runContents, const JPetParamBank & bank);
+    void fillFrames(boost::property_tree::ptree & runContents, const JPetParamBank & bank);
+    void fillFEBs(boost::property_tree::ptree & runContents, const JPetParamBank & bank);
+    void fillTRBs(boost::property_tree::ptree & runContents, const JPetParamBank & bank);
+    void fillTOMBChannels(boost::property_tree::ptree & runContents, const JPetParamBank & bank);
 
-		boost::property_tree::ptree scintillatorToInfo(const JPetScin & scin);
-		boost::property_tree::ptree PMToInfo(const JPetPM & pm);
-		boost::property_tree::ptree PMCalibToInfo(const JPetPMCalib & pmCalib);
-		boost::property_tree::ptree barrelSlotToInfo(const JPetBarrelSlot & bs);
-		boost::property_tree::ptree layerToInfo(const JPetLayer & layer);
-		boost::property_tree::ptree frameToInfo(const JPetFrame & frame);
-		boost::property_tree::ptree FEBToInfo(const JPetFEB & feb);
-		boost::property_tree::ptree TRBToInfo(const JPetTRB & trb);
-		boost::property_tree::ptree TOMBChannelToInfo(const JPetTOMBChannel & tomb);
+    boost::property_tree::ptree scintillatorToInfo(const JPetScin & scin);
+    boost::property_tree::ptree PMToInfo(const JPetPM & pm);
+    boost::property_tree::ptree PMCalibToInfo(const JPetPMCalib & pmCalib);
+    boost::property_tree::ptree barrelSlotToInfo(const JPetBarrelSlot & bs);
+    boost::property_tree::ptree layerToInfo(const JPetLayer & layer);
+    boost::property_tree::ptree frameToInfo(const JPetFrame & frame);
+    boost::property_tree::ptree FEBToInfo(const JPetFEB & feb);
+    boost::property_tree::ptree TRBToInfo(const JPetTRB & trb);
+    boost::property_tree::ptree TOMBChannelToInfo(const JPetTOMBChannel & tomb);
 
 };
 

--- a/JPetParamManager/JPetParamManager.cpp
+++ b/JPetParamManager/JPetParamManager.cpp
@@ -18,38 +18,172 @@
 #include <TFile.h>
 #include <boost/property_tree/xml_parser.hpp>
 
-using namespace std;
-
-
-JPetParamManager::JPetParamManager(bool isNull):
-  fParamGetter(new JPetDBParamGetter()),
-  fBank(0),
-  fIsNullObject(isNull)
-{
-  /* */
-}
-
 JPetParamManager::~JPetParamManager()
 {
   if (fBank) {
     delete fBank;
     fBank = 0;
   }
-		if (fParamGetter) {
-				delete fParamGetter;
-				fParamGetter = 0;
-		}
+  if (fParamGetter) {
+    delete fParamGetter;
+    fParamGetter = 0;
+  }
 }
 
-bool JPetParamManager::fillParameterBank(const int run)
+std::map<int, JPetTRB *> & JPetParamManager::getTRBs(const int runId)
+{
+  return getTRBFactory(runId).getTRBs();
+}
+
+JPetTRBFactory & JPetParamManager::getTRBFactory(const int runId)
+{
+  if (fTRBFactories.count(runId) == 0) {
+    fTRBFactories.emplace(std::piecewise_construct, std::forward_as_tuple(runId), std::forward_as_tuple(*fParamGetter, runId));
+  }
+  return fTRBFactories.at(runId);
+}
+
+std::map<int, JPetFEB *> & JPetParamManager::getFEBs(const int runId)
+{
+  return getFEBFactory(runId).getFEBs();
+}
+
+JPetFEBFactory & JPetParamManager::getFEBFactory(const int runId)
+{
+  if (fFEBFactories.count(runId) == 0) {
+    fFEBFactories.emplace(std::piecewise_construct, std::forward_as_tuple(runId), std::forward_as_tuple(*fParamGetter, runId, getTRBFactory(runId)));
+  }
+  return fFEBFactories.at(runId);
+}
+
+std::map<int, JPetFrame *> & JPetParamManager::getFrames(const int runId)
+{
+  return getFrameFactory(runId).getFrames();
+}
+
+JPetFrameFactory & JPetParamManager::getFrameFactory(const int runId)
+{
+  if (fFrameFactories.count(runId) == 0) {
+    fFrameFactories.emplace(std::piecewise_construct, std::forward_as_tuple(runId), std::forward_as_tuple(*fParamGetter, runId));
+  }
+  return fFrameFactories.at(runId);
+}
+
+std::map<int, JPetLayer *> & JPetParamManager::getLayers(const int runId)
+{
+  return getLayerFactory(runId).getLayers();
+}
+
+JPetLayerFactory & JPetParamManager::getLayerFactory(const int runId)
+{
+  if (fLayerFactories.count(runId) == 0) {
+    fLayerFactories.emplace(std::piecewise_construct, std::forward_as_tuple(runId), std::forward_as_tuple(*fParamGetter, runId, getFrameFactory(runId)));
+  }
+  return fLayerFactories.at(runId);
+}
+
+std::map<int, JPetBarrelSlot *> & JPetParamManager::getBarrelSlots(const int runId)
+{
+  return getBarrelSlotFactory(runId).getBarrelSlots();
+}
+
+JPetBarrelSlotFactory & JPetParamManager::getBarrelSlotFactory(const int runId)
+{
+  if (fBarrelSlotFactories.count(runId) == 0) {
+    fBarrelSlotFactories.emplace(std::piecewise_construct, std::forward_as_tuple(runId), std::forward_as_tuple(*fParamGetter, runId, getLayerFactory(runId)));
+  }
+  fBarrelSlotFactories.at(runId);
+  return fBarrelSlotFactories.at(runId);
+}
+
+std::map<int, JPetScin *> & JPetParamManager::getScins(const int runId)
+{
+  return getScinFactory(runId).getScins();
+}
+
+JPetScinFactory & JPetParamManager::getScinFactory(const int runId)
+{
+  if (fScinFactories.count(runId) == 0) {
+    fScinFactories.emplace(std::piecewise_construct, std::forward_as_tuple(runId), std::forward_as_tuple(*fParamGetter, runId, getBarrelSlotFactory(runId)));
+  }
+  return fScinFactories.at(runId);
+}
+
+std::map<int, JPetPM *> & JPetParamManager::getPMs(const int runId)
+{
+  return getPMFactory(runId).getPMs();
+}
+
+JPetPMFactory & JPetParamManager::getPMFactory(const int runId)
+{
+  if (fPMFactories.count(runId) == 0) {
+    fPMFactories.emplace(std::piecewise_construct, std::forward_as_tuple(runId), std::forward_as_tuple(*fParamGetter, runId, getFEBFactory(runId), getScinFactory(runId), getBarrelSlotFactory(runId)));
+  }
+  return fPMFactories.at(runId);
+}
+
+std::map<int, JPetTOMBChannel *> & JPetParamManager::getTOMBChannels(const int runId)
+{
+  return getTOMBChannelFactory(runId).getTOMBChannels();
+}
+
+JPetTOMBChannelFactory & JPetParamManager::getTOMBChannelFactory(const int runId)
+{
+  if (fTOMBChannelFactories.count(runId) == 0) {
+    fTOMBChannelFactories.emplace(std::piecewise_construct, std::forward_as_tuple(runId), std::forward_as_tuple(*fParamGetter, runId, getFEBFactory(runId), getTRBFactory(runId), getPMFactory(runId)));
+  }
+  return fTOMBChannelFactories.at(runId);
+}
+
+void JPetParamManager::fillParameterBank(const int run)
 {
   if (fBank) {
     delete fBank;
     fBank = 0;
   }
-  fBank = fParamGetter->generateParamBank(run);
-  if (!fBank) return false;
-  return true; 
+  fBank = new JPetParamBank();
+  for (auto & trbp : getTRBs(run)) {
+    auto & trb = *trbp.second;
+    fBank->addTRB(trb);
+  }
+  for (auto & febp : getFEBs(run)) {
+    auto & feb = *febp.second;
+    fBank->addFEB(feb);
+    fBank->getFEB(feb.getID()).setTRB(fBank->getTRB(feb.getTRB().getID()));
+  }
+  for (auto & framep : getFrames(run)) {
+    auto & frame = *framep.second;
+    fBank->addFrame(frame);
+  }
+  for (auto & layerp : getLayers(run)) {
+    auto & layer = *layerp.second;
+    fBank->addLayer(layer);
+    fBank->getLayer(layer.getId()).setFrame(fBank->getFrame(layer.getFrame().getId()));
+  }
+  for (auto & barrelSlotp : getBarrelSlots(run)) {
+    auto & barrelSlot = *barrelSlotp.second;
+    fBank->addBarrelSlot(barrelSlot);
+    fBank->getBarrelSlot(barrelSlot.getID()).setLayer(fBank->getLayer(barrelSlot.getLayer().getId()));
+  }
+  for (auto & scinp : getScins(run)) {
+    auto & scin = *scinp.second;
+    fBank->addScintillator(scin);
+    fBank->getScintillator(scin.getID()).setBarrelSlot(fBank->getBarrelSlot(scin.getBarrelSlot().getID()));
+  }
+  for (auto & pmp : getPMs(run)) {
+    auto & pm = *pmp.second;
+    fBank->addPM(pm);
+    fBank->getPM(pm.getID()).setFEB(fBank->getFEB(pm.getFEB().getID()));
+    fBank->getPM(pm.getID()).setScin(fBank->getScintillator(pm.getScin().getID()));
+    fBank->getPM(pm.getID()).setBarrelSlot(fBank->getBarrelSlot(pm.getBarrelSlot().getID()));
+  }
+  for (auto & tombChannelp : getTOMBChannels(run)) {
+    auto & tombChannel = *tombChannelp.second;
+    fBank->addTOMBChannel(tombChannel);
+    fBank->getTOMBChannel(tombChannel.getChannel()).setFEB(fBank->getFEB(tombChannel.getFEB().getID()));
+    fBank->getTOMBChannel(tombChannel.getChannel()).setTRB(fBank->getTRB(tombChannel.getTRB().getID()));
+    fBank->getTOMBChannel(tombChannel.getChannel()).setPM(fBank->getPM(tombChannel.getPM().getID()));
+  }
 }
 
 bool JPetParamManager::readParametersFromFile(JPetReader * reader)
@@ -89,7 +223,8 @@ bool JPetParamManager::readParametersFromFile(std::string filename)
   return true;
 }
 
-const JPetParamBank& JPetParamManager::getParamBank() const{
+const JPetParamBank& JPetParamManager::getParamBank() const
+{
   DEBUG("getParamBank() from JPetParamManager");
   static JPetParamBank DummyResult(true);
   if(fBank) return *fBank;
@@ -130,7 +265,7 @@ void JPetParamManager::createXMLFile(const std::string &channelDataFileName, int
 {
   using boost::property_tree::ptree;
   ptree pt;
-  
+
   std::string debug = "OFF";
   std::string dataSourceType = "TRB3_S";
   std::string dataSourceTrbNetAddress = "8000";
@@ -144,9 +279,9 @@ void JPetParamManager::createXMLFile(const std::string &channelDataFileName, int
   pt.put("READOUT.DATA_SOURCE.HUB_ADDRESS", dataSourceHubAddress);
   pt.put("READOUT.DATA_SOURCE.REFERENCE_CHANNEL", dataSourceReferenceChannel);
   pt.put("READOUT.DATA_SOURCE.CORRECTION_FILE", dataSourceCorrectionFile);
-  
+
   ptree &externalNode = pt.add("READOUT.DATA_SOURCE.MODULES", "");
-  
+
   ptree &internalNode = externalNode.add("MODULE", "");
   internalNode.put("TYPE", "LATTICE_TDC");
   internalNode.put("TRBNET_ADDRESS", "e000");
@@ -164,7 +299,7 @@ void JPetParamManager::getTOMBDataAndCreateXMLFile(const int p_run_id)
   int TOMBChannelsSize = fBank->getTOMBChannelsSize();
   int channelOffset = 0;
   int numberOfChannels = 0;
-  
+
   if(TOMBChannelsSize)
   {
     for(int i=0;i<TOMBChannelsSize;++i)
@@ -172,7 +307,7 @@ void JPetParamManager::getTOMBDataAndCreateXMLFile(const int p_run_id)
       if(i==0)
       {
         std::string description = fBank->getTOMBChannel(i).getDescription();
-        channelOffset = JPetParamBank::getTOMBChannelFromDescription(description);
+        channelOffset = JPetParamGetter::getTOMBChannelFromDescription(description);
       }
       ++numberOfChannels;
     }

--- a/JPetParamManager/JPetParamManager.h
+++ b/JPetParamManager/JPetParamManager.h
@@ -28,44 +28,80 @@
 #include "../JPetWriter/JPetWriter.h"
 #include "../JPetScopeConfigParser/JPetScopeConfigPOD.h" /// for generateParametersFromScopeConfig
 
+#include "../JPetTRB/JPetTRBFactory.h"
+#include "../JPetFEB/JPetFEBFactory.h"
+#include "../JPetFrame/JPetFrameFactory.h"
+#include "../JPetLayer/JPetLayerFactory.h"
+#include "../JPetBarrelSlot/JPetBarrelSlotFactory.h"
+#include "../JPetScin/JPetScinFactory.h"
+#include "../JPetPM/JPetPMFactory.h"
+#include "../JPetTOMBChannel/JPetTOMBChannelFactory.h"
+
 class JPetParamManager
 {
- public:
-  JPetParamManager() : fParamGetter(new JPetDBParamGetter()), fBank(0), fIsNullObject(false) {}
-  JPetParamManager(JPetParamGetter* paramGetter) : fParamGetter(paramGetter), fBank(0) , fIsNullObject(false) {}
-  /// Special constructor to create NullObject.
-  /// This object can be returned if JPetParamManager is not created, 
-  /// and the const& is expected to be returned.
-  explicit JPetParamManager(bool isNull);   
-  ~JPetParamManager();
+  public:
+    JPetParamManager() : fParamGetter(new JPetDBParamGetter()), fBank(0), fIsNullObject(false) {}
+    JPetParamManager(JPetParamGetter* paramGetter) : fParamGetter(paramGetter), fBank(0) , fIsNullObject(false) {}
+    /// Special constructor to create NullObject.
+    /// This object can be returned if JPetParamManager is not created,
+    /// and the const& is expected to be returned.
+    explicit JPetParamManager(bool isNull) : fParamGetter(new JPetDBParamGetter()), fBank(0), fIsNullObject(isNull) {}
+    ~JPetParamManager();
 
-  bool fillParameterBank(const int run);
-  
-  bool readParametersFromFile(JPetReader * reader);
-  bool saveParametersToFile(JPetWriter * writer);
+    std::map<int, JPetTRB *> & getTRBs(const int runId);
+    std::map<int, JPetFEB *> & getFEBs(const int runId);
+    std::map<int, JPetFrame *> & getFrames(const int runId);
+    std::map<int, JPetLayer *> & getLayers(const int runId);
+    std::map<int, JPetBarrelSlot *> & getBarrelSlots(const int runId);
+    std::map<int, JPetScin *> & getScins(const int runId);
+    std::map<int, JPetPM *> & getPMs(const int runId);
+    std::map<int, JPetTOMBChannel *> & getTOMBChannels(const int runId);
 
-  bool readParametersFromFile(std::string filename);
-  bool saveParametersToFile(std::string filename);
-  
-  bool getParametersFromScopeConfig(const std::string& scopeConfFile);
- 
-  void clearParameters();
-  const JPetParamBank& getParamBank() const;
+    void fillParameterBank(const int run);
 
-  inline bool isNullObject() const { return fIsNullObject; }
+    bool readParametersFromFile(JPetReader * reader);
+    bool saveParametersToFile(JPetWriter * writer);
 
- private:
-  JPetParamManager(const JPetParamManager&);
-  JPetParamManager& operator=(const JPetParamManager&);
+    bool readParametersFromFile(std::string filename);
+    bool saveParametersToFile(std::string filename);
 
-  JPetScopeParamGetter fScopeParamGetter;
-  JPetParamGetter* fParamGetter;
-  JPetParamBank* fBank;
-  bool fIsNullObject;
+    bool getParametersFromScopeConfig(const std::string& scopeConfFile);
 
- protected:
-  void createXMLFile(const std::string &channelDataFileName, int channelOffset, int numberOfChannels);
-  void getTOMBDataAndCreateXMLFile(const int p_run_id);
+    void clearParameters();
+    const JPetParamBank& getParamBank() const;
+
+    inline bool isNullObject() const { return fIsNullObject; }
+
+  private:
+    JPetParamManager(const JPetParamManager&);
+    JPetParamManager& operator=(const JPetParamManager&);
+
+    JPetScopeParamGetter fScopeParamGetter;
+    JPetParamGetter* fParamGetter;
+    JPetParamBank* fBank;
+    bool fIsNullObject;
+
+    std::map<int, JPetTRBFactory> fTRBFactories;
+    std::map<int, JPetFEBFactory> fFEBFactories;
+    std::map<int, JPetFrameFactory> fFrameFactories;
+    std::map<int, JPetLayerFactory> fLayerFactories;
+    std::map<int, JPetBarrelSlotFactory> fBarrelSlotFactories;
+    std::map<int, JPetScinFactory> fScinFactories;
+    std::map<int, JPetPMFactory> fPMFactories;
+    std::map<int, JPetTOMBChannelFactory> fTOMBChannelFactories;
+
+    JPetTRBFactory & getTRBFactory(const int runId);
+    JPetFEBFactory & getFEBFactory(const int runId);
+    JPetFrameFactory & getFrameFactory(const int runId);
+    JPetLayerFactory & getLayerFactory(const int runId);
+    JPetBarrelSlotFactory & getBarrelSlotFactory(const int runId);
+    JPetScinFactory & getScinFactory(const int runId);
+    JPetPMFactory & getPMFactory(const int runId);
+    JPetTOMBChannelFactory & getTOMBChannelFactory(const int runId);
+
+  protected:
+    void createXMLFile(const std::string &channelDataFileName, int channelOffset, int numberOfChannels);
+    void getTOMBDataAndCreateXMLFile(const int p_run_id);
 };
 
 #endif

--- a/JPetParamManager/JPetParamManagerTest.cpp
+++ b/JPetParamManager/JPetParamManagerTest.cpp
@@ -43,8 +43,8 @@ BOOST_AUTO_TEST_CASE(generateParamBankTest)
 
 // BOOST_AUTO_TEST_CASE(writeAndReadDataFromFileByWriterAndReaderObjectsTest)
 // {
-// 	DB::SERVICES::DBHandler::createDBConnection(gDefaultConfigFile);
-// 	
+//  DB::SERVICES::DBHandler::createDBConnection(gDefaultConfigFile);
+//
 //   JPetParamManager l_paramManagerInstance;
 //   
 //   l_paramManagerInstance.getParametersFromDatabase(1);
@@ -61,7 +61,7 @@ BOOST_AUTO_TEST_CASE(writeAndReadDataFromFileByFileNameTest)
 {
   JPetDBParamGetter::clearParamCache();
   JPetScopeParamGetter::clearParamCache();
-	std::string testDatafile = dataDir+"testDataFile.txt";
+  std::string testDatafile = dataDir+"testDataFile.txt";
   JPetParamManager l_paramManagerInstance(new JPetParamGetterAscii(dataFileName));
   
   
@@ -71,14 +71,14 @@ BOOST_AUTO_TEST_CASE(writeAndReadDataFromFileByFileNameTest)
   
   BOOST_CHECK(l_paramManagerInstance.saveParametersToFile(testDatafile) == true);
   
-		boost::filesystem::remove(testDatafile);
+  boost::filesystem::remove(testDatafile);
 }
 
 BOOST_AUTO_TEST_CASE(some_Test_that_had_no_name)
 {
   JPetDBParamGetter::clearParamCache();
   JPetScopeParamGetter::clearParamCache();
-	
+
   JPetParamManager l_paramManagerInstance(new JPetParamGetterAscii(dataFileName));
   
   l_paramManagerInstance.fillParameterBank(1);

--- a/JPetScin/JPetScinFactory.cpp
+++ b/JPetScin/JPetScinFactory.cpp
@@ -1,0 +1,60 @@
+/**
+ *  @copyright Copyright 2016 The J-PET Framework Authors. All rights reserved.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may find a copy of the License in the LICENCE file.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  @file JPetScinFactory.cpp
+ */
+
+#include "JPetScinFactory.h"
+
+#include <exception>
+#include <string>
+#include <tuple>
+#include <boost/lexical_cast.hpp>
+
+std::map<int, JPetScin *> & JPetScinFactory::getScins()
+{
+  if (!fInitialized) {
+    initialize();
+  }
+  return fScins;
+}
+
+void JPetScinFactory::initialize()
+{
+  ParamObjectsDescriptions descriptions = paramGetter.getAllBasicData(ParamObjectType::kScintillator, runId);
+  if (descriptions.size() == 0) {
+    ERROR(std::string("No scintillators in run ") + boost::lexical_cast<std::string>(runId));
+  }
+  for (auto description : descriptions) {
+    fScins[description.first] = build(description.second);
+  }
+  fInitialized = true;
+  ParamRelationalData relations = paramGetter.getAllRelationalData(ParamObjectType::kScintillator, ParamObjectType::kBarrelSlot, runId);
+  for (auto relation : relations) {
+    fScins[relation.first]->setBarrelSlot(*barrelSlotFactory.getBarrelSlots().at(relation.second));
+  }
+}
+
+JPetScin * JPetScinFactory::build(ParamObjectDescription data)
+{
+  try {
+    int id = boost::lexical_cast<int>(data.at("id"));
+    double attenuationLength = boost::lexical_cast<double>(data.at("attenuation_length"));
+    double length = boost::lexical_cast<double>(data.at("length"));
+    double width = boost::lexical_cast<double>(data.at("width"));
+    double height = boost::lexical_cast<double>(data.at("height"));
+    return new JPetScin(id, attenuationLength, length, width, height);
+  } catch (const std::exception & e) {
+    ERROR(std::string("Failed to build scintillator with error: ") + e.what());
+    throw;
+  }
+}

--- a/JPetScin/JPetScinFactory.h
+++ b/JPetScin/JPetScinFactory.h
@@ -1,0 +1,52 @@
+/**
+ *  @copyright Copyright 2016 The J-PET Framework Authors. All rights reserved.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may find a copy of the License in the LICENCE file.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  @file JPetScinFactory.h
+ */
+
+#ifndef JPET_SCIN_FACTORY_H
+#define JPET_SCIN_FACTORY_H
+
+#include "../JPetParamGetter/JPetParamGetter.h"
+#include "JPetScin.h"
+#include "../JPetBarrelSlot/JPetBarrelSlotFactory.h"
+
+#include <map>
+
+/**
+ * @brief A factory of JPetScin objects.
+ *
+ * This class is able to create those objects using data from the database.
+ */
+class JPetScinFactory
+{
+  public:
+    JPetScinFactory(JPetParamGetter & paramGetter, int runId, JPetBarrelSlotFactory & barrelSlotFactory) :
+      paramGetter(paramGetter),
+      runId(runId),
+      barrelSlotFactory(barrelSlotFactory),
+      fInitialized(false) {}
+
+    std::map<int, JPetScin *> & getScins();
+  private:
+    JPetParamGetter & paramGetter;
+    const int runId;
+    JPetBarrelSlotFactory & barrelSlotFactory;
+
+    bool fInitialized;
+    std::map<int, JPetScin *> fScins;
+
+    void initialize();
+    JPetScin * build(ParamObjectDescription data);
+};
+
+#endif // JPET_SCIN_FACTORY_H

--- a/JPetScin/JPetScinTest.cpp
+++ b/JPetScin/JPetScinTest.cpp
@@ -1,7 +1,8 @@
 #define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MODULE JPetScinTest
 #include <boost/test/unit_test.hpp>
-#include "../JPetScin/JPetScin.h"
+#include "JPetScin.h"
+#include "JPetScinFactory.h"
 
 
 
@@ -17,13 +18,13 @@
 //inline void setScinSize(ScinDimensions size) { fScinSize = size; }
 //void setScinSize(Dimension dim, float value);
 
+const float epsilon = 0.0001;
 
 BOOST_AUTO_TEST_SUITE(FirstSuite)
-  
+
 BOOST_AUTO_TEST_CASE( default_constructor )
 {
   JPetScin scint;
-  float epsilon = 0.0001; 
   BOOST_REQUIRE_EQUAL(scint.getID(), 0);
   BOOST_REQUIRE_CLOSE(scint.getAttenLen(), 0, epsilon);
   BOOST_REQUIRE_CLOSE(scint.getScinSize(JPetScin::kLength), 0, epsilon);
@@ -38,9 +39,8 @@ BOOST_AUTO_TEST_CASE( default_constructor )
 
 BOOST_AUTO_TEST_CASE( constructor )
 {
-  JPetScin scint(25, 10.34, 100, 4.5, 2.5);
-  float epsilon = 0.0001; 
-  BOOST_REQUIRE_EQUAL(scint.getID(), 25);
+  JPetScin scint(1, 10.34, 100, 4.5, 2.5);
+  BOOST_REQUIRE_EQUAL(scint.getID(), 1);
   BOOST_REQUIRE_CLOSE(scint.getAttenLen(), 10.34, epsilon);
   BOOST_REQUIRE_CLOSE(scint.getScinSize(JPetScin::kLength), 100, epsilon);
   BOOST_REQUIRE_CLOSE(scint.getScinSize(JPetScin::kHeight), 4.5, epsilon);
@@ -49,6 +49,242 @@ BOOST_AUTO_TEST_CASE( constructor )
   BOOST_REQUIRE_CLOSE(size.fLength, 100, epsilon);
   BOOST_REQUIRE_CLOSE(size.fHeight, 4.5, epsilon);
   BOOST_REQUIRE_CLOSE(size.fWidth, 2.5, epsilon);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE(FactorySuite)
+
+class TestParamGetter : public JPetParamGetter
+{
+  ParamObjectsDescriptions getAllBasicData(ParamObjectType type, const int runId)
+  {
+    ParamObjectsDescriptions result;
+    switch (type) {
+      case ParamObjectType::kScintillator:
+        switch (runId) {
+          case 0: //No scins
+            break;
+          case 1: //Simple single object
+          case 5: //Wrong relation
+            result = {
+              {1, {
+                    {"id", "1"},
+                    {"attenuation_length", "10.34"},
+                    {"length", "100"},
+                    {"width", "4.5"},
+                    {"height", "2.5"}
+                  }
+              }
+            };
+            break;
+          case 2: //Simple two objects
+            result = {
+              {1, {
+                    {"id", "1"},
+                    {"attenuation_length", "10.34"},
+                    {"length", "100"},
+                    {"width", "4.5"},
+                    {"height", "2.5"}
+                  }
+              },
+              {5, {
+                    {"id", "5"},
+                    {"attenuation_length", "11.34"},
+                    {"length", "101"},
+                    {"width", "5.5"},
+                    {"height", "3.5"}
+                  }
+              }
+            };
+            break;
+          case 3: //Object with missing field
+            result = {
+              {1, {
+                    {"id", "1"},
+                    {"length", "100"},
+                    {"width", "4.5"},
+                    {"height", "2.5"}
+                  }
+              }
+            };
+            break;
+          case 4: //Object with wrong field
+            result = {
+              {1, {
+                    {"id", "1"},
+                    {"attenuation_length", "none"},
+                    {"length", "100"},
+                    {"width", "4.5"},
+                    {"height", "2.5"}
+                  }
+              }
+            };
+            break;
+        }
+        break;
+      case ParamObjectType::kBarrelSlot:
+        result = {
+          {1, {
+                {"id", "1"},
+                {"active", "1"},
+                {"name", "pepe"},
+                {"theta1", "5.5"},
+                {"frame_id", "6"}
+              }
+          }
+        };
+        break;
+      case ParamObjectType::kLayer:
+        result = {
+          {1, {
+                {"id", "1"},
+                {"active", "1"},
+                {"name", "ala"},
+                {"radius", "10.5"}
+              }
+          }
+        };
+        break;
+      case ParamObjectType::kFrame:
+        result = {
+          {1, {
+                {"id", "1"},
+                {"active", "1"},
+                {"status", "ok"},
+                {"description", "descr1"},
+                {"version", "2"},
+                {"creator_id", "1"}
+              }
+          }
+        };
+        break;
+      default: //Other cases not needed.
+        break;
+    }
+    return result;
+  }
+  ParamRelationalData getAllRelationalData(ParamObjectType type1, ParamObjectType, const int runId)
+  {
+    ParamRelationalData result;
+    switch (type1) {
+      case ParamObjectType::kScintillator:
+        switch (runId) {
+          case 0: //No relations
+            break;
+          case 1: //Simple single object
+            result = {
+              {1, 1}
+            };
+            break;
+          case 2: //Simple two objects
+            result = {
+              {1, 1},
+              {5, 1}
+            };
+            break;
+          case 5: //Wrong relation
+            result = {
+              {1, 43}
+            };
+            break;
+        }
+        break;
+      case ParamObjectType::kBarrelSlot:
+      case ParamObjectType::kLayer:
+        result = {
+          {1, 1}
+        };
+        break;
+      default: //Other cases not needed.
+        break;
+    }
+    return result;
+  }
+};
+
+TestParamGetter paramGetter;
+
+BOOST_AUTO_TEST_CASE( no_scins )
+{
+  JPetFrameFactory frameFactory(paramGetter, 0);
+  JPetLayerFactory layerFactory(paramGetter, 0, frameFactory);
+  JPetBarrelSlotFactory barrelSlotFactory(paramGetter, 0, layerFactory);
+  JPetScinFactory factory(paramGetter, 0, barrelSlotFactory);
+  auto & scins = factory.getScins();
+  BOOST_REQUIRE_EQUAL(scins.size(), 0);
+}
+
+BOOST_AUTO_TEST_CASE( single_object )
+{
+  JPetFrameFactory frameFactory(paramGetter, 1);
+  JPetLayerFactory layerFactory(paramGetter, 1, frameFactory);
+  JPetBarrelSlotFactory barrelSlotFactory(paramGetter, 1, layerFactory);
+  JPetScinFactory factory(paramGetter, 1, barrelSlotFactory);
+  auto & scins = factory.getScins();
+  BOOST_REQUIRE_EQUAL(scins.size(), 1);
+  auto scin = scins[1];
+  BOOST_REQUIRE_EQUAL(scin->getID(), 1);
+  BOOST_REQUIRE_CLOSE(scin->getAttenLen(), 10.34, epsilon);
+  BOOST_REQUIRE_CLOSE(scin->getScinSize(JPetScin::kLength), 100, epsilon);
+  BOOST_REQUIRE_CLOSE(scin->getScinSize(JPetScin::kHeight), 4.5, epsilon);
+  BOOST_REQUIRE_CLOSE(scin->getScinSize(JPetScin::kWidth), 2.5, epsilon);
+
+  BOOST_REQUIRE_EQUAL(scin->getBarrelSlot().getID(), barrelSlotFactory.getBarrelSlots().at(1)->getID());
+}
+
+BOOST_AUTO_TEST_CASE( two_objects )
+{
+  JPetFrameFactory frameFactory(paramGetter, 2);
+  JPetLayerFactory layerFactory(paramGetter, 2, frameFactory);
+  JPetBarrelSlotFactory barrelSlotFactory(paramGetter, 2, layerFactory);
+  JPetScinFactory factory(paramGetter, 2, barrelSlotFactory);
+  auto & scins = factory.getScins();
+  BOOST_REQUIRE_EQUAL(scins.size(), 2);
+  auto scin = scins[1];
+  BOOST_REQUIRE_EQUAL(scin->getID(), 1);
+  BOOST_REQUIRE_CLOSE(scin->getAttenLen(), 10.34, epsilon);
+  BOOST_REQUIRE_CLOSE(scin->getScinSize(JPetScin::kLength), 100, epsilon);
+  BOOST_REQUIRE_CLOSE(scin->getScinSize(JPetScin::kHeight), 4.5, epsilon);
+  BOOST_REQUIRE_CLOSE(scin->getScinSize(JPetScin::kWidth), 2.5, epsilon);
+
+  BOOST_REQUIRE_EQUAL(scin->getBarrelSlot().getID(), barrelSlotFactory.getBarrelSlots().at(1)->getID());
+
+  scin = scins[5];
+  BOOST_REQUIRE_EQUAL(scin->getID(), 5);
+  BOOST_REQUIRE_CLOSE(scin->getAttenLen(), 11.34, epsilon);
+  BOOST_REQUIRE_CLOSE(scin->getScinSize(JPetScin::kLength), 101, epsilon);
+  BOOST_REQUIRE_CLOSE(scin->getScinSize(JPetScin::kHeight), 5.5, epsilon);
+  BOOST_REQUIRE_CLOSE(scin->getScinSize(JPetScin::kWidth), 3.5, epsilon);
+
+  BOOST_REQUIRE_EQUAL(scin->getBarrelSlot().getID(), barrelSlotFactory.getBarrelSlots().at(1)->getID());
+}
+
+BOOST_AUTO_TEST_CASE( missing_field )
+{
+  JPetFrameFactory frameFactory(paramGetter, 3);
+  JPetLayerFactory layerFactory(paramGetter, 3, frameFactory);
+  JPetBarrelSlotFactory barrelSlotFactory(paramGetter, 3, layerFactory);
+  JPetScinFactory factory(paramGetter, 3, barrelSlotFactory);
+  BOOST_REQUIRE_THROW(factory.getScins(), std::out_of_range);
+}
+
+BOOST_AUTO_TEST_CASE( wrong_field )
+{
+  JPetFrameFactory frameFactory(paramGetter, 4);
+  JPetLayerFactory layerFactory(paramGetter, 4, frameFactory);
+  JPetBarrelSlotFactory barrelSlotFactory(paramGetter, 4, layerFactory);
+  JPetScinFactory factory(paramGetter, 4, barrelSlotFactory);
+  BOOST_REQUIRE_THROW(factory.getScins(), std::bad_cast);
+}
+
+BOOST_AUTO_TEST_CASE( wrong_relation )
+{
+  JPetFrameFactory frameFactory(paramGetter, 5);
+  JPetLayerFactory layerFactory(paramGetter, 5, frameFactory);
+  JPetBarrelSlotFactory barrelSlotFactory(paramGetter, 5, layerFactory);
+  JPetScinFactory factory(paramGetter, 5, barrelSlotFactory);
+  BOOST_REQUIRE_THROW(factory.getScins(), std::out_of_range);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/JPetTOMBChannel/JPetTOMBChannelFactory.cpp
+++ b/JPetTOMBChannel/JPetTOMBChannelFactory.cpp
@@ -1,0 +1,71 @@
+/**
+ *  @copyright Copyright 2016 The J-PET Framework Authors. All rights reserved.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may find a copy of the License in the LICENCE file.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  @file JPetTOMBChannelFactory.cpp
+ */
+
+#include "JPetTOMBChannelFactory.h"
+
+#include <exception>
+#include <string>
+#include <tuple>
+#include <boost/lexical_cast.hpp>
+
+std::map<int, JPetTOMBChannel *> & JPetTOMBChannelFactory::getTOMBChannels()
+{
+  if (!fInitialized) {
+    initialize();
+  }
+  return fTOMBChannels;
+}
+
+void JPetTOMBChannelFactory::initialize()
+{
+  ParamObjectsDescriptions descriptions = paramGetter.getAllBasicData(ParamObjectType::kTOMBChannel, runId);
+  if (descriptions.size() == 0) {
+    ERROR(std::string("No TOMBChannels in run ") + boost::lexical_cast<std::string>(runId));
+  }
+  for (auto description : descriptions) {
+    fTOMBChannels[description.first] = build(description.second);
+  }
+  fInitialized = true;
+  ParamRelationalData relations = paramGetter.getAllRelationalData(ParamObjectType::kTOMBChannel, ParamObjectType::kFEB, runId);
+  for (auto relation : relations) {
+    fTOMBChannels[relation.first]->setFEB(*febFactory.getFEBs().at(relation.second));
+  }
+  relations = paramGetter.getAllRelationalData(ParamObjectType::kTOMBChannel, ParamObjectType::kTRB, runId);
+  for (auto relation : relations) {
+    fTOMBChannels[relation.first]->setTRB(*TRBFactory.getTRBs().at(relation.second));
+  }
+  relations = paramGetter.getAllRelationalData(ParamObjectType::kTOMBChannel, ParamObjectType::kPM, runId);
+  for (auto relation : relations) {
+    fTOMBChannels[relation.first]->setPM(*PMFactory.getPMs().at(relation.second));
+  }
+}
+
+JPetTOMBChannel * JPetTOMBChannelFactory::build(ParamObjectDescription data)
+{
+  try {
+    int id = boost::lexical_cast<int>(data.at("channel"));
+    int channel = boost::lexical_cast<int>(data.at("local_number"));
+    int FEB = boost::lexical_cast<int>(data.at("FEB"));
+    float threshold = boost::lexical_cast<float>(data.at("threshold"));
+    JPetTOMBChannel * result = new JPetTOMBChannel(id);
+    result->setLocalChannelNumber(channel);
+    result->setFEBInputNumber(FEB);
+    result->setThreshold(threshold);
+    return result;
+  } catch (const std::exception & e) {
+    ERROR(std::string("Failed to build TOMBChannel with error: ") + e.what());
+    throw;
+  }
+}

--- a/JPetTOMBChannel/JPetTOMBChannelFactory.h
+++ b/JPetTOMBChannel/JPetTOMBChannelFactory.h
@@ -1,0 +1,58 @@
+/**
+ *  @copyright Copyright 2016 The J-PET Framework Authors. All rights reserved.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may find a copy of the License in the LICENCE file.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  @file JPetTOMBChannelFactory.h
+ */
+
+#ifndef JPET_TOMB_CHANNEL_FACTORY_H
+#define JPET_TOMB_CHANNEL_FACTORY_H
+
+#include "../JPetParamGetter/JPetParamGetter.h"
+#include "JPetTOMBChannel.h"
+#include "../JPetFEB/JPetFEBFactory.h"
+#include "../JPetTRB/JPetTRBFactory.h"
+#include "../JPetPM/JPetPMFactory.h"
+
+#include <map>
+
+/**
+ * @brief A factory of JPetTOMBChannel objects.
+ *
+ * This class is able to create those objects using data from the database.
+ */
+class JPetTOMBChannelFactory
+{
+  public:
+    JPetTOMBChannelFactory(JPetParamGetter & paramGetter, int runId, JPetFEBFactory & febFactory, JPetTRBFactory & TRBFactory, JPetPMFactory & PMFactory) :
+      paramGetter(paramGetter),
+      runId(runId),
+      febFactory(febFactory),
+      TRBFactory(TRBFactory),
+      PMFactory(PMFactory),
+      fInitialized(false) {}
+
+    std::map<int, JPetTOMBChannel *> & getTOMBChannels();
+  private:
+    JPetParamGetter & paramGetter;
+    const int runId;
+    JPetFEBFactory & febFactory;
+    JPetTRBFactory & TRBFactory;
+    JPetPMFactory & PMFactory;
+
+    bool fInitialized;
+    std::map<int, JPetTOMBChannel *> fTOMBChannels;
+
+    void initialize();
+    JPetTOMBChannel * build(ParamObjectDescription data);
+};
+
+#endif // JPET_TOMB_CHANNEL_FACTORY_H

--- a/JPetTRB/JPetTRBFactory.cpp
+++ b/JPetTRB/JPetTRBFactory.cpp
@@ -1,0 +1,54 @@
+/**
+ *  @copyright Copyright 2016 The J-PET Framework Authors. All rights reserved.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may find a copy of the License in the LICENCE file.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  @file JPetTRBFactory.cpp
+ */
+
+#include "JPetTRBFactory.h"
+
+#include <exception>
+#include <string>
+#include <tuple>
+#include <boost/lexical_cast.hpp>
+
+std::map<int, JPetTRB *> & JPetTRBFactory::getTRBs()
+{
+  if (!fInitialized) {
+    initialize();
+  }
+  return fTRBs;
+}
+
+void JPetTRBFactory::initialize()
+{
+  ParamObjectsDescriptions descriptions = paramGetter.getAllBasicData(ParamObjectType::kTRB, runId);
+  if (descriptions.size() == 0) {
+    ERROR(std::string("No TRBs in run ") + boost::lexical_cast<std::string>(runId));
+  }
+  for (auto description : descriptions) {
+    fTRBs[description.first] = build(description.second);
+  }
+  fInitialized = true;
+}
+
+JPetTRB * JPetTRBFactory::build(ParamObjectDescription data)
+{
+  try {
+    int id = boost::lexical_cast<int>(data.at("id"));
+    int type = boost::lexical_cast<int>(data.at("type"));
+    int channel = boost::lexical_cast<int>(data.at("channel"));
+    return new JPetTRB(id, type, channel);
+  } catch (const std::exception & e) {
+    ERROR(std::string("Failed to build TRB with error: ") + e.what());
+    throw;
+  }
+}

--- a/JPetTRB/JPetTRBFactory.h
+++ b/JPetTRB/JPetTRBFactory.h
@@ -1,0 +1,49 @@
+/**
+ *  @copyright Copyright 2016 The J-PET Framework Authors. All rights reserved.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may find a copy of the License in the LICENCE file.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  @file JPetTRBFactory.h
+ */
+
+#ifndef JPET_TRB_FACTORY_H
+#define JPET_TRB_FACTORY_H
+
+#include "../JPetParamGetter/JPetParamGetter.h"
+#include "JPetTRB.h"
+
+#include <map>
+
+/**
+ * @brief A factory of JPetTRB objects.
+ *
+ * This class is able to create those objects using data from the database.
+ */
+class JPetTRBFactory
+{
+  public:
+    JPetTRBFactory(JPetParamGetter & paramGetter, int runId) :
+      paramGetter(paramGetter),
+      runId(runId),
+      fInitialized(false) {}
+
+    std::map<int, JPetTRB *> & getTRBs();
+  private:
+    JPetParamGetter & paramGetter;
+    const int runId;
+
+    bool fInitialized;
+    std::map<int, JPetTRB *> fTRBs;
+
+    void initialize();
+    JPetTRB * build(ParamObjectDescription data);
+};
+
+#endif // JPET_TRB_FACTORY_H

--- a/JPetTRB/JPetTRBTest.cpp
+++ b/JPetTRB/JPetTRBTest.cpp
@@ -1,7 +1,8 @@
 #define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MODULE JPetTRBTest
 #include <boost/test/unit_test.hpp>
-#include "../JPetTRB/JPetTRB.h"
+#include "JPetTRB.h"
+#include "JPetTRBFactory.h"
 
 
 
@@ -28,10 +29,120 @@ BOOST_AUTO_TEST_CASE( default_constructor )
 
 BOOST_AUTO_TEST_CASE( constructor )
 {
-  JPetTRB trb(12, 1, 224);
-  BOOST_REQUIRE_EQUAL(trb.getID(), 12);
+  JPetTRB trb(1, 1, 224);
+  BOOST_REQUIRE_EQUAL(trb.getID(), 1);
   BOOST_REQUIRE_EQUAL(trb.getType(), 1);
   BOOST_REQUIRE_EQUAL(trb.getChannel(), 224);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE(FactorySuite)
+
+class TestParamGetter : public JPetParamGetter
+{
+  ParamObjectsDescriptions getAllBasicData(ParamObjectType, const int runId)
+  {
+    ParamObjectsDescriptions result;
+    switch (runId) {
+      case 0: //No TRBs
+        break;
+      case 1: //Simple single object
+        result = {
+          {1, {
+                {"id", "1"},
+                {"type", "1"},
+                {"channel", "224"}
+              }
+          }
+        };
+        break;
+      case 2: //Simple two objects
+        result = {
+          {1, {
+                {"id", "1"},
+                {"type", "1"},
+                {"channel", "224"}
+              }
+          },
+          {5, {
+                {"id", "5"},
+                {"type", "2"},
+                {"channel", "225"}
+              }
+          }
+        };
+        break;
+      case 3: //Object with missing field
+        result = {
+          {1, {
+                {"id", "1"},
+                {"channel", "224"}
+              }
+          }
+        };
+        break;
+      case 4: //Object with wrong field
+        result = {
+          {1, {
+                {"id", "1"},
+                {"type", "torus"},
+                {"channel", "224"}
+              }
+          }
+        };
+        break;
+    }
+    return result;
+  }
+  ParamRelationalData getAllRelationalData(ParamObjectType, ParamObjectType, const int) {return ParamRelationalData();} //Irrelevant for this test.
+};
+
+TestParamGetter paramGetter;
+
+BOOST_AUTO_TEST_CASE( no_trbs )
+{
+  JPetTRBFactory factory(paramGetter, 0);
+  auto & trbs = factory.getTRBs();
+  BOOST_REQUIRE_EQUAL(trbs.size(), 0);
+}
+
+BOOST_AUTO_TEST_CASE( single_object )
+{
+  JPetTRBFactory factory(paramGetter, 1);
+  auto & trbs = factory.getTRBs();
+  BOOST_REQUIRE_EQUAL(trbs.size(), 1);
+  auto trb = trbs[1];
+  BOOST_REQUIRE_EQUAL(trb->getID(), 1);
+  BOOST_REQUIRE_EQUAL(trb->getType(), 1);
+  BOOST_REQUIRE_EQUAL(trb->getChannel(), 224);
+}
+
+BOOST_AUTO_TEST_CASE( two_objects )
+{
+  JPetTRBFactory factory(paramGetter, 2);
+  auto & trbs = factory.getTRBs();
+  BOOST_REQUIRE_EQUAL(trbs.size(), 2);
+  auto trb = trbs[1];
+  BOOST_REQUIRE_EQUAL(trb->getID(), 1);
+  BOOST_REQUIRE_EQUAL(trb->getType(), 1);
+  BOOST_REQUIRE_EQUAL(trb->getChannel(), 224);
+  trb = trbs[5];
+  BOOST_REQUIRE_EQUAL(trb->getID(), 5);
+  BOOST_REQUIRE_EQUAL(trb->getType(), 2);
+  BOOST_REQUIRE_EQUAL(trb->getChannel(), 225);
+}
+
+BOOST_AUTO_TEST_CASE( missing_field )
+{
+  JPetTRBFactory factory(paramGetter, 3);
+  BOOST_REQUIRE_THROW(factory.getTRBs(), std::out_of_range);
+}
+
+BOOST_AUTO_TEST_CASE( wrong_field )
+{
+  JPetTRBFactory factory(paramGetter, 4);
+  BOOST_REQUIRE_THROW(factory.getTRBs(), std::bad_cast);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/JPetTaskExecutor/JPetTaskExecutor.cpp
+++ b/JPetTaskExecutor/JPetTaskExecutor.cpp
@@ -84,8 +84,9 @@ bool JPetTaskExecutor::processFromCmdLineArgs(int)
 {
   auto runNum = fOptions.getRunNumber();
   if (runNum >= 0) {
-    bool isParamBankGenerated = fParamManager->fillParameterBank(runNum);
-    if (!isParamBankGenerated) {
+    try {
+      fParamManager->fillParameterBank(runNum);
+    } catch (...) {
       ERROR("Param bank was not generated correctly.\n The run number used:" + JPetCommonTools::intToString(runNum));
       return false;
     }


### PR DESCRIPTION
Now the creaton of parameter resources is handled by factories
specific for every type of resource. ParamGetters are heavily
simplified and only return plain data.

This change is mostly backwards compatible. Because of that
ParamManager behaves inconsistently -- the new interface
returns different references than the old one.

There are some problems with missing database fields.
Workarounds are in place, hopefully temporarily.

This does not work with current examples -- root fails to generate
some dictionaries, because of the c++11 'using' directives in
one of the headers. Since we might be moving to
ROOT 6 soon [citation needed]  I didn't want to fix that yet.