### PR TITLE
Change log file name to a unique one

### DIFF
--- a/JPetLogger/JPetLogger.cpp
+++ b/JPetLogger/JPetLogger.cpp
@@ -18,16 +18,17 @@
 #include "./JPetLogger.h"
 #include "../JPetLoggerInclude.h"
 
+
 #if JPET_SCREEN_OUTPUT == 1
 bool JPetLogger::fIsLogFile = false;
 #else
 bool JPetLogger::fIsLogFile = true;
 #endif
-const char* JPetLogger::fFileName = "JPet.log";
 
+const std::string JPetLogger::fFileName = JPetLogger::generateFilename();
 
 void JPetLogger::dateAndTime() {
-  std::ofstream log(fFileName, std::ios_base::app);
+  std::ofstream log(fFileName.c_str(), std::ios_base::app);
   std::streambuf* originalCoutBuffer = 0; 
   // we redirect std::cout to a file 
   if (fIsLogFile) {
@@ -54,7 +55,7 @@ void JPetLogger::dateAndTime() {
 
 
 void JPetLogger::logMessage(const char* func, const char* msg, MessageType type) {
-  std::ofstream log(fFileName, std::ios_base::app);
+  std::ofstream log(fFileName.c_str(), std::ios_base::app);
   std::streambuf* originalCoutBuffer = 0; 
   // we redirect std::cout to a file 
   if (fIsLogFile) {

--- a/JPetLogger/JPetLogger.h
+++ b/JPetLogger/JPetLogger.h
@@ -23,6 +23,10 @@
 #include <iostream>
 #include <string>
 
+#include <boost/uuid/uuid.hpp>            // uuid class
+#include <boost/uuid/uuid_generators.hpp> // generators
+#include <boost/uuid/uuid_io.hpp>         // streaming operators etc.
+
 class JPetLogger {
  public:
   static void dateAndTime();
@@ -58,9 +62,13 @@ class JPetLogger {
   JPetLogger(const JPetLogger&);
   JPetLogger& operator=(const JPetLogger&);
 
+  inline static const std::string generateFilename(){
+    return std::string("JPet_") + to_string(boost::uuids::random_generator()()) + std::string(".log");
+  }
+  
   static void logMessage(const char* func, const char* msg, MessageType type);
 
-  static const char* fFileName;
+  static const std::string fFileName;
   static bool fIsLogFile;
 };
 


### PR DESCRIPTION
Previously the log file was always called JPet.log which caused
a risk of overwriting if several programs were run in the same
directory. The name was changed so that it contains a UUID.