### PR TITLE
Git hooks for automatic prettyfying of code

### DIFF
--- a/extras/fix_style.pl
+++ b/extras/fix_style.pl
@@ -1,0 +1,16 @@
+#!/usr/bin/perl
+use warnings;
+use strict;
+use IPC::Cmd qw[can_run];
+
+my $numArgs = $#ARGV + 1;
+if ($numArgs != 1) {
+  die "usage: ./fix_style.pl filename\n";
+}
+my $gitRoot = `git rev-parse --show-toplevel`;
+chomp $gitRoot;
+my $astyle = can_run('astyle') or die "astyle not found, please install it!\n";
+my $astyleConfig = $gitRoot."/extras/_astylerc";
+my $command = $astyle." --options=".$astyleConfig;
+my $fullCommand = $command." $ARGV[0]";
+`$fullCommand`;

--- a/hooks/applypatch-msg
+++ b/hooks/applypatch-msg
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+#Do not delete this line
+./hooks/run_local_hook.sh $@

--- a/hooks/commit-msg
+++ b/hooks/commit-msg
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+#Do not delete this line
+./hooks/run_local_hook.sh $@

--- a/hooks/initiateHooks.sh
+++ b/hooks/initiateHooks.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+if [ ! -d ../.git/hooks.local ]; then
+  mv ../.git/hooks ../.git/hooks.local
+  ln -s ../hooks ../.git/hooks
+else
+  echo "You already have hooks.local directory."
+  echo "If it is the first time you run this script, then you should fix it so"
+  echo "that hooks links to ../hooks and your own git hooks are in hooks.local."
+fi

--- a/hooks/post-applypatch
+++ b/hooks/post-applypatch
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+#Do not delete this line
+./hooks/run_local_hook.sh $@

--- a/hooks/post-auto-gc
+++ b/hooks/post-auto-gc
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+#Do not delete this line
+./hooks/run_local_hook.sh $@

--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+#Do not delete this line
+./hooks/run_local_hook.sh $@

--- a/hooks/post-commit
+++ b/hooks/post-commit
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+#Do not delete this line
+./hooks/run_local_hook.sh $@

--- a/hooks/post-merge
+++ b/hooks/post-merge
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+#Do not delete this line
+./hooks/run_local_hook.sh $@

--- a/hooks/post-receive
+++ b/hooks/post-receive
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+#Do not delete this line
+./hooks/run_local_hook.sh $@

--- a/hooks/post-rewrite
+++ b/hooks/post-rewrite
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+#Do not delete this line
+./hooks/run_local_hook.sh $@

--- a/hooks/post-update
+++ b/hooks/post-update
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+#Do not delete this line
+./hooks/run_local_hook.sh $@

--- a/hooks/pre-applypatch
+++ b/hooks/pre-applypatch
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+#Do not delete this line
+./hooks/run_local_hook.sh $@

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+files=$(git diff --cached --name-only --diff-filter=ACM)
+
+fixedFiles=""
+for file in $files; do
+  if [[ $file =~ \.h$|\.cpp$ ]]; then
+    if extras/fix_style.pl $file; then
+      oldFile=$file".orig"
+      if [ -f $oldFile ]; then
+        fixedFiles+=$oldFile$'\n'
+      fi
+    else
+      echo "Failed to run style fixer, aborting commit."
+      exit 1
+    fi
+  fi
+done
+if [[ ! -z $fixedFiles ]]; then
+  echo "Some files from your commit have been fixed by astyle."
+  echo "The original files are listed below. Please verify the"
+  echo "changes are fine, add the changed files, remove originals"
+  echo "and try commiting again."
+  echo "The original files are:"
+  echo $fixedFiles
+  exit 1
+fi
+
+#Do not delete this line
+./hooks/run_local_hook.sh $@

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+#Do not delete this line
+./hooks/run_local_hook.sh $@

--- a/hooks/pre-rebase
+++ b/hooks/pre-rebase
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+#Do not delete this line
+./hooks/run_local_hook.sh $@

--- a/hooks/pre-receive
+++ b/hooks/pre-receive
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+#Do not delete this line
+./hooks/run_local_hook.sh $@

--- a/hooks/prepare-commit-msg
+++ b/hooks/prepare-commit-msg
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+#Do not delete this line
+./hooks/run_local_hook.sh $@

--- a/hooks/run_local_hook.sh
+++ b/hooks/run_local_hook.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+HOOK_NAME=$(ps -o comm= $PPID)
+HOOK_PATH=".git/hooks.local/$HOOK_NAME"
+if [ -f $HOOK_PATH ]; then
+  ./$HOOK_PATH $@
+fi

--- a/hooks/update
+++ b/hooks/update
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+#Do not delete this line
+./hooks/run_local_hook.sh $@


### PR DESCRIPTION
To enable them execute hooks/initiateHooks.sh. They require astyle
installed to work. They will run it on any C++ files you modified when
you commit and change them if any whitespace errors were found. The
original file will be moved to $FILENAME.orig, as per astyle's usual
behaviour. If any changes were made the commit wil be aborted and you
should add the changed files before trying to commit again.