### PR TITLE
Migration to ROOT6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,30 +16,15 @@ if(NOT MSVC)
   add_definitions(-std=c++11 -Wall -Wunused-parameter)
 endif()
 
-foreach(mode QUIET REQUIRED)
-  find_package(ROOT 5 ${mode} COMPONENTS
-    Hist
-    Physics
-    RIO
-    Thread
-    Tree
-    )
-  if(ROOT_USE_FILE)
-    include(${ROOT_USE_FILE})
-  endif()
-  if(ROOT_FOUND)
-    break()
-  endif()
-  # if we failed with CMake based find_package, use fallback
-  # root-config version from cmake/fallback/
-  list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/fallback)
-endforeach()
+find_package(ROOT REQUIRED)
+
+if(ROOT_USE_FILE)
+  include(${ROOT_USE_FILE})
+endif()
+
 include_directories(${ROOT_INCLUDE_DIRS})
 add_definitions(${ROOT_DEFINITIONS})
 message(STATUS "ROOT version: ${ROOT_VERSION}")
-if(ROOT_FOUND AND NOT ROOT_VERSION VERSION_LESS "6.0")
-  message(FATAL_ERROR "ROOT 6.0 is not compatible")
-endif()
 
 find_package(PQXX REQUIRED)
 include_directories(${PQXX_INCLUDE_DIRS})
@@ -121,7 +106,7 @@ set(DOWNLOAD_DATA ${CMAKE_CURRENT_SOURCE_DIR}/download_data.sh ${CMAKE_CURRENT_S
 if(NOT DOWNLOAD_DATA_HAPPENED)
   execute_process( COMMAND ${DOWNLOAD_DATA} )
   set(DOWNLOAD_DATA_HAPPENED TRUE CACHE BOOL "Has the download data happened?" FORCE)
-endif() 
+endif()
 
 generate_root_dictionaries(DICTIONARIES SOURCES ${SOURCES}
   # exclude following sources from ROOT dictionary
@@ -214,7 +199,7 @@ target_link_libraries(dbhandler
 # copy the DB config file to an expected location
 set(db_config_dir ${CMAKE_CURRENT_BINARY_DIR}/DBConfig)
 add_custom_command(TARGET dbhandler
-  POST_BUILD 
+  POST_BUILD
   COMMAND cp -r ${CMAKE_CURRENT_SOURCE_DIR}/DBHandler/Config ${db_config_dir}
   )
 

--- a/JPetTreeHeader/JPetTreeHeader.h
+++ b/JPetTreeHeader/JPetTreeHeader.h
@@ -36,7 +36,7 @@
  *
  */
 class JPetTreeHeader: public TObject{
- protected:
+ public:
   struct ProcessingStageInfo
   {
     std::string fModuleName;
@@ -56,10 +56,10 @@ class JPetTreeHeader: public TObject{
 
   inline int getRunNumber()  const { return fRunNo; }
   inline void setRunNumber(int p_run_no) { fRunNo = p_run_no; }
-  
+
   inline std::string getBaseFileName() const {return fBaseFilename;}
   inline void setBaseFileName(const char * p_name){ fBaseFilename = p_name; }
-  
+
   /// set source position in mm or -1 of no source was used
   inline double getSourcePosition() const { return fSourcePosition; }
   /// get source position in mm; -1 means no source was used
@@ -73,7 +73,7 @@ class JPetTreeHeader: public TObject{
 
   void setVariable(std::string name, std::string value);
   std::string getVariable(std::string name) const;
-  
+
 protected:
 
   /// auxilliary methods for the Print() functionality

--- a/cmake/FindROOT.cmake
+++ b/cmake/FindROOT.cmake
@@ -7,13 +7,15 @@
 # ROOT_LIBRARIES      Most common libraries
 # ROOT_<name>_LIBRARY Full path to the library <name>
 # ROOT_LIBRARY_DIR    PATH to the library directory
-# ROOT_DEFINITIONS    Compiler definitions and flags
+# ROOT_DEFINITIONS    Compiler definitions
+# ROOT_CXX_FLAGS      Compiler flags to used by client packages
+# ROOT_C_FLAGS        Compiler flags to used by client packages
 #
 # Updated by K. Smith (ksmith37@nd.edu) to properly handle
 #  dependencies in ROOT_GENERATE_DICTIONARY
 
 find_program(ROOT_CONFIG_EXECUTABLE root-config
-  PATHS $ENV{ROOTSYS}/bin)
+  HINTS $ENV{ROOTSYS}/bin)
 
 execute_process(
     COMMAND ${ROOT_CONFIG_EXECUTABLE} --prefix
@@ -51,14 +53,19 @@ list(REMOVE_DUPLICATES ROOT_LIBRARIES)
 
 execute_process(
     COMMAND ${ROOT_CONFIG_EXECUTABLE} --cflags
-    OUTPUT_VARIABLE ROOT_DEFINITIONS
+    OUTPUT_VARIABLE __cflags
     OUTPUT_STRIP_TRAILING_WHITESPACE)
-string(REGEX REPLACE "(^|[ ]*)-I[^ ]*" "" ROOT_DEFINITIONS ${ROOT_DEFINITIONS})
+string(REGEX MATCHALL "-(D|U)[^ ]*" ROOT_DEFINITIONS "${__cflags}")
+string(REGEX REPLACE "(^|[ ]*)-I[^ ]*" "" ROOT_CXX_FLAGS "${__cflags}")
+string(REGEX REPLACE "(^|[ ]*)-I[^ ]*" "" ROOT_C_FLAGS "${__cflags}")
+
+set(ROOT_USE_FILE ${CMAKE_CURRENT_LIST_DIR}/RootUseFile.cmake)
 
 execute_process(
   COMMAND ${ROOT_CONFIG_EXECUTABLE} --features
   OUTPUT_VARIABLE _root_options
   OUTPUT_STRIP_TRAILING_WHITESPACE)
+separate_arguments(_root_options)
 foreach(_opt ${_root_options})
   set(ROOT_${_opt}_FOUND TRUE)
 endforeach()
@@ -70,8 +77,8 @@ find_package_handle_standard_args(ROOT DEFAULT_MSG ROOT_CONFIG_EXECUTABLE
 mark_as_advanced(ROOT_CONFIG_EXECUTABLE)
 
 include(CMakeParseArguments)
-find_program(ROOTCINT_EXECUTABLE rootcint PATHS $ENV{ROOTSYS}/bin)
-find_program(GENREFLEX_EXECUTABLE genreflex PATHS $ENV{ROOTSYS}/bin)
+find_program(ROOTCINT_EXECUTABLE rootcint HINTS $ENV{ROOTSYS}/bin)
+find_program(GENREFLEX_EXECUTABLE genreflex HINTS $ENV{ROOTSYS}/bin)
 find_package(GCCXML)
 
 #----------------------------------------------------------------------------
@@ -98,7 +105,7 @@ function(ROOT_GENERATE_DICTIONARY dictionary)
         endif()
       endforeach()
     else()
-      find_file(headerFile ${fp} PATHS ${incdirs})
+      find_file(headerFile ${fp} HINTS ${incdirs})
       set(headerfiles ${headerfiles} ${headerFile})
       unset(headerFile CACHE)
     endif()
@@ -106,12 +113,12 @@ function(ROOT_GENERATE_DICTIONARY dictionary)
   #---Get LinkDef.h file------------------------------------
   set(linkdefs)
   foreach( f ${ARG_LINKDEF})
-    find_file(linkFile ${f} PATHS ${incdirs})
+    find_file(linkFile ${f} HINTS ${incdirs})
     set(linkdefs ${linkdefs} ${linkFile})
     unset(linkFile CACHE)
   endforeach()
   #---call rootcint------------------------------------------
-  add_custom_command(OUTPUT ${dictionary}.cxx ${dictionary}.h
+  add_custom_command(OUTPUT ${dictionary}.cxx
                      COMMAND ${ROOTCINT_EXECUTABLE} -cint -f  ${dictionary}.cxx
                                           -c ${ARG_OPTIONS} ${includedirs} ${headerfiles} ${linkdefs}
                      DEPENDS ${headerfiles} ${linkdefs} VERBATIM)

--- a/cmake/RootUseFile.cmake
+++ b/cmake/RootUseFile.cmake
@@ -1,0 +1,9 @@
+#---Set Link and include directories--------------------------------------------------------------
+include_directories(${ROOT_INCLUDE_DIRS})
+link_directories(${ROOT_LIBRARY_DIR})
+
+#---Set Flags-------------------------------------------------------------------------------------
+add_definitions(${ROOT_DEFINITIONS})
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${ROOT_CXX_FLAGS}")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${ROOT_C_FLAGS}")
+set(CMAKE_fortran_FLAGS "${CMAKE_fortran_FLAGS} ${ROOT_fortran_FLAGS}")


### PR DESCRIPTION
ROOT 6 compiled by function:
cmake -DCMAKE_CXX_FLAGS="-D_GLIBCXX_USE_CXX11_ABI=0" /path_to_root_source/
make

framework prerequisites:
sudo aptitude install libboost-all-dev libpqxx-dev libpqxx-4.0 libconfig++9v5 libconfig++-dev libtinyxml2-dev doxygen
Compiles on clean Linux Mint 18 install without problems.

HOWEVER, tests do not compile - probably due to some problems with libraries linking in cmake
