### PR TITLE
JPetEvent data class.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,6 +154,7 @@ generate_root_dictionaries(DICTIONARIES SOURCES ${SOURCES}
   JPetFEB
   JPetUser
   JPetUnpacker
+  JPetEvent
   )
 add_library(JPetFramework SHARED ${SOURCES} ${HEADERS} ${DICTIONARIES})
 

--- a/JPetEvent/JPetEvent.cpp
+++ b/JPetEvent/JPetEvent.cpp
@@ -1,0 +1,72 @@
+/**
+ *  @copyright Copyright 2016 The J-PET Framework Authors. All rights reserved.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may find a copy of the License in the LICENCE file.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  @file JPetEvent.cpp
+ */
+
+#include "./JPetEvent.h"
+
+ClassImp(JPetEvent);
+
+JPetEvent::JPetEvent()
+{
+  /* */
+}
+
+JPetEvent::JPetEvent(float time, float qualityOfTime, const std::vector<JPetHit>& hits):
+  fTime(time),
+  fQualityOfTime(qualityOfTime),
+  fHits(hits)
+{
+  /* */
+}
+
+void JPetEvent::setHits(const std::vector<JPetHit>& hits)
+{
+  fHits = hits;
+}
+
+void JPetEvent::addHit(const JPetHit& hit)
+{
+  fHits.push_back(hit);
+}
+
+void JPetEvent::setTimeAndQuality(float time, float qualityOfTime)
+{
+  fTime = time;
+  fQualityOfTime = qualityOfTime;
+}
+
+const std::vector<JPetHit> JPetEvent::getHits() const
+{
+  return fHits;
+}
+
+const std::vector<JPetHit> JPetEvent::getHitsOrderedByTime() const
+{
+  auto hits = getHits();
+  std::sort(hits.begin(), hits.end(),
+  [] (const JPetHit & h1, const JPetHit & h2) {
+    return h1.getTime() < h2.getTime();
+  });
+  return hits;
+}
+
+float JPetEvent::getTime() const
+{
+  return fTime;
+}
+
+float JPetEvent::getQualityOfTime() const
+{
+  return fQualityOfTime;
+}

--- a/JPetEvent/JPetEvent.h
+++ b/JPetEvent/JPetEvent.h
@@ -1,0 +1,54 @@
+/**
+ *  @copyright Copyright 2016 The J-PET Framework Authors. All rights reserved.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may find a copy of the License in the LICENCE file.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  @file JPetEvent.h
+ *  @brief Class representing an event from a single emission.
+ */
+
+#ifndef JPETEVENT_H
+#define JPETEVENT_H
+
+#include "../JPetHit/JPetHit.h"
+#include <TNamed.h>
+#include <vector>
+
+/**
+ * @brief Data class representing an event from a single emission.
+ *
+ * An event consists of one or more  hits (JPetHit objects) registered in barel slots.
+ * The appropriate time order of the hits is not guaranteed! Special methods are provided for it.
+ */
+class JPetEvent : public TNamed
+{
+
+public:
+  JPetEvent();
+  JPetEvent(float time, float qualityOfTime, const std::vector<JPetHit>& hits);
+
+  void setHits(const std::vector<JPetHit>& hits);
+  void addHit(const JPetHit& hit);
+  void setTimeAndQuality(float time, float qualityOfTime);
+  const std::vector<JPetHit> getHits() const;
+  /// Returns the vector of hits ordered by the hit time. Ascending time.
+  const std::vector<JPetHit> getHitsOrderedByTime() const;
+  float getTime() const;
+  float getQualityOfTime() const;
+
+  ClassDef(JPetEvent, 1);
+
+private:
+  float fTime = 0.0f; ///< reconstructed absolute time of the event wrt to beginning of the run [ps]
+  float fQualityOfTime = 0.0f;
+  std::vector<JPetHit> fHits;
+
+};
+#endif /*  !JPETEVENT_H */

--- a/JPetEvent/JPetEventTest.cpp
+++ b/JPetEvent/JPetEventTest.cpp
@@ -1,0 +1,73 @@
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE JPetEventTest
+#include <boost/test/unit_test.hpp>
+
+#include "../JPetEvent/JPetEvent.h"
+
+BOOST_AUTO_TEST_SUITE(FirstSuite)
+BOOST_AUTO_TEST_CASE( default_constructor )
+{
+  JPetEvent event;
+  auto epsilon = 0.0001;
+  BOOST_REQUIRE_CLOSE(event.getTime(), 0.0f, epsilon);
+  BOOST_REQUIRE_CLOSE(event.getQualityOfTime(), 0.0f, epsilon);
+  BOOST_REQUIRE(event.getHits().empty());
+}
+
+BOOST_AUTO_TEST_CASE(constructor)
+{
+
+  JPetBarrelSlot slot1(43, true, "", 0, 43);
+  JPetBarrelSlot slot2(44, true, "", 0, 44);
+  JPetHit firstHit;
+  JPetHit secondHit;
+  firstHit.setBarrelSlot(slot1);
+  secondHit.setBarrelSlot(slot2);
+  JPetEvent event(8.5f, 4.5f, {firstHit, secondHit});
+
+  float epsilon = 0.0001f;
+  BOOST_REQUIRE_CLOSE(event.getTime(), 8.5f, epsilon);
+  BOOST_REQUIRE_CLOSE(event.getQualityOfTime(), 4.5f, epsilon);
+  BOOST_REQUIRE(!event.getHits().empty());
+  BOOST_REQUIRE_EQUAL(event.getHits().size(), 2);
+}
+
+BOOST_AUTO_TEST_CASE(TimeAndqualityOfTimeTest)
+{
+  JPetEvent event;
+  event.setTimeAndQuality(111.f, 222.f);
+  float epsilon = 0.0001f;
+  BOOST_REQUIRE_CLOSE(event.getQualityOfTime(), 222.f, epsilon);
+  BOOST_REQUIRE_CLOSE(event.getTime(), 111.f, epsilon);
+}
+
+BOOST_AUTO_TEST_CASE(addHit)
+{
+  JPetEvent event;
+  JPetHit firstHit;
+  JPetHit secondHit;
+  JPetHit thirdHit;
+  event.setHits( { firstHit, secondHit});
+  BOOST_REQUIRE(!event.getHits().empty());
+  BOOST_REQUIRE_EQUAL(event.getHits().size(), 2);
+  event.addHit(thirdHit);
+  BOOST_REQUIRE_EQUAL(event.getHits().size(), 3);
+}
+
+BOOST_AUTO_TEST_CASE(getHitsOrderedByTime)
+{
+  JPetEvent event;
+  std::vector<JPetHit> hits(4);
+  hits[0].setTime(2);
+  hits[1].setTime(1);
+  hits[2].setTime(4);
+  hits[3].setTime(3);
+  event.setHits(hits);
+  auto results = event.getHitsOrderedByTime();
+  BOOST_REQUIRE_EQUAL(results[0].getTime(), 1);
+  BOOST_REQUIRE_EQUAL(results[1].getTime(), 2);
+  BOOST_REQUIRE_EQUAL(results[2].getTime(), 3);
+  BOOST_REQUIRE_EQUAL(results[3].getTime(), 4);
+}
+BOOST_AUTO_TEST_SUITE_END()
+


### PR DESCRIPTION
PetEvent data class  should be more general than JPetLOR, because it accepts different number of hits. Added some tests, and a method that returns hits ordered by time.