### PR TITLE
Add error detection and error handling in case of the duplicated ids in the scope configuration file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,11 +21,11 @@ install:
   - sudo apt-get install -y root-system
 script:
     - mkdir -p DBHandler/Config
-    - export SSHPASS=$KOZA_PASSWORD
-    - sshpass -e scp -r -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $KOZA_USERNAME@koza.if.uj.edu.pl:/home/framework_configs/configDB.cfg DBHandler/Config/
+    - export SSHPASS=$SPHINX_PASSWORD
+    - sshpass -e scp -r -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $SPHINX_USERNAME@sphinx.if.uj.edu.pl:/home/framework_configs/configDB.cfg DBHandler/Config/
     - ls DBHandler/Config/
-    - sshpass -e scp -r -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $KOZA_USERNAME@koza.if.uj.edu.pl:/home/framework_configs/configDB.cfg.koza DBHandler/Config/
-    - sshpass -e scp -r -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $KOZA_USERNAME@koza.if.uj.edu.pl:/home/framework_configs/ReadMe.txt DBHandler/Config/
+    - sshpass -e scp -r -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $SPHINX_USERNAME@sphinx.if.uj.edu.pl:/home/framework_configs/configDB.cfg.koza DBHandler/Config/
+    - sshpass -e scp -r -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $SPHINX_USERNAME@sphinx.if.uj.edu.pl:/home/framework_configs/ReadMe.txt DBHandler/Config/
     - mkdir build
     - cd build
     - cmake ..

--- a/JPetParamBank/JPetParamBank.h
+++ b/JPetParamBank/JPetParamBank.h
@@ -33,7 +33,7 @@
 
 class JPetParamBank: public TObject
 {
- public:
+public:
   JPetParamBank();
   JPetParamBank(const JPetParamBank& paramBank);
   ~JPetParamBank();
@@ -44,9 +44,12 @@ class JPetParamBank: public TObject
 
   int getSize(ParamObjectType type) const;
 
-  // Scintillators
+  /// Adds scintillator to Param Bank. If the scintillator with the same id already exists in the Param Bank,
+  /// the new element will not be added.
   inline void addScintillator(JPetScin scintillator) {
-    fScintillators[scintillator.getID()] = new JPetScin(scintillator);
+    if (fScintillators.insert(std::make_pair(scintillator.getID(), new JPetScin(scintillator))).second == false) {
+      WARNING("the scintillator with this id already exists in the ParamBank. It will not be added.");
+    }
   }
   inline const std::map<int, JPetScin*>& getScintillators() const {
     return fScintillators;
@@ -58,9 +61,12 @@ class JPetParamBank: public TObject
     return fScintillators.size();
   }
 
-  // PMs
+  /// Adds photomultipliers(PM) to Param Bank. If the PM with the same id already exists in the Param Bank,
+  /// the new element will not be added.
   inline void addPM(JPetPM pm) {
-    fPMs[pm.getID()] = new JPetPM(pm);
+    if (fPMs.insert(std::make_pair(pm.getID(), new JPetPM(pm))).second == false) {
+      WARNING("the pm with this id already exists in the ParamBank. It will not be added.");
+    }
   }
   inline const std::map<int, JPetPM*>& getPMs() const {
     return fPMs;
@@ -72,9 +78,12 @@ class JPetParamBank: public TObject
     return fPMs.size();
   }
 
-  // PMCalibs
+  /// Adds PMCalib to Param Bank. If the PMCalib with the same id already exists in the Param Bank,
+  /// the new element will not be added.
   inline void addPMCalib(JPetPMCalib pmCalib) {
-    fPMCalibs[pmCalib.GetId()] = new JPetPMCalib(pmCalib);
+    if (fPMCalibs.insert(std::make_pair(pmCalib.GetId(), new JPetPMCalib(pmCalib))).second == false) {
+      WARNING("the pmCalib with this id already exists in the ParamBank. It will not be added.");
+    }
   }
   inline const std::map<int, JPetPMCalib*>& getPMCalibs() const {
     return fPMCalibs;
@@ -86,9 +95,12 @@ class JPetParamBank: public TObject
     return fPMCalibs.size();
   }
 
-  // FEBs
+  /// Adds FEB to the Param Bank. If the FEB with the same id already exists in the Param Bank,
+  /// the new element will not be added.
   inline void addFEB(JPetFEB feb) {
-    fFEBs[feb.getID()] = new JPetFEB(feb);
+    if (fFEBs.insert(std::make_pair(feb.getID(), new JPetFEB(feb))).second == false) {
+      WARNING("the feb with this id already exists in the ParamBank. It will not be added.");
+    }
   }
   inline const std::map<int, JPetFEB*>& getFEBs() const {
     return fFEBs;
@@ -100,9 +112,12 @@ class JPetParamBank: public TObject
     return fFEBs.size();
   }
 
-  // TRBs
+  /// Adds TRB to the Param Bank. If the TRB with the same id already exists in the Param Bank,
+  /// the new element will not be added.
   inline void addTRB(JPetTRB trb) {
-    fTRBs[trb.getID()] = new JPetTRB(trb);
+    if (fTRBs.insert(std::make_pair(trb.getID(), new JPetTRB(trb))).second == false) {
+      WARNING("the trb with this id already exists in the ParamBank. It will not be added.");
+    }
   }
   inline const std::map<int, JPetTRB*>& getTRBs() const {
     return fTRBs;
@@ -114,9 +129,12 @@ class JPetParamBank: public TObject
     return fTRBs.size();
   }
 
-  // Barrel Slot
+  /// Adds BarrelSlot to the Param Bank. If the BarrelSlot with the same id already exists in the Param Bank,
+  /// the new element will not be added.
   inline void addBarrelSlot(JPetBarrelSlot slot) {
-    fBarrelSlots[slot.getID()] = new JPetBarrelSlot(slot);
+    if (fBarrelSlots.insert(std::make_pair(slot.getID(), new JPetBarrelSlot(slot))).second == false) {
+      WARNING("the barrelslot with this id already exists in the ParamBank. It will not be added.");
+    }
   }
   inline const std::map<int, JPetBarrelSlot*>& getBarrelSlots() const {
     return fBarrelSlots;
@@ -128,9 +146,12 @@ class JPetParamBank: public TObject
     return fBarrelSlots.size();
   }
 
-  // Layer
+  /// Adds Layer to the Param Bank. If the Layer with the same id already exists in the Param Bank,
+  /// the new element will not be added.
   inline void addLayer(JPetLayer layer) {
-    fLayers[layer.getId()] = new JPetLayer(layer);
+    if (fLayers.insert(std::make_pair(layer.getId(), new JPetLayer(layer))).second == false) {
+      WARNING("the layer with this id already exists in the ParamBank. It will not be added.");
+    }
   }
   inline const std::map<int, JPetLayer*>& getLayers() const {
     return fLayers;
@@ -142,9 +163,12 @@ class JPetParamBank: public TObject
     return fLayers.size();
   }
 
-  // Frame
+  /// Adds Frame to the Param Bank. If the Frame with the same id already exists in the Param Bank,
+  /// the new element will not be added.
   inline void addFrame(JPetFrame frame) {
-    fFrames[frame.getId()] = new JPetFrame(frame);
+    if (fFrames.insert(std::make_pair(frame.getId(), new JPetFrame(frame))).second == false) {
+      WARNING("the frame with this id already exists in the ParamBank. It will not be added.");
+    }
   }
   inline const std::map<int, JPetFrame*>& getFrames() const {
     return fFrames;
@@ -156,9 +180,12 @@ class JPetParamBank: public TObject
     return fFrames.size();
   }
 
-  // TOMB Channels
+  /// Adds TOMB to the Param Bank. If the TOMB with the same id already exists in the Param Bank,
+  /// the new element will not be added.
   inline void addTOMBChannel(JPetTOMBChannel tombchannel) {
-    fTOMBChannels[tombchannel.getChannel()] = new JPetTOMBChannel(tombchannel);
+    if (fTOMBChannels.insert(std::make_pair(tombchannel.getChannel(), new JPetTOMBChannel(tombchannel))).second == false) {
+      WARNING("the tombchannel with this id already exists in the ParamBank. It will not be added.");
+    }
   }
   inline const std::map<int, JPetTOMBChannel*>& getTOMBChannels() const {
     return fTOMBChannels;
@@ -170,7 +197,7 @@ class JPetParamBank: public TObject
     return fTOMBChannels.size();
   }
 
- private:
+private:
   void operator=(const JPetParamBank&);
   bool fDummy;
   std::map<int, JPetScin*> fScintillators;
@@ -185,11 +212,10 @@ class JPetParamBank: public TObject
   ClassDef (JPetParamBank, 3);
 
   template <typename T>
-  void copyMapValues(std::map<int, T*>& target, const std::map<int, T*>& source)
-  {
-      for (auto & c : source) {
-          target[c.first] = new T(*c.second);
-      }
+  void copyMapValues(std::map<int, T*>& target, const std::map<int, T*>& source) {
+    for (auto & c : source) {
+      target[c.first] = new T(*c.second);
+    }
   }
 };
 

--- a/JPetScopeConfigParser/JPetScopeConfigParser.cpp
+++ b/JPetScopeConfigParser/JPetScopeConfigParser.cpp
@@ -35,7 +35,7 @@ scope_config::Config JPetScopeConfigParser::getConfig(const std::string& configF
   using boost::property_tree::ptree;
   Config config;
   auto prop_tree = getJsonContent(configFileName);
-  if(prop_tree.size() > 1 ) {
+  if (prop_tree.size() > 1 ) {
     ERROR("More than one config found in the configuration file! Only the last set will be used!");
   }
   for (ptree::const_iterator it = prop_tree.begin(); it != prop_tree.end(); ++it) {
@@ -56,13 +56,13 @@ scope_config::Config JPetScopeConfigParser::getConfig(std::string configName, bo
   config.fBSlots = getBSlots(configContent);
   config.fPMs = getPMs(configContent);
   config.fScins = getScins(configContent);
-  return config; 
+  return config;
 }
 
 std::vector<JPetScopeConfigParser::InputDirectory> JPetScopeConfigParser::getInputDirectories(const std::string& configFileLocation, const scope_config::Config& config) const
 {
   std::vector<std::string> directories;
-  auto path = configFileLocation + "/" +config.fLocation;
+  auto path = configFileLocation + "/" + config.fLocation;
   auto currDir = generateDirectories(path, transformToNumbers(config.fCollimatorPositions));
   directories.insert(directories.end(), currDir.begin(), currDir.end());
   return directories;
@@ -88,7 +88,9 @@ JPetScopeConfigParser::DirFileContainer JPetScopeConfigParser::getInputDirectori
     container.reserve(filenames.size());
     std::transform(
       directories.begin(), directories.end(), filenames.begin(), std::back_inserter(container),
-      [](InputDirectory dir, FakeInputFile file) { return std::make_pair(dir, file); }
+    [](InputDirectory dir, FakeInputFile file) {
+      return std::make_pair(dir, file);
+    }
     );
   }
   return getElementsWithExistingDirs(container);
@@ -96,12 +98,14 @@ JPetScopeConfigParser::DirFileContainer JPetScopeConfigParser::getInputDirectori
 
 
 JPetScopeConfigParser::DirFileContainer JPetScopeConfigParser::getElementsWithExistingDirs(
-  const JPetScopeConfigParser::DirFileContainer& dirsAndFiles) const 
+  const JPetScopeConfigParser::DirFileContainer& dirsAndFiles) const
 {
   JPetScopeConfigParser::DirFileContainer result;
-  std::copy_if(dirsAndFiles.begin(), dirsAndFiles.end(), std::back_inserter(result),  
-      [](const DirFilePair dirFilePair) { return JPetCommonTools::isDirectory(dirFilePair.first); }
-    );
+  std::copy_if(dirsAndFiles.begin(), dirsAndFiles.end(), std::back_inserter(result),
+  [](const DirFilePair dirFilePair) {
+    return JPetCommonTools::isDirectory(dirFilePair.first);
+  }
+              );
   return result;
 }
 
@@ -125,7 +129,7 @@ std::vector<int> JPetScopeConfigParser::transformToNumbers(const std::vector<std
 }
 
 /// The directory is generated according to the following pattern:
-/// base_path/position 
+/// base_path/position
 /// e.g. "unittests/data/1"
 std::vector<std::string>  JPetScopeConfigParser::generateDirectories(
   const std::string& basePath,
@@ -268,4 +272,32 @@ boost::property_tree::ptree JPetScopeConfigParser::getJsonContent(const std::str
     ERROR(message);
   }
   return propTree;
+}
+
+
+
+/// We store id of given types in a set. Set can contain only unique id, therefore in case of
+/// duplication the set size will be smaller that orginal vector size.
+bool JPetScopeConfigParser::areObjectsWithDuplicatedIds(const scope_config::Config& config) const
+{
+  using namespace scope_config;
+  std::set<int> bSlotIdSet;
+  for (const auto &  bslot : config.fBSlots) {
+    bSlotIdSet.insert(bslot.fId);
+  }
+  if (bSlotIdSet.size() < config.fBSlots.size()) return true;
+
+  std::set<int> pmIdSet;
+  for (const auto &  pm : config.fPMs) {
+    pmIdSet.insert(pm.fId);
+  }
+  if (pmIdSet.size() < config.fPMs.size()) return true;
+
+  std::set<int> scinIdSet;
+  for (const auto &  scin : config.fScins) {
+    scinIdSet.insert(scin.fId);
+  }
+  if (scinIdSet.size() < config.fScins.size()) return true;
+
+  return false;
 }

--- a/JPetScopeConfigParser/JPetScopeConfigParser.h
+++ b/JPetScopeConfigParser/JPetScopeConfigParser.h
@@ -24,11 +24,11 @@
 class JPetScopeConfigParser
 {
 public:
-  using FakeInputFile=std::string; /// fake input file name is generated only to be parsed by next modules 
+  using FakeInputFile = std::string; /// fake input file name is generated only to be parsed by next modules
   /// (if needed by any) and create correct output file name.
-  using InputDirectory=std::string;
+  using InputDirectory = std::string;
   using DirFilePair = std::pair< InputDirectory, FakeInputFile >;
-  using DirFileContainer=std::vector< DirFilePair>; 
+  using DirFileContainer = std::vector< DirFilePair>;
 
   JPetScopeConfigParser() {}
   DirFileContainer getInputDirectoriesAndFakeInputFiles(const std::string& configFileWithPath) const;
@@ -38,11 +38,14 @@ public:
   std::vector<FakeInputFile> getFakeInputFileNames(const std::string& configFileName, const scope_config::Config& config) const;
   std::vector<std::string>  generateFileNames(const std::string& configFileName, const std::string& configName, const std::vector<int>& positions) const;
   std::vector<std::string> generateDirectories(const std::string& basePath, const std::vector<int>& positions) const;
-  boost::property_tree::ptree getJsonContent(const std::string &configFileName) const;
+  boost::property_tree::ptree getJsonContent(const std::string& configFileName) const;
   std::vector<int> transformToNumbers(const std::vector<std::string>& positions) const;
 
   DirFileContainer getElementsWithExistingDirs(const JPetScopeConfigParser::DirFileContainer& dirsAndFiles) const;
-  
+
+  /// Method returns true if the barrelslots, scins, pms ids are not unique.
+  bool areObjectsWithDuplicatedIds(const scope_config::Config& config) const;
+
 protected:
   scope_config::Config getConfig(std::string configName, boost::property_tree::ptree const& configContent) const;
   std::vector<std::string> getPositions(boost::property_tree::ptree const& configContent) const;
@@ -50,7 +53,7 @@ protected:
   std::vector<scope_config::BSlot> getBSlots(boost::property_tree::ptree const& content) const;
   std::vector<scope_config::PM> getPMs(boost::property_tree::ptree const& content) const;
   std::vector<scope_config::Scin> getScins(boost::property_tree::ptree const& content) const;
-                                               
+
 private:
   JPetScopeConfigParser(const JPetScopeConfigParser&);
   void operator=(const JPetScopeConfigParser&);

--- a/JPetScopeConfigParser/JPetScopeConfigParserTest.cpp
+++ b/JPetScopeConfigParser/JPetScopeConfigParserTest.cpp
@@ -41,7 +41,7 @@ BOOST_AUTO_TEST_CASE(transformToNumbers)
   BOOST_REQUIRE(parser.transformToNumbers(VecOfStrings {"a"}).empty());
   BOOST_REQUIRE(parser.transformToNumbers(VecOfStrings {"1", "a", "10"}) == (VecOfNums {1, 10}));
   BOOST_REQUIRE(parser.transformToNumbers(VecOfStrings {"a", "2", "5"}) == (VecOfNums {2, 5}));
-  BOOST_REQUIRE(parser.transformToNumbers(VecOfStrings {"1 2", "3", "7 a 3", "1.2"}) == (VecOfNums {1, 2, 3, 7,1}));
+  BOOST_REQUIRE(parser.transformToNumbers(VecOfStrings {"1 2", "3", "7 a 3", "1.2"}) == (VecOfNums {1, 2, 3, 7, 1}));
 }
 
 BOOST_AUTO_TEST_CASE(generateFileNames)
@@ -80,7 +80,7 @@ BOOST_AUTO_TEST_CASE(getInputDirectoriesAndFakeInputFile)
   JPetScopeConfigParser parser;
   using namespace scope_config;
   Config config;
-  BOOST_REQUIRE(parser.getInputDirectoriesAndFakeInputFiles("").empty()); 
+  BOOST_REQUIRE(parser.getInputDirectoriesAndFakeInputFiles("").empty());
   /// The result is still empty, because now the result contains only elements with directories which actually exist
   /// and there are no directories in this location.
   BOOST_REQUIRE(parser.getInputDirectoriesAndFakeInputFiles(gInputConfigJsonFilenameTest).empty());
@@ -101,13 +101,13 @@ BOOST_AUTO_TEST_CASE(getConfig)
   BOOST_REQUIRE(emptyConf.fCollimatorPositions.empty());
 
   Config config;
-  config.fLocation="data";
+  config.fLocation = "data";
   config.fCollimatorPositions = VecOfStrings { "1 5 2", "12", "6"};
-  config.fBSlots= std::vector<BSlot>{ BSlot(-1,false,"",-1., -1), BSlot(-1,false,"",-1., -1)};
-  config.fPMs = std::vector<PM>{PM(3,"C2"), PM(98, "C4"), PM(32, "C1"), PM(42, "C3")}; 
-  config.fScins=std::vector<Scin>{Scin(32), Scin(12)};
-  config.fName="config1";
-  
+  config.fBSlots = std::vector<BSlot> { BSlot(-1, false, "", -1., -1), BSlot(-1, false, "", -1., -1)};
+  config.fPMs = std::vector<PM> {PM(3, "C2"), PM(98, "C4"), PM(32, "C1"), PM(42, "C3")};
+  config.fScins = std::vector<Scin> {Scin(32), Scin(12)};
+  config.fName = "config1";
+
   auto res = parser.getConfig(gInputConfigJsonFilenameTest);
 
   BOOST_REQUIRE(res.fName == config.fName);
@@ -115,21 +115,18 @@ BOOST_AUTO_TEST_CASE(getConfig)
   BOOST_REQUIRE(res.fCollimatorPositions == config.fCollimatorPositions);
 
   BOOST_REQUIRE(res.fPMs.size() == config.fPMs.size());
-  for (auto i = 0u ; i < config.fPMs.size(); i++)
-  {
+  for (auto i = 0u ; i < config.fPMs.size(); i++) {
     BOOST_REQUIRE(config.fPMs[i].fId == res.fPMs[i].fId);
     BOOST_REQUIRE(config.fPMs[i].fPrefix == res.fPMs[i].fPrefix);
   }
 
   BOOST_REQUIRE(res.fScins.size() == config.fScins.size());
-  for (auto i = 0u ; i < config.fScins.size(); i++)
-  {
+  for (auto i = 0u ; i < config.fScins.size(); i++) {
     BOOST_REQUIRE(config.fScins[i].fId == res.fScins[i].fId);
   }
 
   BOOST_REQUIRE(res.fBSlots.size() == config.fBSlots.size());
-  for (auto i = 0u ; i < config.fBSlots.size(); i++)
-  {
+  for (auto i = 0u ; i < config.fBSlots.size(); i++) {
     BOOST_REQUIRE(config.fBSlots[i].fId == res.fBSlots[i].fId);
     BOOST_REQUIRE(config.fBSlots[i].fActive == res.fBSlots[i].fActive);
     BOOST_REQUIRE(config.fBSlots[i].fName == res.fBSlots[i].fName);
@@ -143,10 +140,61 @@ BOOST_AUTO_TEST_CASE(getElementsWithExistingDirs)
   std::vector<std::pair<std::string, std::string> >  dirsAndFakeFiles = { std::make_pair("./", "file1"), std::make_pair("fake/directory", "file2")};
   JPetScopeConfigParser parser;
   auto result = parser.getElementsWithExistingDirs(dirsAndFakeFiles );
-  BOOST_REQUIRE_EQUAL(result.size(), 1); 
-  BOOST_REQUIRE_EQUAL(result.at(0).first, "./"); 
-  BOOST_REQUIRE_EQUAL(result.at(0).second, "file1"); 
+  BOOST_REQUIRE_EQUAL(result.size(), 1);
+  BOOST_REQUIRE_EQUAL(result.at(0).first, "./");
+  BOOST_REQUIRE_EQUAL(result.at(0).second, "file1");
   BOOST_REQUIRE(parser.getElementsWithExistingDirs({}).empty());
+}
+
+BOOST_AUTO_TEST_CASE(areObjectsWithDuplicatedIds)
+{
+  using namespace scope_config;
+  using VecOfStrings = std::vector<std::string>;
+  JPetScopeConfigParser parser;
+
+  /// No duplicates
+  Config config;
+  config.fLocation = "data";
+  config.fCollimatorPositions = VecOfStrings { "1 5 2", "12", "6"};
+  config.fBSlots = std::vector<BSlot> { BSlot(-1, false, "", -1., -1), BSlot(-2, false, "", -1., -1)};
+  config.fPMs = std::vector<PM> {PM(3, "C2"), PM(98, "C4"), PM(32, "C1"), PM(42, "C3")};
+  config.fScins = std::vector<Scin> {Scin(32), Scin(12)};
+  config.fName = "config1";
+  BOOST_REQUIRE(!parser.areObjectsWithDuplicatedIds(config));
+
+  /// Same Bslots ids.
+  Config config2;
+  config2.fLocation = "data";
+  config2.fCollimatorPositions = VecOfStrings { "1 5 2", "12", "6"};
+  config2.fBSlots = std::vector<BSlot> { BSlot(-1, false, "", -1., -1), BSlot(-1, false, "", -1., -1)};
+  config2.fPMs = std::vector<PM> {PM(3, "C2"), PM(98, "C4"), PM(32, "C1"), PM(42, "C3")};
+  config2.fScins = std::vector<Scin> {Scin(32), Scin(12)};
+  config2.fName = "config2";
+  BOOST_REQUIRE(parser.areObjectsWithDuplicatedIds(config2));
+
+  /// Same PM ids.
+  Config config3;
+  config3.fLocation = "data";
+  config3.fCollimatorPositions = VecOfStrings { "1 5 2", "12", "6"};
+  config3.fBSlots = std::vector<BSlot> { BSlot(-1, false, "", -1., -1), BSlot(-2, false, "", -1., -1)};
+  config3.fPMs = std::vector<PM> {PM(3, "C2"), PM(98, "C4"), PM(32, "C1"), PM(98, "C3")};
+  config3.fScins = std::vector<Scin> {Scin(32), Scin(12)};
+  config3.fName = "config3";
+  BOOST_REQUIRE(parser.areObjectsWithDuplicatedIds(config3));
+
+  /// Same Scins ids.
+  Config config4;
+  config4.fLocation = "data";
+  config4.fCollimatorPositions = VecOfStrings { "1 5 2", "12", "6"};
+  config4.fBSlots = std::vector<BSlot> { BSlot(-1, false, "", -1., -1), BSlot(-2, false, "", -1., -1)};
+  config4.fPMs = std::vector<PM> {PM(3, "C2"), PM(98, "C4"), PM(32, "C1"), PM(11, "C3")};
+  config4.fScins = std::vector<Scin> {Scin(32), Scin(32)};
+  config4.fName = "config4";
+  BOOST_REQUIRE(parser.areObjectsWithDuplicatedIds(config4));
+
+  /// Empty config.
+  Config config5;
+  BOOST_REQUIRE(!parser.areObjectsWithDuplicatedIds(config5));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/JPetScopeLoader/JPetScopeLoaderTest.cpp
+++ b/JPetScopeLoader/JPetScopeLoaderTest.cpp
@@ -1,5 +1,5 @@
 #define BOOST_TEST_DYN_LINK
-#define BOOST_TEST_MODULE ScopeReader
+#define BOOST_TEST_MODULE ScopeLoader
 #define BOOST_TEST_LOG_LEVEL message
 #include <cstddef>
 #include <functional>
@@ -17,7 +17,7 @@ char* convertStringToCharP(const std::string& s)
   return pc;
 }
 
-std::vector<char*> createArgs(const std::string& commandLine) 
+std::vector<char*> createArgs(const std::string& commandLine)
 {
   std::istringstream iss(commandLine);
   std::vector<std::string> args {std::istream_iterator<std::string>{iss},
@@ -31,7 +31,7 @@ std::vector<char*> createArgs(const std::string& commandLine)
 
 BOOST_AUTO_TEST_SUITE (JPetScopeLoaderTestSuite)
 
-BOOST_AUTO_TEST_CASE (getFilePrefix) 
+BOOST_AUTO_TEST_CASE (getFilePrefix)
 {
   JPetDBParamGetter::clearParamCache();
   JPetScopeParamGetter::clearParamCache();
@@ -45,35 +45,35 @@ BOOST_AUTO_TEST_CASE (getFilePrefix)
   BOOST_REQUIRE_EQUAL(reader.getFilePrefix("a_ss_q"), "a");
 }
 
-BOOST_AUTO_TEST_CASE (createInputScopeFileNames) 
+BOOST_AUTO_TEST_CASE (createInputScopeFileNames)
 {
   JPetDBParamGetter::clearParamCache();
   JPetScopeParamGetter::clearParamCache();
   JPetScopeLoader reader(0);
   BOOST_REQUIRE(reader.createInputScopeFileNames("", {}).empty());
   BOOST_REQUIRE(reader.createInputScopeFileNames("non_existing", {}).empty());
-  BOOST_REQUIRE(!reader.createInputScopeFileNames("unitTestData/JPetScopeLoaderTest/scope_files/0", {{"C1",0}, {"C2",1}, {"C3", 2}, {"C4",3}}).empty());
+  BOOST_REQUIRE(!reader.createInputScopeFileNames("unitTestData/JPetScopeLoaderTest/scope_files/0", {{"C1", 0}, {"C2", 1}, {"C3", 2}, {"C4", 3}}).empty());
   std::map<std::string, int>  expectedRes0 {
-      {"C1_00003.txt",0}, {"C1_00004.txt", 0},  {"C2_00003.txt",1}, {"C2_00004.txt",1},   
-    {"C3_00003.txt",2},{"C3_00004.txt", 2}, {"C4_00003.txt",3},{"C4_00004.txt", 3}
+    {"C1_00003.txt", 0}, {"C1_00004.txt", 0},  {"C2_00003.txt", 1}, {"C2_00004.txt", 1},
+    {"C3_00003.txt", 2}, {"C3_00004.txt", 2}, {"C4_00003.txt", 3}, {"C4_00004.txt", 3}
   };
   std::map<std::string, int>  expectedRes;
   std::string pathToFiles = "unitTestData/JPetScopeLoaderTest/scope_files/0";
-  for (const auto& el: expectedRes0) {
+  for (const auto & el : expectedRes0) {
     expectedRes[pathToFiles + "/" + el.first] = el.second;
   }
-  std::map<std::string, int> obtainedRes = reader.createInputScopeFileNames(pathToFiles, {{"C1",0}, {"C2",1}, {"C3", 2}, {"C4",3}});
+  std::map<std::string, int> obtainedRes = reader.createInputScopeFileNames(pathToFiles, {{"C1", 0}, {"C2", 1}, {"C3", 2}, {"C4", 3}});
   BOOST_REQUIRE(!obtainedRes.empty());
   BOOST_REQUIRE_EQUAL(obtainedRes.size(), expectedRes.size());
   auto it2 = obtainedRes.begin();
-  for (auto it =expectedRes.begin(); it != expectedRes.end(); ++it) {
+  for (auto it = expectedRes.begin(); it != expectedRes.end(); ++it) {
     BOOST_REQUIRE_EQUAL(it->first, it2->first);
     BOOST_REQUIRE_EQUAL(it->second, it2->second);
     ++it2;
   }
 }
 
-BOOST_AUTO_TEST_CASE (isCorrectScopeFileName) 
+BOOST_AUTO_TEST_CASE (isCorrectScopeFileName)
 {
   JPetDBParamGetter::clearParamCache();
   JPetScopeParamGetter::clearParamCache();
@@ -89,11 +89,12 @@ BOOST_AUTO_TEST_CASE (isCorrectScopeFileName)
   BOOST_REQUIRE(reader.isCorrectScopeFileName("AA_004.txt"));
 }
 
-BOOST_AUTO_TEST_CASE (generate_root_file) {
+BOOST_AUTO_TEST_CASE (generate_root_file)
+{
   JPetDBParamGetter::clearParamCache();
   JPetScopeParamGetter::clearParamCache();
   const char* test_root_filename = "unitTestData/JPetScopeLoaderTest/test_file_test_0.reco.sig.root";
-  boost::filesystem::remove(test_root_filename); 
+  boost::filesystem::remove(test_root_filename);
   auto commandLine = "main.exe  -t scope -f unitTestData/JPetScopeLoaderTest/test_file.json";
   auto args_char = createArgs(commandLine);
   auto argc = args_char.size();
@@ -105,13 +106,14 @@ BOOST_AUTO_TEST_CASE (generate_root_file) {
   BOOST_REQUIRE_MESSAGE(boost::filesystem::exists(test_root_filename), "File " << test_root_filename << " does not exist.");
 }
 
-BOOST_AUTO_TEST_CASE (position_does_not_exist) {
+BOOST_AUTO_TEST_CASE (position_does_not_exist)
+{
   JPetDBParamGetter::clearParamCache();
   JPetScopeParamGetter::clearParamCache();
 
   const char* test_root_filename = "unitTestData/JPetScopeLoaderTest/wrong_file_test_30.reco.sig.root";
-  boost::filesystem::remove(test_root_filename); 
-  auto commandLine = "main.exe  -t scope -f unitTestData/JPetScopeLoaderTest/wrong_file.json"; 
+  boost::filesystem::remove(test_root_filename);
+  auto commandLine = "main.exe  -t scope -f unitTestData/JPetScopeLoaderTest/wrong_file.json";
   //contains a single position 30 that does not exist
   auto args_char = createArgs(commandLine);
   auto argc = args_char.size();
@@ -123,13 +125,13 @@ BOOST_AUTO_TEST_CASE (position_does_not_exist) {
   BOOST_REQUIRE_MESSAGE(!boost::filesystem::exists(test_root_filename), "File " << test_root_filename << " exists.");
 }
 
-BOOST_AUTO_TEST_CASE (folder_does_not_exist) 
+BOOST_AUTO_TEST_CASE (folder_does_not_exist)
 {
   JPetDBParamGetter::clearParamCache();
   JPetScopeParamGetter::clearParamCache();
   const char* test_root_filename = "unitTestData/JPetScopeLoaderTest/wrong_file2_test_0.reco.sig.root";
-  boost::filesystem::remove(test_root_filename); 
-  auto commandLine = "main.exe  -t scope -f unitTestData/JPetScopeLoaderTest/wrong_file2.json"; 
+  boost::filesystem::remove(test_root_filename);
+  auto commandLine = "main.exe  -t scope -f unitTestData/JPetScopeLoaderTest/wrong_file2.json";
   //contains a wrong data folder name
   auto args_char = createArgs(commandLine);
   auto argc = args_char.size();
@@ -141,14 +143,15 @@ BOOST_AUTO_TEST_CASE (folder_does_not_exist)
   BOOST_REQUIRE_MESSAGE(!boost::filesystem::exists(test_root_filename), "File " << test_root_filename << " exists.");
 }
 
-BOOST_AUTO_TEST_CASE (generate_root_file2) {
+BOOST_AUTO_TEST_CASE (generate_root_file2)
+{
   JPetDBParamGetter::clearParamCache();
   JPetScopeParamGetter::clearParamCache();
 
   const char* test_root_filename1 = "unitTestData/JPetScopeLoaderTest/test_file2_test_0.reco.sig.root";
   const char* test_root_filename2 = "unitTestData/JPetScopeLoaderTest/test_file2_test_1.reco.sig.root";
-  boost::filesystem::remove(test_root_filename1); 
-  boost::filesystem::remove(test_root_filename2); 
+  boost::filesystem::remove(test_root_filename1);
+  boost::filesystem::remove(test_root_filename2);
   auto commandLine = "main.exe  -t scope -f unitTestData/JPetScopeLoaderTest/test_file2.json";
   auto args_char = createArgs(commandLine);
   auto argc = args_char.size();
@@ -160,31 +163,5 @@ BOOST_AUTO_TEST_CASE (generate_root_file2) {
   BOOST_REQUIRE_MESSAGE(boost::filesystem::exists(test_root_filename1), "File " << test_root_filename1 << " does not exist.");
   BOOST_REQUIRE_MESSAGE(boost::filesystem::exists(test_root_filename2), "File " << test_root_filename2 << " does not exist.");
 }
-
-//BOOST_FIXTURE_TEST_CASE (signal_generation_test, signal_generation_fixture) {
-
-  //check_header(
-    //[] (int osc_file_size, int reco_signal_size) -> void {
-      //BOOST_REQUIRE_EQUAL(osc_file_size, reco_signal_size);
-    //}
-  //);
-
-  //check_data(
-    //[] (float osc_file_time, float reco_signal_time, float osc_file_ampl, float reco_signal_ampl) -> void {
-      //BOOST_CHECK_CLOSE_FRACTION(osc_file_time, reco_signal_time, 1.f / 131072.f);
-      //BOOST_CHECK_CLOSE_FRACTION(osc_file_ampl, reco_signal_ampl, 1.f / 131072.f);
-    //}
-  //);
-//}
-//BOOST_FIXTURE_TEST_CASE (tref_correctness_test, tref_correctness_fixture) {
-  
-  //check_tref_simple(
-    //[] (const void* tref_pointer) -> void {
-      //BOOST_CHECK_PREDICATE(std::not_equal_to <size_t> (), ((size_t) tref_pointer)((size_t) nullptr));
-    //}
-  //);
-  ////check_tref_simple(nullptr);
-//}
-
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/JPetScopeParamGetter/JPetScopeParamGetter.cpp
+++ b/JPetScopeParamGetter/JPetScopeParamGetter.cpp
@@ -50,49 +50,54 @@ JPetParamBank* JPetScopeParamGetter::generateParamBank(const std::string& scopeC
   JPetScopeConfigParser parser;
   auto config = parser.getConfig(scopeConfFile);
   auto configName = config.fName;
-  if (JPetScopeParamGetter::gParamCache.find(configName) == JPetScopeParamGetter::gParamCache.end()) {
-    JPetParamBank* param_bank = new JPetParamBank();
-    for (const auto &  bslot : config.fBSlots) {
-      JPetBarrelSlot tmp(bslot.fId, bslot.fActive, bslot.fName, bslot.fTheta, bslot.fFrame);
-      param_bank->addBarrelSlot(tmp);
-    }
-    for (const auto &  pm : config.fPMs) {
-      JPetPM tmp(pm.fId);
-      param_bank->addPM(tmp);
-    }
+  JPetParamBank* returnedParamBank = 0;
+  if ( parser.areObjectsWithDuplicatedIds(config) ) {
+    ERROR("Duplicated ids has been found while parsing the configuration scope file! The param bank will not be properly initialized!");
+    //returnedParamBank = new JPetParamBank();
+  } else {
+    if (JPetScopeParamGetter::gParamCache.find(configName) == JPetScopeParamGetter::gParamCache.end()) {
+      JPetParamBank* param_bank = new JPetParamBank();
+      for (const auto &  bslot : config.fBSlots) {
+        JPetBarrelSlot tmp(bslot.fId, bslot.fActive, bslot.fName, bslot.fTheta, bslot.fFrame);
+        param_bank->addBarrelSlot(tmp);
+      }
+      for (const auto &  pm : config.fPMs) {
+        JPetPM tmp(pm.fId);
+        param_bank->addPM(tmp);
+      }
 
-    for (const auto &  scin : config.fScins) {
-      JPetScin tmp(scin.fId);
-      param_bank->addScintillator(tmp);
+      for (const auto &  scin : config.fScins) {
+        JPetScin tmp(scin.fId);
+        param_bank->addScintillator(tmp);
+      }
+
+      /**
+      * A		B
+      * PM1	PM2
+      * PM3	PM4
+      */
+      assert(config.fPMs.size() == 4);
+      (param_bank->getPM(config.fPMs[0].fId)).setSide(JPetPM::SideA);
+      (param_bank->getPM(config.fPMs[1].fId)).setSide(JPetPM::SideB);
+      (param_bank->getPM(config.fPMs[2].fId)).setSide(JPetPM::SideA);
+      (param_bank->getPM(config.fPMs[3].fId)).setSide(JPetPM::SideB);
+      assert(config.fScins.size() == 2);
+      (param_bank->getPM(config.fPMs[0].fId)).setScin(param_bank->getScintillator(config.fScins[0].fId));
+      (param_bank->getPM(config.fPMs[1].fId)).setScin(param_bank->getScintillator(config.fScins[0].fId));
+      (param_bank->getPM(config.fPMs[2].fId)).setScin(param_bank->getScintillator(config.fScins[1].fId));
+      (param_bank->getPM(config.fPMs[3].fId)).setScin(param_bank->getScintillator(config.fScins[1].fId));
+      assert(config.fBSlots.size() == 2);
+      (param_bank->getPM(config.fPMs[0].fId)).setBarrelSlot(param_bank->getBarrelSlot(config.fBSlots[0].fId));
+      (param_bank->getPM(config.fPMs[1].fId)).setBarrelSlot(param_bank->getBarrelSlot(config.fBSlots[0].fId));
+      (param_bank->getPM(config.fPMs[2].fId)).setBarrelSlot(param_bank->getBarrelSlot(config.fBSlots[1].fId));
+      (param_bank->getPM(config.fPMs[3].fId)).setBarrelSlot(param_bank->getBarrelSlot(config.fBSlots[1].fId));
+
+      (param_bank->getScintillator(config.fScins[0].fId)).setBarrelSlot(param_bank->getBarrelSlot(config.fBSlots[0].fId));
+      (param_bank->getScintillator(config.fScins[1].fId)).setBarrelSlot(param_bank->getBarrelSlot(config.fBSlots[1].fId));
+      JPetScopeParamGetter::gParamCache[configName] = param_bank;
     }
-
-    /**
-    * A		B
-    * PM1	PM2
-    * PM3	PM4
-    */
-    assert(config.fPMs.size()==4);
-    (param_bank->getPM(config.fPMs[0].fId)).setSide(JPetPM::SideA);
-    (param_bank->getPM(config.fPMs[1].fId)).setSide(JPetPM::SideB);
-    (param_bank->getPM(config.fPMs[2].fId)).setSide(JPetPM::SideA);
-    (param_bank->getPM(config.fPMs[3].fId)).setSide(JPetPM::SideB);
-    assert(config.fScins.size()==2);
-    (param_bank->getPM(config.fPMs[0].fId)).setScin(param_bank->getScintillator(config.fScins[0].fId));
-    (param_bank->getPM(config.fPMs[1].fId)).setScin(param_bank->getScintillator(config.fScins[0].fId));
-    (param_bank->getPM(config.fPMs[2].fId)).setScin(param_bank->getScintillator(config.fScins[1].fId));
-    (param_bank->getPM(config.fPMs[3].fId)).setScin(param_bank->getScintillator(config.fScins[1].fId));
-    assert(config.fBSlots.size()==2);
-    (param_bank->getPM(config.fPMs[0].fId)).setBarrelSlot(param_bank->getBarrelSlot(config.fBSlots[0].fId));
-    (param_bank->getPM(config.fPMs[1].fId)).setBarrelSlot(param_bank->getBarrelSlot(config.fBSlots[0].fId));
-    (param_bank->getPM(config.fPMs[2].fId)).setBarrelSlot(param_bank->getBarrelSlot(config.fBSlots[1].fId));
-    (param_bank->getPM(config.fPMs[3].fId)).setBarrelSlot(param_bank->getBarrelSlot(config.fBSlots[1].fId));
-
-    (param_bank->getScintillator(config.fScins[0].fId)).setBarrelSlot(param_bank->getBarrelSlot(config.fBSlots[0].fId));
-    (param_bank->getScintillator(config.fScins[1].fId)).setBarrelSlot(param_bank->getBarrelSlot(config.fBSlots[1].fId));
-    JPetScopeParamGetter::gParamCache[configName] = param_bank;
+    returnedParamBank = new JPetParamBank(*JPetScopeParamGetter::gParamCache[configName]);
   }
-  JPetParamBank* returnedParamBank = new JPetParamBank(*JPetScopeParamGetter::gParamCache[configName]);
-
   TThread::UnLock();
   return returnedParamBank;
 }

--- a/JPetTaskExecutor/JPetTaskExecutor.h
+++ b/JPetTaskExecutor/JPetTaskExecutor.h
@@ -38,7 +38,7 @@ public :
 
   bool process(); /// That was private. I made it public to run without threads.
 private:
-  void createScopeTaskAndAddToTaskList();
+  bool createScopeTaskAndAddToTaskList();
   static void* processProxy(void*);
   bool processFromCmdLineArgs(int);
   void unpackFile();

--- a/download_data.sh
+++ b/download_data.sh
@@ -7,11 +7,11 @@
 SCP_INPUT=/home/framework_configs
 SCP_OUTPUT=./DBHandler/Config
 declare -a CFG_FILES=("configDB.cfg" "configDB.cfg.koza" "ReadMe.txt")
-SERVER=koza.if.uj.edu.pl
+SERVER=sphinx.if.uj.edu.pl
 
 #for wget
 WGET_DIR="unitTestData"
-WGET_INPUT="http://koza.if.uj.edu.pl/framework/"${WGET_DIR}
+WGET_INPUT="http://sphinx.if.uj.edu.pl/framework/"${WGET_DIR}
 WGET_OUTPUT="./"
 # -r  means recursive, 
 # --cut-dirs=1 ignore given level of directories (e.g. remove framework from path) 

--- a/download_data.sh
+++ b/download_data.sh
@@ -7,11 +7,11 @@
 SCP_INPUT=/home/framework_configs
 SCP_OUTPUT=./DBHandler/Config
 declare -a CFG_FILES=("configDB.cfg" "configDB.cfg.koza" "ReadMe.txt")
-SERVER=sphinx.if.uj.edu.pl
+SERVER=koza.if.uj.edu.pl
 
 #for wget
 WGET_DIR="unitTestData"
-WGET_INPUT="http://sphinx.if.uj.edu.pl/framework/"${WGET_DIR}
+WGET_INPUT="http://koza.if.uj.edu.pl/framework/"${WGET_DIR}
 WGET_OUTPUT="./"
 # -r  means recursive, 
 # --cut-dirs=1 ignore given level of directories (e.g. remove framework from path) 


### PR DESCRIPTION
Up to now, if the scope configuration file contained e.g. two scintillators with the same ids (or PMs, or barrelSlots) the uncorrect Param Bank was generated. The method to check for the duplicated ids was added. Also, some error handlng was added.

Also, change travis settings to use sphinx server instead of koza (for securized data)