### PR TITLE
Fix of JPetReaderTest

### DIFF
--- a/JPetReader/JPetReaderTest.cpp
+++ b/JPetReader/JPetReaderTest.cpp
@@ -71,9 +71,9 @@ BOOST_AUTO_TEST_CASE (bad_file)
 
 BOOST_AUTO_TEST_CASE (good_file_with_constructor)
 {
-  JPetReader reader("unitTestData/JPetReaderTest/small.root");
+  JPetReader reader("unitTestData/JPetReaderTest/timewindows.root");
   BOOST_REQUIRE(reader.isOpen());
-  BOOST_REQUIRE(std::string(reader.getCurrentEvent().GetName())==std::string("JPetTSlot"));
+  BOOST_REQUIRE(std::string(reader.getCurrentEvent().GetName())==std::string("JPetTimeWindow"));
   BOOST_REQUIRE(reader.nextEvent());
   BOOST_REQUIRE(reader.firstEvent());
   BOOST_REQUIRE(reader.lastEvent());
@@ -85,7 +85,7 @@ BOOST_AUTO_TEST_CASE (good_file_with_constructor)
 }
 BOOST_AUTO_TEST_CASE (good_file_getObject)
 {
-  JPetReader reader("unitTestData/JPetReaderTest/small.root");
+  JPetReader reader("unitTestData/JPetReaderTest/timewindows.root");
   BOOST_REQUIRE(!reader.getObjectFromFile("nonExistentObj"));
   BOOST_REQUIRE(reader.getObjectFromFile("tree"));
 }
@@ -93,9 +93,9 @@ BOOST_AUTO_TEST_CASE (good_file_getObject)
 BOOST_AUTO_TEST_CASE (good_file_openFileAndLoadData)
 {
   JPetReader reader;
-  BOOST_REQUIRE(reader.openFileAndLoadData("unitTestData/JPetReaderTest/small.root","tree"));
+  BOOST_REQUIRE(reader.openFileAndLoadData("unitTestData/JPetReaderTest/timewindows.root","tree"));
   BOOST_REQUIRE(reader.isOpen());
-  BOOST_REQUIRE(std::string(reader.getCurrentEvent().GetName())==std::string("JPetTSlot"));
+  BOOST_REQUIRE(std::string(reader.getCurrentEvent().GetName())==std::string("JPetTimeWindow"));
   BOOST_REQUIRE(reader.firstEvent());
   BOOST_REQUIRE(reader.nextEvent());
   BOOST_REQUIRE(reader.lastEvent());
@@ -110,7 +110,7 @@ BOOST_AUTO_TEST_CASE (good_file_openFileAndLoadData)
 BOOST_AUTO_TEST_CASE (good_file_closeFile)
 {
   JPetReader reader;
-  BOOST_REQUIRE(reader.openFileAndLoadData("unitTestData/JPetReaderTest/small.root","tree"));
+  BOOST_REQUIRE(reader.openFileAndLoadData("unitTestData/JPetReaderTest/timewindows.root","tree"));
   BOOST_REQUIRE(reader.isOpen());
   reader.closeFile();
   BOOST_REQUIRE(!reader.isOpen());

--- a/JPetTimeWindow/JPetTimeWindow.h
+++ b/JPetTimeWindow/JPetTimeWindow.h
@@ -68,7 +68,7 @@ public:
 
   inline void setIndex(unsigned int index) { fIndex = index; }
 
-  ClassDef(JPetTimeWindow, 1);
+  ClassDef(JPetTimeWindow, 2);
 
 private:
   std::vector<JPetSigCh> fSigChannels; 

--- a/JPetTreeHeader/JPetTreeHeader.h
+++ b/JPetTreeHeader/JPetTreeHeader.h
@@ -93,7 +93,7 @@ protected:
   std::vector<ProcessingStageInfo> fStages;
   std::map<std::string, std::string> fDictionary;
 
-  ClassDef(JPetTreeHeader, 3);
+  ClassDef(JPetTreeHeader, 4);
 };
 
 #endif


### PR DESCRIPTION
Small fixes related to JPetReader unit tests and updated ClassDef versions.

Updated test file is available at the sphinx server but still needs to be updated at the koza server.

Travis tests passed.