### PR TITLE
Internal refactoring

### DIFF
--- a/JPetCommonTools/JPetCommonTools.h
+++ b/JPetCommonTools/JPetCommonTools.h
@@ -48,9 +48,9 @@ public:
     out << x;
     return out.str();
   }
-  
+
   static std::string doubleToString(double x);
-  
+
   static int stringToInt(const std::string& str);
 
   static bool to_bool(std::string str) {
@@ -74,8 +74,7 @@ public:
   /**
     * @brief returns the time std::string in the format dd.mm.yyyy HH:MM
     */
-  static std::string getTimeString()
-  {
+  static std::string getTimeString() {
     time_t _tm = time(NULL );
     struct tm* curtime = localtime ( &_tm );
     char buf[100];
@@ -83,23 +82,20 @@ public:
 
     return std::string( buf );
   }
-  
-  template <typename Map>
-  static bool mapComparator(Map const &lhs, Map const &rhs)
-  {
-      auto pred = [](decltype(*lhs.begin()) a, decltype(a) b)
-		      {
-			  return a.first == b.first
-			      && a.second == b.second;
-		      };
 
-      return lhs.size() == rhs.size()
-	  && std::equal(lhs.begin(), lhs.end(), rhs.begin(), pred);
+  template <typename Map>
+  static bool mapComparator(Map const& lhs, Map const& rhs) {
+    auto pred = [](decltype(*lhs.begin()) a, decltype(a) b) {
+      return a.first == b.first
+             && a.second == b.second;
+    };
+
+    return lhs.size() == rhs.size()
+           && std::equal(lhs.begin(), lhs.end(), rhs.begin(), pred);
   }
 
   ///removes the suffix of the file
-  inline static std::string stripFileNameSuffix(const std::string& filename)
-  {
+  inline static std::string stripFileNameSuffix(const std::string& filename) {
     return  boost::filesystem::change_extension(filename, "").string();
   }
   inline static std::string currentFullPath() {
@@ -115,21 +111,12 @@ public:
   }
 
   inline static std::string appendSlashToPathIfAbsent(const std::string& path) {
-    if (!path.empty() && path.back() != '/') return path +'/';
+    if (!path.empty() && path.back() != '/') return path + '/';
     else return path;
   }
-  
+
   inline static bool isDirectory( const std::string& dir) {
     return boost::filesystem::is_directory(dir);
-  }
-  
-  inline static bool unzipFile(const char* filename){
-    //system(...) is returning integer, 0 when everything went smoothly and error code when not
-    //here I just convert return value into boolean type - Sz.N.
-    if( system( ( std::string("gzip -d ") + std::string(filename) ).c_str() ) )
-      return false;
-    else
-      return true;
   }
 };
 

--- a/JPetCommonTools/JPetCommonToolsTest.cpp
+++ b/JPetCommonTools/JPetCommonToolsTest.cpp
@@ -26,7 +26,7 @@ BOOST_AUTO_TEST_CASE(findSubstringTest)
 {
   std::string str("There are two needles in this haystack with needles.");
   std::string str2("needle");
-  
+
   std::size_t found = JPetCommonTools::findSubstring(str, str2);
   BOOST_REQUIRE_EQUAL(found != std::string::npos, true);
 }
@@ -34,7 +34,7 @@ BOOST_AUTO_TEST_CASE(findSubstringTest)
 BOOST_AUTO_TEST_CASE(ItoaTest)
 {
   int testNumber = 64;
-  
+
   std::string intAsASting = JPetCommonTools::Itoa(testNumber);
   BOOST_REQUIRE_EQUAL(intAsASting == "64", true);
 }
@@ -42,7 +42,7 @@ BOOST_AUTO_TEST_CASE(ItoaTest)
 BOOST_AUTO_TEST_CASE(intToStringTest)
 {
   int testNumber = 64;
-  
+
   std::string intAsASting = JPetCommonTools::intToString(testNumber);
   BOOST_REQUIRE_EQUAL(intAsASting == "64", true);
 }
@@ -50,7 +50,7 @@ BOOST_AUTO_TEST_CASE(intToStringTest)
 BOOST_AUTO_TEST_CASE(doubleToStringTest)
 {
   double testNumber = 256.3264;
-  
+
   std::string doubleAsASting = JPetCommonTools::doubleToString(testNumber);
   BOOST_REQUIRE_EQUAL(doubleAsASting == "256.326", true);
 }
@@ -58,7 +58,7 @@ BOOST_AUTO_TEST_CASE(doubleToStringTest)
 BOOST_AUTO_TEST_CASE(stringToIntTest)
 {
   std::string testString = "1024";
-  
+
   int stringAsAInt = JPetCommonTools::stringToInt(testString);
   BOOST_REQUIRE_EQUAL(stringAsAInt == 1024, true);
 }
@@ -66,7 +66,7 @@ BOOST_AUTO_TEST_CASE(stringToIntTest)
 BOOST_AUTO_TEST_CASE(toBoolTest)
 {
   std::string testString = "0";
-  
+
   bool stringAsABool = JPetCommonTools::to_bool(testString);
   BOOST_REQUIRE_EQUAL(stringAsABool == false, true);
 }
@@ -74,7 +74,7 @@ BOOST_AUTO_TEST_CASE(toBoolTest)
 BOOST_AUTO_TEST_CASE(ifFileExistingTest)
 {
   std::string fileTest = "run_tests.pl";
-  
+
   bool ifFileExisting = JPetCommonTools::ifFileExisting(fileTest);
   BOOST_REQUIRE_EQUAL(ifFileExisting, true);
 }
@@ -88,13 +88,13 @@ BOOST_AUTO_TEST_CASE(mapAreEqualTest)
 
 BOOST_AUTO_TEST_CASE(mapAreNotEqualTest)
 {
-  std::map<char,int> first;
-  first['a']=10;
-  first['b']=30;
-  first['c']=50;
-  first['d']=70;
-  std::map<char,int> second;
-  
+  std::map<char, int> first;
+  first['a'] = 10;
+  first['b'] = 30;
+  first['c'] = 50;
+  first['d'] = 70;
+  std::map<char, int> second;
+
   bool areMapsEqual = JPetCommonTools::mapComparator(first, second);
   BOOST_REQUIRE_EQUAL(areMapsEqual, false);
 }
@@ -102,7 +102,7 @@ BOOST_AUTO_TEST_CASE(mapAreNotEqualTest)
 BOOST_AUTO_TEST_CASE(stripFileNameSuffixTest)
 {
   std::string fileTest = "run_tests.pl";
-  
+
   std::string stripFileNameSuffix = JPetCommonTools::stripFileNameSuffix(fileTest);
   BOOST_REQUIRE_EQUAL(stripFileNameSuffix == "run_tests", true);
 }
@@ -110,7 +110,7 @@ BOOST_AUTO_TEST_CASE(stripFileNameSuffixTest)
 BOOST_AUTO_TEST_CASE(currentFullPathTest)
 {
   std::string currentFullPathTest = boost::filesystem::path(boost::filesystem::current_path()).string();
-  
+
   std::string currentFullPath = JPetCommonTools::currentFullPath();
   BOOST_REQUIRE_EQUAL(currentFullPath == currentFullPathTest, true);
 }
@@ -119,7 +119,7 @@ BOOST_AUTO_TEST_CASE(extractPathFromFileTest)
 {
   std::string currentFullPathTest = boost::filesystem::path(boost::filesystem::current_path()).string();
   std::string currentFullPathTestWithFileName = currentFullPathTest + "/" + "run_tests.pl";
-  
+
   std::string result = JPetCommonTools::extractPathFromFile(currentFullPathTestWithFileName);
   BOOST_REQUIRE_EQUAL(result.compare(currentFullPathTest), 0);
 }
@@ -140,15 +140,6 @@ BOOST_AUTO_TEST_CASE(appendSlashToPathIfAbsent)
   BOOST_REQUIRE_EQUAL(JPetCommonTools::appendSlashToPathIfAbsent("test"), "test/");
 }
 
-BOOST_AUTO_TEST_CASE(tryToUnzipSomethingNotExistingFile)
-{
-  BOOST_REQUIRE(!JPetCommonTools::unzipFile("kiko.gz"));
-  std::string initialPath= boost::filesystem::path(boost::filesystem::current_path()).string();
-  initialPath = initialPath.substr(0, initialPath.find("build") );
-  std::string wrongZipPath = initialPath + "j-pet-framework/unitTestData/JPetCommonToolsTest/wrongZip.gz";
-  BOOST_REQUIRE(!JPetCommonTools::unzipFile( wrongZipPath.c_str() ));
-    
-}
 
 BOOST_AUTO_TEST_SUITE_END()
 

--- a/JPetManager/JPetManager.cpp
+++ b/JPetManager/JPetManager.cpp
@@ -16,16 +16,14 @@
 #include "./JPetManager.h"
 
 #include <cassert>
-#include <ctime>
 #include <string>
 
 #include "../JPetLoggerInclude.h"
-#include "../JPetScopeLoader/JPetScopeLoader.h"
 #include "../JPetCommonTools/JPetCommonTools.h"
 #include "../JPetCmdParser/JPetCmdParser.h"
 
-#include <TDSet.h>
 #include <TThread.h>
+#include <TDSet.h>
 
 
 
@@ -39,29 +37,31 @@ JPetManager& JPetManager::getManager()
 bool JPetManager::run()
 {
   INFO( "======== Starting processing all tasks: " + JPetCommonTools::getTimeString() + " ========\n" );
-  std::vector<JPetTaskExecutor*> executors;
+  std::vector<JPetTaskChainExecutor*> executors;
   std::vector<TThread*> threads;
-  auto i = 0;
+  auto inputDataSeq = 0;
+  /// For every input option, new TaskChainExecutor is created, which creates the chain of previously
+  /// registered tasks. The inputDataSeq is the identifier of given chain.
   for (auto opt : fOptions) {
-    JPetTaskExecutor* executor = new JPetTaskExecutor(fTaskGeneratorChain, i, opt);
+    JPetTaskChainExecutor* executor = new JPetTaskChainExecutor(fTaskGeneratorChain, inputDataSeq, opt);
     executors.push_back(executor);
-    if(!executor->process()) {
+    if (!executor->process()) {
       ERROR("While running process");
       return false;
     }
     //auto thr = executor->run();
     //if (thr) {
-      //threads.push_back(thr);
+    //threads.push_back(thr);
     //} else {
-      //ERROR("thread pointer is null");
+    //ERROR("thread pointer is null");
     //}
-    i++;
+    inputDataSeq++;
   }
   //for (auto thread : threads) {
-    //assert(thread);
-    //thread->Join();
+  //assert(thread);
+  //thread->Join();
   //}
-  for (auto& executor : executors) {
+  for (auto & executor : executors) {
     if (executor) {
       delete executor;
       executor = 0;
@@ -80,7 +80,7 @@ void JPetManager::parseCmdLine(int argc, char** argv)
 
 JPetManager::~JPetManager()
 {
-  /// delete shared caches for paramBanks  
+  /// delete shared caches for paramBanks
   /// @todo I think that should be changed
   JPetDBParamGetter::clearParamCache();
   JPetScopeParamGetter::clearParamCache();

--- a/JPetManager/JPetManager.h
+++ b/JPetManager/JPetManager.h
@@ -18,14 +18,14 @@
 #define JPETMANAGER_H
 
 #include "../JPetOptions/JPetOptions.h"
-#include "../JPetTaskExecutor/JPetTaskExecutor.h"
+#include "../JPetTaskChainExecutor/JPetTaskChainExecutor.h"
 
 /**
  * @brief Main manager of the analysis performed with the J-PET Framework.
  *
  * Each analysis program needs an instance of the JPetManager which is responsible for parsing the command line arguments
  * registering processing tasks, and
- * sending it to JPetExecutor which executes the registered tasks in threads.
+ * sending it to JPetExecutor which executes the chain of registered tasks in threads.
  */
 
 class JPetManager
@@ -47,7 +47,8 @@ private:
   JPetManager(const JPetManager&);
   void operator=(const JPetManager&);
 
-  std::vector<JPetOptions> fOptions;
-  TaskGeneratorChain* fTaskGeneratorChain;
+  std::vector<JPetOptions> fOptions; /// fOptions are input options.
+  /// Its number corresponds to the number of independent input files.
+  TaskGeneratorChain* fTaskGeneratorChain; /// fTaskGeneratorChain is a sequences of registered computing tasks.
 };
 #endif /*  !JPETMANAGER_H */

--- a/JPetOptions/JPetOptions.h
+++ b/JPetOptions/JPetOptions.h
@@ -19,8 +19,9 @@
 #include <string>
 #include <map>
 #include "../JPetCommonTools/JPetCommonTools.h"
+#include "../JPetOptionsInterface/JPetOptionsInterface.h"
 
-class JPetOptions
+class JPetOptions: public JPetOptionsInterface
 {
 
 public:
@@ -56,7 +57,7 @@ public:
     return std::stoll(fOptions.at("lastEvent"));
   }
   long long getTotalEvents() const;
-  
+
   inline int getRunNumber() const {
     return std::stoi(fOptions.at("runId"));
   }
@@ -93,7 +94,7 @@ public:
 
   void resetEventRange();
   static Options resetEventRange(const Options& srcOpts);
-  
+
 
   static  Options getDefaultOptions() {
     return kDefaultOptions;

--- a/JPetOptionsInterface/JPetOptionsInterface.h
+++ b/JPetOptionsInterface/JPetOptionsInterface.h
@@ -10,26 +10,15 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  *
- *  @file JPetTaskInterface.h
+ *  @file JPetOptionsInterface.h
  */
 
-#ifndef JPETTASKINTERFACE_H
-#define JPETTASKINTERFACE_H
+#ifndef JPETOPTIONSINTERFACE_H
+#define JPETOPTIONSINTERFACE_H
 
-#include <map>
-#include <string>
-//#include "../JPetOptionsInterface/JPetOptionsInterface.h"
-
-class JPetParamManager;
-
-class JPetTaskInterface
+class JPetOptionsInterface
 {
 public:
-  typedef std::map<std::string, std::string> Options;
-  virtual ~JPetTaskInterface() {}
-  virtual void init(const Options& options) = 0;
-  virtual void exec() = 0;
-  virtual void terminate() = 0;
-  virtual void setParamManager(JPetParamManager* paramManager) = 0;
+  virtual ~JPetOptionsInterface() {};
 };
-#endif /*  !JPETTASKINTERFACE_H */
+#endif /*  !JPETOPTIONSINTERFACE_H */

--- a/JPetReader/JPetReader.cpp
+++ b/JPetReader/JPetReader.cpp
@@ -22,7 +22,7 @@ JPetReader::JPetReader() :
   fBranch(0),
   fEvent(0),
   fTree(0),
-  fFile(0),
+  fFile(NULL),
   fCurrentEventNumber(-1)
 {/**/}
 

--- a/JPetScopeLoader/JPetScopeLoader.cpp
+++ b/JPetScopeLoader/JPetScopeLoader.cpp
@@ -77,7 +77,7 @@ void JPetScopeLoader::createInputObjects(const char* inputFileName)
 
   auto prefix2PM =  getPMPrefixToPMIdMap(config);
   std::map<std::string, int> inputScopeFiles = createInputScopeFileNames(fOptions.getScopeInputDirectory(), prefix2PM);
-  auto task = std::dynamic_pointer_cast<JPetScopeTask>(fTask);
+  auto task = dynamic_cast<JPetScopeTask*>(fTask);
   task->setInputFiles(inputScopeFiles);
 
 

--- a/JPetScopeLoader/JPetScopeLoader.cpp
+++ b/JPetScopeLoader/JPetScopeLoader.cpp
@@ -57,7 +57,7 @@ using boost::property_tree::ptree;
 
 JPetScopeLoader::JPetScopeLoader(JPetScopeTask* task): JPetTaskLoader("", "reco.sig", task)
 {
-gSystem->Load("libTree");
+  gSystem->Load("libTree");
   /**/
 }
 
@@ -77,7 +77,8 @@ void JPetScopeLoader::createInputObjects(const char* inputFileName)
 
   auto prefix2PM =  getPMPrefixToPMIdMap(config);
   std::map<std::string, int> inputScopeFiles = createInputScopeFileNames(fOptions.getScopeInputDirectory(), prefix2PM);
-  (static_cast<JPetScopeTask*>(fTask))->setInputFiles(inputScopeFiles);
+  auto task = std::dynamic_pointer_cast<JPetScopeTask>(fTask);
+  task->setInputFiles(inputScopeFiles);
 
 
   // create an object for storing histograms and counters during processing
@@ -86,7 +87,7 @@ void JPetScopeLoader::createInputObjects(const char* inputFileName)
   fHeader = new JPetTreeHeader(fOptions.getRunNumber());
   assert(fHeader);
   fHeader->setBaseFileName(fOptions.getInputFile());
-  fHeader->addStageInfo(fTask->GetName(), fTask->GetTitle(), 0, JPetCommonTools::getTimeString());
+  fHeader->addStageInfo(task->GetName(), task->GetTitle(), 0, JPetCommonTools::getTimeString());
   //fHeader->setSourcePosition((*fIter).pCollPosition);
 }
 
@@ -102,11 +103,11 @@ std::map<std::string, int> JPetScopeLoader::getPMPrefixToPMIdMap(const scope_con
 /// Returns a map of list of scope input files. The key is the corresponding
 /// index of the photomultiplier in the param bank.
 std::map<std::string, int> JPetScopeLoader::createInputScopeFileNames(
-                                       const std::string& inputPathToScopeFiles,
-                                       std::map<std::string, int> pmPref2Id
-                                     ) const
+  const std::string& inputPathToScopeFiles,
+  std::map<std::string, int> pmPref2Id
+) const
 {
-  for (auto el:pmPref2Id){
+  for (auto el : pmPref2Id) {
   }
   std::map<std::string, int> scopeFiles;
   path current_dir(inputPathToScopeFiles);
@@ -171,7 +172,7 @@ void JPetScopeLoader::terminate()
   assert(fStatistics);
   fWriter->writeHeader(fHeader);
   fWriter->writeObject(fStatistics->getHistogramsTable(), "Stats");
-   //store the parametric objects in the ouptut ROOT file
+  //store the parametric objects in the ouptut ROOT file
   getParamManager().saveParametersToFile(fWriter);
   getParamManager().clearParameters();
   fWriter->closeFile();

--- a/JPetTask/JPetTask.h
+++ b/JPetTask/JPetTask.h
@@ -16,6 +16,8 @@
 #ifndef JPETTASK_H
 #define JPETTASK_H
 #include "../JPetTaskInterface/JPetTaskInterface.h"
+#include "../JPetTaskRunnerInterface/JPetTaskRunnerInterface.h"
+//#include "../JPetTaskInterfaceTmp/JPetTaskInterfaceTmp.h"
 #include "../JPetParamBank/JPetParamBank.h"
 #include "../JPetStatistics/JPetStatistics.h"
 #include "../JPetAuxilliaryData/JPetAuxilliaryData.h"
@@ -31,7 +33,6 @@ public:
   virtual void init(const JPetTaskInterface::Options&);
   virtual void exec();
   virtual void terminate();
-  virtual void addSubTask(JPetTaskInterface*) {};
   virtual void setParamManager(JPetParamManager* paramManager);
   virtual void setStatistics(JPetStatistics* statistics);
   virtual void setAuxilliaryData(JPetAuxilliaryData* auxData);

--- a/JPetTask/JPetTask.h
+++ b/JPetTask/JPetTask.h
@@ -28,10 +28,10 @@ class JPetTask: public JPetTaskInterface
 {
 public:
   JPetTask(const char* name = "", const char* description = "");
-  virtual void init(const JPetTaskInterface::Options&);
-  virtual void exec();
-  virtual void terminate();
-  virtual void setParamManager(JPetParamManager* paramManager);
+  virtual void init (const JPetTaskInterface::Options&) override;
+  virtual void exec() override;
+  virtual void terminate() override;
+  virtual void setParamManager(JPetParamManager* paramManager) override;
   virtual void setStatistics(JPetStatistics* statistics);
   virtual void setAuxilliaryData(JPetAuxilliaryData* auxData);
   virtual void setWriter(JPetWriter*) {};

--- a/JPetTask/JPetTask.h
+++ b/JPetTask/JPetTask.h
@@ -16,8 +16,6 @@
 #ifndef JPETTASK_H
 #define JPETTASK_H
 #include "../JPetTaskInterface/JPetTaskInterface.h"
-#include "../JPetTaskRunnerInterface/JPetTaskRunnerInterface.h"
-//#include "../JPetTaskInterfaceTmp/JPetTaskInterfaceTmp.h"
 #include "../JPetParamBank/JPetParamBank.h"
 #include "../JPetStatistics/JPetStatistics.h"
 #include "../JPetAuxilliaryData/JPetAuxilliaryData.h"

--- a/JPetTask/JPetTask.h
+++ b/JPetTask/JPetTask.h
@@ -16,6 +16,8 @@
 #ifndef JPETTASK_H
 #define JPETTASK_H
 #include "../JPetTaskInterface/JPetTaskInterface.h"
+#include "../JPetTaskRunnerInterface/JPetTaskRunnerInterface.h"
+//#include "../JPetTaskInterfaceTmp/JPetTaskInterfaceTmp.h"
 #include "../JPetParamBank/JPetParamBank.h"
 #include "../JPetStatistics/JPetStatistics.h"
 #include "../JPetAuxilliaryData/JPetAuxilliaryData.h"

--- a/JPetTaskChainExecutor/JPetTaskChainExecutor.cpp
+++ b/JPetTaskChainExecutor/JPetTaskChainExecutor.cpp
@@ -16,25 +16,27 @@
 #include "JPetTaskChainExecutor.h"
 #include <cassert>
 #include "../JPetTaskInterface/JPetTaskInterface.h"
+#include "../JPetScopeLoader/JPetScopeLoader.h"
+#include "../JPetTaskLoader/JPetTaskLoader.h"
 #include "../JPetParamGetterAscii/JPetParamGetterAscii.h"
 #include "../JPetParamGetterAscii/JPetParamSaverAscii.h"
 #include "../JPetLoggerInclude.h"
-#include "JPetTaskChainExecutorUtils.h"
-#include <memory>
 
 
 JPetTaskChainExecutor::JPetTaskChainExecutor(TaskGeneratorChain* taskGeneratorChain, int processedFileId, JPetOptions opt) :
   fInputSeqId(processedFileId),
-  fParamManager(0),
   ftaskGeneratorChain(taskGeneratorChain),
   fOptions(opt)
 {
-  fParamManager = JPetTaskChainExecutorUtils::generateParamManager(fOptions);
+  if (fOptions.isLocalDB()) {
+    fParamManager = new JPetParamManager(new JPetParamGetterAscii(fOptions.getLocalDB()));
+  } else {
+    fParamManager = new JPetParamManager();
+  }
   if (taskGeneratorChain) {
     for (auto taskGenerator : *ftaskGeneratorChain) {
       auto task = taskGenerator();
-      ///@todo change it
-      (dynamic_cast<JPetTaskIO*>(task))->setParamManager(fParamManager);
+      task->setParamManager(fParamManager); // maybe that should not be here
       fTasks.push_back(task);
     }
   } else {
@@ -42,16 +44,10 @@ JPetTaskChainExecutor::JPetTaskChainExecutor(TaskGeneratorChain* taskGeneratorCh
   }
 }
 
-bool JPetTaskChainExecutor::preprocessing(const JPetOptions& options, JPetParamManager* manager, std::list<JPetTaskRunnerInterface*>& tasks)
-{
-  JPetTaskChainExecutorUtils utils;
-  return utils.process(options, manager, tasks);
-}
-
 bool JPetTaskChainExecutor::process()
 {
-  if (!preprocessing(fOptions, fParamManager, fTasks)) {
-    ERROR("Error in preprocessing");
+  if (!processFromCmdLineArgs()) {
+    ERROR("Error in processFromCmdLineArgs");
     return false;
   }
   for (auto currentTask = fTasks.begin(); currentTask != fTasks.end(); currentTask++) {
@@ -68,16 +64,12 @@ bool JPetTaskChainExecutor::process()
         currOpts.at("inputFile") = outPath + JPetCommonTools::extractPathFromFile(currOpts.at("inputFile")) + JPetCommonTools::extractFileNameFromFullPath(currOpts.at("inputFile"));
       }
     }
-    auto taskCurr = dynamic_cast<JPetTask*> (dynamic_cast<JPetTaskLoader*>(*currentTask)->getTask());
-    //auto taskCurr = std::dynamic_pointer_cast<JPetTask>((*currentTask)->getTask());
-    auto taskName = taskCurr->GetName();
-    INFO(Form("Starting task: %s", taskName));
-    /// @todo fix it
-    auto taskRunnerCurr =  dynamic_cast<JPetTaskIO*> (*currentTask);
-    taskRunnerCurr->init(currOpts);
-    taskRunnerCurr->exec();
-    taskRunnerCurr->terminate();
-    INFO(Form("Finished task: %s", taskName));
+
+    INFO(Form("Starting task: %s", dynamic_cast<JPetTaskLoader*>(*currentTask)->getSubTask()->GetName()));
+    (*currentTask)->init(currOpts);
+    (*currentTask)->exec();
+    (*currentTask)->terminate();
+    INFO(Form("Finished task: %s", dynamic_cast<JPetTaskLoader*>(*currentTask)->getSubTask()->GetName()));
   }
   return true;
 }
@@ -97,6 +89,74 @@ TThread* JPetTaskChainExecutor::run()
   return thread;
 }
 
+bool JPetTaskChainExecutor::processFromCmdLineArgs()
+{
+  auto runNum = fOptions.getRunNumber();
+  if (runNum >= 0) {
+    try {
+      fParamManager->fillParameterBank(runNum);
+    } catch (...) {
+      ERROR("Param bank was not generated correctly.\n The run number used:" + JPetCommonTools::intToString(runNum));
+      return false;
+    }
+    if (fOptions.isLocalDBCreate()) {
+      JPetParamSaverAscii saver;
+      saver.saveParamBank(fParamManager->getParamBank(), runNum, fOptions.getLocalDBCreate());
+    }
+  }
+
+  auto inputFileType = fOptions.getInputFileType();
+  auto inputFile = fOptions.getInputFile();
+  if (inputFileType == JPetOptions::kScope) {
+    if (!createScopeTaskAndAddToTaskList()) {
+      ERROR("Scope task not added correctly!!!");
+      return false;
+    }
+  } else if (inputFileType == JPetOptions::kHld) {
+    long long nevents = fOptions.getTotalEvents();
+    unpackFile(inputFile, nevents);
+  }
+  //Assumption that only HLD files can be zipped!!!!!! - Sz.N.
+  else if ( inputFileType == JPetOptions::kZip) {
+    INFO( std::string("Unzipping file before unpacking") );
+    if ( !JPetCommonTools::unzipFile(inputFile) )
+      ERROR( std::string("Problem with unpacking file: ") + inputFile );
+    long long nevents = fOptions.getTotalEvents();
+    INFO( std::string("Unpacking") );
+    unpackFile( JPetCommonTools::stripFileNameSuffix( std::string(inputFile) ).c_str(), nevents);
+  }
+
+  if (fOptions.getInputFileType() == JPetOptions::kUndefinedFileType)
+    ERROR( Form("Unknown file type provided for file: %s", fOptions.getInputFile()) );
+
+  return true;
+}
+
+bool JPetTaskChainExecutor::createScopeTaskAndAddToTaskList()
+{
+  JPetScopeLoader* module = new JPetScopeLoader(new JPetScopeTask("JPetScopeReader", "Process Oscilloscope ASCII data into JPetRecoSignal structures."));
+  assert(module);
+  module->setParamManager(fParamManager);
+  auto scopeFile = fOptions.getScopeConfigFile();
+  if (!fParamManager->getParametersFromScopeConfig(scopeFile)) {
+    ERROR("Unable to generate Param Bank from Scope Config");
+    return false;
+  }
+  fTasks.push_front(module);
+  return true;
+}
+
+void JPetTaskChainExecutor::unpackFile(const char* filename, const long long nevents)
+{
+  if (nevents > 0) {
+    fUnpacker.setParams( filename, nevents);
+    WARNING(std::string("Even though the range of events was set, only the first ") + JPetCommonTools::intToString(nevents) + std::string(" will be unpacked by the unpacker. \n The unpacker always starts from the beginning of the file."));
+  } else {
+    fUnpacker.setParams( filename );
+  }
+  fUnpacker.exec();
+}
+
 JPetTaskChainExecutor::~JPetTaskChainExecutor()
 {
   for (auto & task : fTasks) {
@@ -106,4 +166,3 @@ JPetTaskChainExecutor::~JPetTaskChainExecutor()
     }
   }
 }
-

--- a/JPetTaskChainExecutor/JPetTaskChainExecutor.cpp
+++ b/JPetTaskChainExecutor/JPetTaskChainExecutor.cpp
@@ -36,7 +36,8 @@ JPetTaskChainExecutor::JPetTaskChainExecutor(TaskGeneratorChain* taskGeneratorCh
   if (taskGeneratorChain) {
     for (auto taskGenerator : *ftaskGeneratorChain) {
       auto task = taskGenerator();
-      task->setParamManager(fParamManager); // maybe that should not be here
+      ///@todo change it
+      (dynamic_cast<JPetTaskIO*>(task))->setParamManager(fParamManager);
       fTasks.push_back(task);
     }
   } else {
@@ -67,9 +68,11 @@ bool JPetTaskChainExecutor::process()
     auto taskCurr = dynamic_cast<JPetTask*> (dynamic_cast<JPetTaskLoader*>(*currentTask)->getTask());
     auto taskName = taskCurr->GetName();
     INFO(Form("Starting task: %s", taskName));
-    (*currentTask)->init(currOpts);
-    (*currentTask)->exec();
-    (*currentTask)->terminate();
+    /// @todo fix it
+    auto taskRunnerCurr =  dynamic_cast<JPetTaskIO*> (*currentTask);
+    taskRunnerCurr->init(currOpts);
+    taskRunnerCurr->exec();
+    taskRunnerCurr->terminate();
     INFO(Form("Finished task: %s", taskName));
   }
   return true;

--- a/JPetTaskChainExecutor/JPetTaskChainExecutor.cpp
+++ b/JPetTaskChainExecutor/JPetTaskChainExecutor.cpp
@@ -10,10 +10,10 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  *
- *  @file JPetTaskExecutor.cpp
+ *  @file JPetTaskChainExecutor.cpp
  */
 
-#include "JPetTaskExecutor.h"
+#include "JPetTaskChainExecutor.h"
 #include <cassert>
 #include "../JPetTaskInterface/JPetTaskInterface.h"
 #include "../JPetScopeLoader/JPetScopeLoader.h"
@@ -23,8 +23,8 @@
 #include "../JPetLoggerInclude.h"
 
 
-JPetTaskExecutor::JPetTaskExecutor(TaskGeneratorChain* taskGeneratorChain, int processedFileId, JPetOptions opt) :
-  fProcessedFile(processedFileId),
+JPetTaskChainExecutor::JPetTaskChainExecutor(TaskGeneratorChain* taskGeneratorChain, int processedFileId, JPetOptions opt) :
+  fInputSeqId(processedFileId),
   ftaskGeneratorChain(taskGeneratorChain),
   fOptions(opt)
 {
@@ -40,13 +40,13 @@ JPetTaskExecutor::JPetTaskExecutor(TaskGeneratorChain* taskGeneratorChain, int p
       fTasks.push_back(task);
     }
   } else {
-    ERROR("taskGeneratorChain is null while constructing JPetTaskExecutor");
+    ERROR("taskGeneratorChain is null while constructing JPetTaskChainExecutor");
   }
 }
 
-bool JPetTaskExecutor::process()
+bool JPetTaskChainExecutor::process()
 {
-  if (!processFromCmdLineArgs(fProcessedFile)) {
+  if (!processFromCmdLineArgs()) {
     ERROR("Error in processFromCmdLineArgs");
     return false;
   }
@@ -74,22 +74,22 @@ bool JPetTaskExecutor::process()
   return true;
 }
 
-void* JPetTaskExecutor::processProxy(void* runner)
+void* JPetTaskChainExecutor::processProxy(void* runner)
 {
   assert(runner);
-  static_cast<JPetTaskExecutor*>(runner)->process();
+  static_cast<JPetTaskChainExecutor*>(runner)->process();
   return 0;
 }
 
-TThread* JPetTaskExecutor::run()
+TThread* JPetTaskChainExecutor::run()
 {
-  TThread* thread = new TThread(std::to_string(fProcessedFile).c_str(), processProxy, (void*)this);
+  TThread* thread = new TThread(to_string(fInputSeqId).c_str(), processProxy, (void*)this);
   assert(thread);
   thread->Run();
   return thread;
 }
 
-bool JPetTaskExecutor::processFromCmdLineArgs(int)
+bool JPetTaskChainExecutor::processFromCmdLineArgs()
 {
   auto runNum = fOptions.getRunNumber();
   if (runNum >= 0) {
@@ -104,7 +104,7 @@ bool JPetTaskExecutor::processFromCmdLineArgs(int)
       saver.saveParamBank(fParamManager->getParamBank(), runNum, fOptions.getLocalDBCreate());
     }
   }
-  
+
   auto inputFileType = fOptions.getInputFileType();
   auto inputFile = fOptions.getInputFile();
   if (inputFileType == JPetOptions::kScope) {
@@ -117,22 +117,22 @@ bool JPetTaskExecutor::processFromCmdLineArgs(int)
     unpackFile(inputFile, nevents);
   }
   //Assumption that only HLD files can be zipped!!!!!! - Sz.N.
-  else if( inputFileType == JPetOptions::kZip){
+  else if ( inputFileType == JPetOptions::kZip) {
     INFO( std::string("Unzipping file before unpacking") );
-    if( !JPetCommonTools::unzipFile(inputFile) )
+    if ( !JPetCommonTools::unzipFile(inputFile) )
       ERROR( std::string("Problem with unpacking file: ") + inputFile );
     long long nevents = fOptions.getTotalEvents();
     INFO( std::string("Unpacking") );
-    unpackFile( JPetCommonTools::stripFileNameSuffix( std::string(inputFile) ).c_str(), nevents);    
+    unpackFile( JPetCommonTools::stripFileNameSuffix( std::string(inputFile) ).c_str(), nevents);
   }
-  
-  if(fOptions.getInputFileType() == JPetOptions::kUndefinedFileType)
+
+  if (fOptions.getInputFileType() == JPetOptions::kUndefinedFileType)
     ERROR( Form("Unknown file type provided for file: %s", fOptions.getInputFile()) );
-  
+
   return true;
 }
 
-bool JPetTaskExecutor::createScopeTaskAndAddToTaskList()
+bool JPetTaskChainExecutor::createScopeTaskAndAddToTaskList()
 {
   JPetScopeLoader* module = new JPetScopeLoader(new JPetScopeTask("JPetScopeReader", "Process Oscilloscope ASCII data into JPetRecoSignal structures."));
   assert(module);
@@ -146,19 +146,18 @@ bool JPetTaskExecutor::createScopeTaskAndAddToTaskList()
   return true;
 }
 
-void JPetTaskExecutor::unpackFile(const char* filename, const long long nevents)
+void JPetTaskChainExecutor::unpackFile(const char* filename, const long long nevents)
 {
-    if (nevents > 0) {
-      fUnpacker.setParams( filename, nevents);
-      WARNING(std::string("Even though the range of events was set, only the first ") + JPetCommonTools::intToString(nevents) + std::string(" will be unpacked by the unpacker. \n The unpacker always starts from the beginning of the file."));
-    } else {
-      fUnpacker.setParams( filename );
-    }
-    fUnpacker.exec();
+  if (nevents > 0) {
+    fUnpacker.setParams( filename, nevents);
+    WARNING(std::string("Even though the range of events was set, only the first ") + JPetCommonTools::intToString(nevents) + std::string(" will be unpacked by the unpacker. \n The unpacker always starts from the beginning of the file."));
+  } else {
+    fUnpacker.setParams( filename );
+  }
+  fUnpacker.exec();
 }
 
-
-JPetTaskExecutor::~JPetTaskExecutor()
+JPetTaskChainExecutor::~JPetTaskChainExecutor()
 {
   for (auto & task : fTasks) {
     if (task) {

--- a/JPetTaskChainExecutor/JPetTaskChainExecutor.cpp
+++ b/JPetTaskChainExecutor/JPetTaskChainExecutor.cpp
@@ -64,12 +64,13 @@ bool JPetTaskChainExecutor::process()
         currOpts.at("inputFile") = outPath + JPetCommonTools::extractPathFromFile(currOpts.at("inputFile")) + JPetCommonTools::extractFileNameFromFullPath(currOpts.at("inputFile"));
       }
     }
-
-    INFO(Form("Starting task: %s", dynamic_cast<JPetTaskLoader*>(*currentTask)->getSubTask()->GetName()));
+    auto taskCurr = dynamic_cast<JPetTask*> (dynamic_cast<JPetTaskLoader*>(*currentTask)->getTask());
+    auto taskName = taskCurr->GetName();
+    INFO(Form("Starting task: %s", taskName));
     (*currentTask)->init(currOpts);
     (*currentTask)->exec();
     (*currentTask)->terminate();
-    INFO(Form("Finished task: %s", dynamic_cast<JPetTaskLoader*>(*currentTask)->getSubTask()->GetName()));
+    INFO(Form("Finished task: %s", taskName));
   }
   return true;
 }

--- a/JPetTaskChainExecutor/JPetTaskChainExecutor.cpp
+++ b/JPetTaskChainExecutor/JPetTaskChainExecutor.cpp
@@ -24,14 +24,11 @@
 
 JPetTaskChainExecutor::JPetTaskChainExecutor(TaskGeneratorChain* taskGeneratorChain, int processedFileId, JPetOptions opt) :
   fInputSeqId(processedFileId),
+  fParamManager(0),
   ftaskGeneratorChain(taskGeneratorChain),
   fOptions(opt)
 {
-  if (fOptions.isLocalDB()) {
-    fParamManager = new JPetParamManager(new JPetParamGetterAscii(fOptions.getLocalDB()));
-  } else {
-    fParamManager = new JPetParamManager();
-  }
+  fParamManager = JPetTaskChainExecutorUtils::generateParamManager(fOptions);
   if (taskGeneratorChain) {
     for (auto taskGenerator : *ftaskGeneratorChain) {
       auto task = taskGenerator();
@@ -107,3 +104,4 @@ JPetTaskChainExecutor::~JPetTaskChainExecutor()
     }
   }
 }
+

--- a/JPetTaskChainExecutor/JPetTaskChainExecutor.cpp
+++ b/JPetTaskChainExecutor/JPetTaskChainExecutor.cpp
@@ -20,6 +20,7 @@
 #include "../JPetParamGetterAscii/JPetParamSaverAscii.h"
 #include "../JPetLoggerInclude.h"
 #include "JPetTaskChainExecutorUtils.h"
+#include <memory>
 
 
 JPetTaskChainExecutor::JPetTaskChainExecutor(TaskGeneratorChain* taskGeneratorChain, int processedFileId, JPetOptions opt) :
@@ -67,7 +68,8 @@ bool JPetTaskChainExecutor::process()
         currOpts.at("inputFile") = outPath + JPetCommonTools::extractPathFromFile(currOpts.at("inputFile")) + JPetCommonTools::extractFileNameFromFullPath(currOpts.at("inputFile"));
       }
     }
-    auto taskCurr = dynamic_cast<JPetTask*> (dynamic_cast<JPetTaskLoader*>(*currentTask)->getTask());
+    //auto taskCurr = dynamic_cast<JPetTask*> (dynamic_cast<JPetTaskLoader*>(*currentTask)->getTask());
+    auto taskCurr = std::dynamic_pointer_cast<JPetTask>((*currentTask)->getTask());
     auto taskName = taskCurr->GetName();
     INFO(Form("Starting task: %s", taskName));
     /// @todo fix it

--- a/JPetTaskChainExecutor/JPetTaskChainExecutor.cpp
+++ b/JPetTaskChainExecutor/JPetTaskChainExecutor.cpp
@@ -68,8 +68,8 @@ bool JPetTaskChainExecutor::process()
         currOpts.at("inputFile") = outPath + JPetCommonTools::extractPathFromFile(currOpts.at("inputFile")) + JPetCommonTools::extractFileNameFromFullPath(currOpts.at("inputFile"));
       }
     }
-    //auto taskCurr = dynamic_cast<JPetTask*> (dynamic_cast<JPetTaskLoader*>(*currentTask)->getTask());
-    auto taskCurr = std::dynamic_pointer_cast<JPetTask>((*currentTask)->getTask());
+    auto taskCurr = dynamic_cast<JPetTask*> (dynamic_cast<JPetTaskLoader*>(*currentTask)->getTask());
+    //auto taskCurr = std::dynamic_pointer_cast<JPetTask>((*currentTask)->getTask());
     auto taskName = taskCurr->GetName();
     INFO(Form("Starting task: %s", taskName));
     /// @todo fix it

--- a/JPetTaskChainExecutor/JPetTaskChainExecutor.cpp
+++ b/JPetTaskChainExecutor/JPetTaskChainExecutor.cpp
@@ -91,7 +91,7 @@ void* JPetTaskChainExecutor::processProxy(void* runner)
 
 TThread* JPetTaskChainExecutor::run()
 {
-  TThread* thread = new TThread(to_string(fInputSeqId).c_str(), processProxy, (void*)this);
+  TThread* thread = new TThread(std::to_string(fInputSeqId).c_str(), processProxy, (void*)this);
   assert(thread);
   thread->Run();
   return thread;

--- a/JPetTaskChainExecutor/JPetTaskChainExecutor.h
+++ b/JPetTaskChainExecutor/JPetTaskChainExecutor.h
@@ -10,11 +10,11 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  *
- *  @file JPetTaskExecutor.h
+ *  @file JPetTaskChainExecutor.h
  */
 
-#ifndef FRAMEWORK_JPETTASKEXECUTOR_H
-#define FRAMEWORK_JPETTASKEXECUTOR_H
+#ifndef FRAMEWORK_JPETTASCHAINKEXECUTOR_H
+#define FRAMEWORK_JPETTASKCHAINEXECUTOR_H
 
 #include <list>
 #include <TThread.h>
@@ -28,21 +28,25 @@ class JPetTaskInterface;
 using TaskGenerator = std::function< JPetTaskInterface* () >;
 using TaskGeneratorChain = std::vector<TaskGenerator>;
 
-
-class JPetTaskExecutor
+/**
+ * JPetTaskChainExecutor generates the previously registered chain of tasks.
+ * One chain can be run as a thread independently
+ */
+class JPetTaskChainExecutor
 {
 public :
-  JPetTaskExecutor(TaskGeneratorChain* taskGeneratorChain, int processedFile, JPetOptions opts);
+  JPetTaskChainExecutor(TaskGeneratorChain* taskGeneratorChain, int processedFile, JPetOptions opts);
   TThread* run();
-  virtual ~JPetTaskExecutor();
+  virtual ~JPetTaskChainExecutor();
 
   bool process(); /// That was private. I made it public to run without threads.
 private:
   bool createScopeTaskAndAddToTaskList();
   static void* processProxy(void*);
-  bool processFromCmdLineArgs(int);
+  bool processFromCmdLineArgs();
   void unpackFile(const char* filename, const long long nevents);
-  int fProcessedFile;
+
+  int fInputSeqId;
   JPetParamManager* fParamManager;
   JPetUnpacker fUnpacker;
   std::list<JPetTaskInterface*> fTasks;
@@ -51,4 +55,4 @@ private:
 };
 
 
-#endif //FRAMEWORK_JPETTASKEXECUTOR_H
+#endif //FRAMEWORK_JPETTASCHAINKEXECUTOR_H

--- a/JPetTaskChainExecutor/JPetTaskChainExecutor.h
+++ b/JPetTaskChainExecutor/JPetTaskChainExecutor.h
@@ -24,8 +24,10 @@
 #include "../JPetUnpacker/JPetUnpacker.h"
 #include "../JPetOptions/JPetOptions.h"
 
-class JPetTaskInterface;
-using TaskGenerator = std::function< JPetTaskInterface* () >;
+#include "../JPetTaskRunnerInterface/JPetTaskRunnerInterface.h"
+//class JPetTaskInterface;
+//using TaskGenerator = std::function< JPetTaskInterface* () >;
+using TaskGenerator = std::function< JPetTaskRunnerInterface* () >;
 using TaskGeneratorChain = std::vector<TaskGenerator>;
 
 /**
@@ -49,7 +51,8 @@ private:
   int fInputSeqId;
   JPetParamManager* fParamManager;
   JPetUnpacker fUnpacker;
-  std::list<JPetTaskInterface*> fTasks;
+  //std::list<JPetTaskInterface*> fTasks;
+  std::list<JPetTaskRunnerInterface*> fTasks;
   TaskGeneratorChain* ftaskGeneratorChain;
   JPetOptions fOptions;
 };

--- a/JPetTaskChainExecutor/JPetTaskChainExecutor.h
+++ b/JPetTaskChainExecutor/JPetTaskChainExecutor.h
@@ -21,12 +21,9 @@
 #include <functional> // for TaskGenerator declaration
 #include <vector> // for TaskGeneratorChain declaration
 #include "../JPetParamManager/JPetParamManager.h"
-#include "../JPetUnpacker/JPetUnpacker.h"
 #include "../JPetOptions/JPetOptions.h"
 
 #include "../JPetTaskRunnerInterface/JPetTaskRunnerInterface.h"
-//class JPetTaskInterface;
-//using TaskGenerator = std::function< JPetTaskInterface* () >;
 using TaskGenerator = std::function< JPetTaskRunnerInterface* () >;
 using TaskGeneratorChain = std::vector<TaskGenerator>;
 
@@ -43,15 +40,11 @@ public :
 
   bool process(); /// That was private. I made it public to run without threads.
 private:
-  bool createScopeTaskAndAddToTaskList();
   static void* processProxy(void*);
-  bool processFromCmdLineArgs();
-  void unpackFile(const char* filename, const long long nevents);
+  bool preprocessing(const JPetOptions& options, JPetParamManager* manager, std::list<JPetTaskRunnerInterface*>& tasks);
 
   int fInputSeqId;
   JPetParamManager* fParamManager;
-  JPetUnpacker fUnpacker;
-  //std::list<JPetTaskInterface*> fTasks;
   std::list<JPetTaskRunnerInterface*> fTasks;
   TaskGeneratorChain* ftaskGeneratorChain;
   JPetOptions fOptions;

--- a/JPetTaskChainExecutor/JPetTaskChainExecutorUtils.cpp
+++ b/JPetTaskChainExecutor/JPetTaskChainExecutorUtils.cpp
@@ -88,8 +88,7 @@ void JPetTaskChainExecutorUtils::unpackFile(const char* filename, long long neve
   } else {
     unpacker.setParams(filename);
   }
-<<<<<<< HEAD
-  unpacker.exec();
+    unpacker.exec();
 }
 
 JPetParamManager* JPetTaskChainExecutorUtils::generateParamManager(const JPetOptions& options)
@@ -100,9 +99,3 @@ JPetParamManager* JPetTaskChainExecutorUtils::generateParamManager(const JPetOpt
     return new JPetParamManager();
   }
 }
-=======
-    unpacker.exec();
-}
-
-
->>>>>>> Add JPeTaskChainExecutorUtils

--- a/JPetTaskChainExecutor/JPetTaskChainExecutorUtils.cpp
+++ b/JPetTaskChainExecutor/JPetTaskChainExecutorUtils.cpp
@@ -35,6 +35,7 @@ bool JPetTaskChainExecutorUtils::process(const JPetOptions& options, JPetParamMa
       saver.saveParamBank(paramMgr->getParamBank(), runNum, options.getLocalDBCreate());
     }
   }
+  auto inputFile = options.getInputFile();
   auto inputFileType = options.getInputFileType();
   if (inputFileType == JPetOptions::kScope) {
     if (!createScopeTaskAndAddToTaskList(options, paramMgr, tasks)) {
@@ -43,19 +44,19 @@ bool JPetTaskChainExecutorUtils::process(const JPetOptions& options, JPetParamMa
     }
   } else if (inputFileType == JPetOptions::kHld) {
     unpackFile(inputFile, options.getTotalEvents());
-  } 
-    /// Assumption that if the file is zipped than it is in the hld format
-    /// and we will also unpack if from hld  after unzipping.
-    else if ( inputFileType == JPetOptions::kZip) {
-      INFO( std::string("Unzipping file before unpacking") );
-      if ( !JPetCommonTools::unzipFile(inputFile) ) {
-        ERROR( std::string("Problem with unpacking file: ") + inputFile );
-        return false; 
-      } else {
-        INFO( std::string("Unpacking") );
-        auto unzippedFilename = JPetCommonTools::stripFileNameSuffix(std::string(inputFile)).c_str();
-        unpackFile(unzippedFilename, options.getTotalEvents());
-      }
+  }
+  /// Assumption that if the file is zipped than it is in the hld format
+  /// and we will also unpack if from hld  after unzipping.
+  else if ( inputFileType == JPetOptions::kZip) {
+    INFO( std::string("Unzipping file before unpacking") );
+    if ( !JPetCommonTools::unzipFile(inputFile) ) {
+      ERROR( std::string("Problem with unpacking file: ") + inputFile );
+      return false;
+    } else {
+      INFO( std::string("Unpacking") );
+      auto unzippedFilename = JPetCommonTools::stripFileNameSuffix(std::string(inputFile)).c_str();
+      unpackFile(unzippedFilename, options.getTotalEvents());
+    }
   }
 
   if (options.getInputFileType() == JPetOptions::kUndefinedFileType)
@@ -87,7 +88,7 @@ void JPetTaskChainExecutorUtils::unpackFile(const char* filename, long long neve
   } else {
     unpacker.setParams(filename);
   }
-    unpacker.exec();
+  unpacker.exec();
 }
 
 JPetParamManager* JPetTaskChainExecutorUtils::generateParamManager(const JPetOptions& options)

--- a/JPetTaskChainExecutor/JPetTaskChainExecutorUtils.cpp
+++ b/JPetTaskChainExecutor/JPetTaskChainExecutorUtils.cpp
@@ -88,7 +88,7 @@ void JPetTaskChainExecutorUtils::unpackFile(const char* filename, long long neve
   } else {
     unpacker.setParams(filename);
   }
-    unpacker.exec();
+  unpacker.exec();
 }
 
 JPetParamManager* JPetTaskChainExecutorUtils::generateParamManager(const JPetOptions& options)

--- a/JPetTaskChainExecutor/JPetTaskChainExecutorUtils.cpp
+++ b/JPetTaskChainExecutor/JPetTaskChainExecutorUtils.cpp
@@ -49,7 +49,7 @@ bool JPetTaskChainExecutorUtils::process(const JPetOptions& options, JPetParamMa
   /// and we will also unpack if from hld  after unzipping.
   else if ( inputFileType == JPetOptions::kZip) {
     INFO( std::string("Unzipping file before unpacking") );
-    if ( !JPetCommonTools::unzipFile(inputFile) ) {
+    if ( !unzipFile(inputFile) ) {
       ERROR( std::string("Problem with unpacking file: ") + inputFile );
       return false;
     } else {

--- a/JPetTaskChainExecutor/JPetTaskChainExecutorUtils.cpp
+++ b/JPetTaskChainExecutor/JPetTaskChainExecutorUtils.cpp
@@ -1,0 +1,94 @@
+/**
+ *  @copyright Copyright 2016 The J-PET Framework Authors. All rights reserved.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may find a copy of the License in the LICENCE file.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  @file JPetTaskChainExecutorUtils.cpp
+ */
+
+#include <cassert>
+#include "./JPetTaskChainExecutorUtils.h"
+#include "../JPetTaskLoader/JPetTaskLoader.h"
+#include "../JPetParamGetterAscii/JPetParamGetterAscii.h"
+#include "../JPetParamGetterAscii/JPetParamSaverAscii.h"
+
+bool JPetTaskChainExecutorUtils::process(const JPetOptions& options, JPetParamManager* paramMgr, std::list<JPetTaskRunnerInterface*>& tasks)
+{
+  assert(paramMgr);
+  auto runNum = options.getRunNumber();
+  if (runNum >= 0) {
+    try {
+      paramMgr->fillParameterBank(runNum);
+    } catch (...) {
+      ERROR("Param bank was not generated correctly.\n The run number used:" + JPetCommonTools::intToString(runNum));
+      return false;
+    }
+    if (options.isLocalDBCreate()) {
+      JPetParamSaverAscii saver;
+      saver.saveParamBank(paramMgr->getParamBank(), runNum, options.getLocalDBCreate());
+    }
+  }
+  auto inputFileType = options.getInputFileType();
+  auto inputFile = options.getInputFile();
+  if (inputFileType == JPetOptions::kScope) {
+    if (!createScopeTaskAndAddToTaskList(options, paramMgr, tasks)) {
+      ERROR("Scope task not added correctly!!!");
+      return false;
+    }
+  } else if (inputFileType == JPetOptions::kHld) {
+    unpackFile(inputFile, options.getTotalEvents());
+  } 
+    /// Assumption that if the file is zipped than it is in the hld format
+    /// and we will also unpack if from hld  after unzipping.
+    else if ( inputFileType == JPetOptions::kZip) {
+      INFO( std::string("Unzipping file before unpacking") );
+      if ( !JPetCommonTools::unzipFile(inputFile) ) {
+        ERROR( std::string("Problem with unpacking file: ") + inputFile );
+        return false; 
+      } else {
+        INFO( std::string("Unpacking") );
+        auto unzippedFilename = JPetCommonTools::stripFileNameSuffix(std::string(inputFile)).c_str();
+        unpackFile(unzippedFilename, options.getTotalEvents());
+      }
+  }
+
+  if (options.getInputFileType() == JPetOptions::kUndefinedFileType)
+    ERROR( Form("Unknown file type provided for file: %s", options.getInputFile()) );
+  return true;
+}
+
+bool JPetTaskChainExecutorUtils::createScopeTaskAndAddToTaskList(const JPetOptions& options, JPetParamManager* paramMgr, std::list<JPetTaskRunnerInterface*>& tasks)
+{
+  assert(paramMgr);
+  auto scopeFile = options.getScopeConfigFile();
+  if (!paramMgr->getParametersFromScopeConfig(scopeFile)) {
+    ERROR("Unable to generate Param Bank from Scope Config");
+    return false;
+  }
+  JPetScopeLoader* module = new JPetScopeLoader(new JPetScopeTask("JPetScopeReader", "Process Oscilloscope ASCII data into JPetRecoSignal structures."));
+  assert(module);
+  module->setParamManager(paramMgr);
+  tasks.push_front(module);
+  return true;
+}
+
+void JPetTaskChainExecutorUtils::unpackFile(const char* filename, long long nevents)
+{
+  JPetUnpacker unpacker;
+  if (nevents > 0) {
+    unpacker.setParams(filename, nevents);
+    WARNING(std::string("Even though the range of events was set, only the first ") + JPetCommonTools::intToString(nevents) + std::string(" will be unpacked by the unpacker. \n The unpacker always starts from the beginning of the file."));
+  } else {
+    unpacker.setParams(filename);
+  }
+    unpacker.exec();
+}
+
+

--- a/JPetTaskChainExecutor/JPetTaskChainExecutorUtils.cpp
+++ b/JPetTaskChainExecutor/JPetTaskChainExecutorUtils.cpp
@@ -36,7 +36,6 @@ bool JPetTaskChainExecutorUtils::process(const JPetOptions& options, JPetParamMa
     }
   }
   auto inputFileType = options.getInputFileType();
-  auto inputFile = options.getInputFile();
   if (inputFileType == JPetOptions::kScope) {
     if (!createScopeTaskAndAddToTaskList(options, paramMgr, tasks)) {
       ERROR("Scope task not added correctly!!!");

--- a/JPetTaskChainExecutor/JPetTaskChainExecutorUtils.cpp
+++ b/JPetTaskChainExecutor/JPetTaskChainExecutorUtils.cpp
@@ -91,4 +91,11 @@ void JPetTaskChainExecutorUtils::unpackFile(const char* filename, long long neve
     unpacker.exec();
 }
 
-
+JPetParamManager* JPetTaskChainExecutorUtils::generateParamManager(const JPetOptions& options)
+{
+  if (options.isLocalDB()) {
+    return new JPetParamManager(new JPetParamGetterAscii(options.getLocalDB()));
+  } else {
+    return new JPetParamManager();
+  }
+}

--- a/JPetTaskChainExecutor/JPetTaskChainExecutorUtils.cpp
+++ b/JPetTaskChainExecutor/JPetTaskChainExecutorUtils.cpp
@@ -88,6 +88,7 @@ void JPetTaskChainExecutorUtils::unpackFile(const char* filename, long long neve
   } else {
     unpacker.setParams(filename);
   }
+<<<<<<< HEAD
   unpacker.exec();
 }
 
@@ -99,3 +100,9 @@ JPetParamManager* JPetTaskChainExecutorUtils::generateParamManager(const JPetOpt
     return new JPetParamManager();
   }
 }
+=======
+    unpacker.exec();
+}
+
+
+>>>>>>> Add JPeTaskChainExecutorUtils

--- a/JPetTaskChainExecutor/JPetTaskChainExecutorUtils.h
+++ b/JPetTaskChainExecutor/JPetTaskChainExecutorUtils.h
@@ -35,13 +35,10 @@ public:
   void unpackFile(const char* filename, long long nevents);
   bool createScopeTaskAndAddToTaskList(const JPetOptions& options, JPetParamManager* paramMgr, std::list<JPetTaskRunnerInterface*>& tasks);
   static JPetParamManager* generateParamManager(const  JPetOptions& options);
-<<<<<<< HEAD
   /// system(...) is returning integer, 0 when everything went smoothly and error code when not.
   /// Here I just convert return value into boolean type - Sz.N.
   inline static bool unzipFile(const char* filename) {
     return !( system( ( std::string("gzip -d ") + std::string(filename) ).c_str() ) );
   }
-=======
->>>>>>> Extract generateParamManager method to JPetTaskExecutorUtils
 };
 #endif /*  !JPETTASKCHAINEXECUTORUTILS_H */

--- a/JPetTaskChainExecutor/JPetTaskChainExecutorUtils.h
+++ b/JPetTaskChainExecutor/JPetTaskChainExecutorUtils.h
@@ -35,10 +35,13 @@ public:
   void unpackFile(const char* filename, long long nevents);
   bool createScopeTaskAndAddToTaskList(const JPetOptions& options, JPetParamManager* paramMgr, std::list<JPetTaskRunnerInterface*>& tasks);
   static JPetParamManager* generateParamManager(const  JPetOptions& options);
+<<<<<<< HEAD
   /// system(...) is returning integer, 0 when everything went smoothly and error code when not.
   /// Here I just convert return value into boolean type - Sz.N.
   inline static bool unzipFile(const char* filename) {
     return !( system( ( std::string("gzip -d ") + std::string(filename) ).c_str() ) );
   }
+=======
+>>>>>>> Extract generateParamManager method to JPetTaskExecutorUtils
 };
 #endif /*  !JPETTASKCHAINEXECUTORUTILS_H */

--- a/JPetTaskChainExecutor/JPetTaskChainExecutorUtils.h
+++ b/JPetTaskChainExecutor/JPetTaskChainExecutorUtils.h
@@ -1,0 +1,38 @@
+/**
+ *  @copyright Copyright 2016 The J-PET Framework Authors. All rights reserved.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may find a copy of the License in the LICENCE file.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  @file JPetTaskChainExecutorUtils.h
+ */
+
+#ifndef JPETTASKCHAINEXECUTORUTILS_H
+#define JPETTASKCHAINEXECUTORUTILS_H
+
+#include "../JPetUnpacker/JPetUnpacker.h"
+#include "../JPetOptions/JPetOptions.h"
+#include "../JPetParamManager/JPetParamManager.h"
+#include "../JPetScopeLoader/JPetScopeLoader.h"
+
+/**
+ * JPetTaskChainExecutorUtils contains methods that can be used by JPetTaskExecutor
+ * to execute some tasks e.g. unpack hld file based on options. This preprocessing
+ * is tipically done before running main tasks.
+ */
+class JPetTaskChainExecutorUtils
+{
+public:
+  /// process() method depends on the options can: 1.saves paramBank locally in ASCII format , 2. generate and add ScopeLoader
+  /// 3. unpack the hld file.
+  bool process(const JPetOptions& options, JPetParamManager* fParamManager, std::list<JPetTaskRunnerInterface*>& tasks);
+  void unpackFile(const char* filename, long long nevents);
+  bool createScopeTaskAndAddToTaskList(const JPetOptions& options, JPetParamManager* paramMgr, std::list<JPetTaskRunnerInterface*>& tasks);
+};
+#endif /*  !JPETTASKCHAINEXECUTORUTILS_H */

--- a/JPetTaskChainExecutor/JPetTaskChainExecutorUtils.h
+++ b/JPetTaskChainExecutor/JPetTaskChainExecutorUtils.h
@@ -34,5 +34,6 @@ public:
   bool process(const JPetOptions& options, JPetParamManager* fParamManager, std::list<JPetTaskRunnerInterface*>& tasks);
   void unpackFile(const char* filename, long long nevents);
   bool createScopeTaskAndAddToTaskList(const JPetOptions& options, JPetParamManager* paramMgr, std::list<JPetTaskRunnerInterface*>& tasks);
+  static JPetParamManager* generateParamManager(const  JPetOptions& options);
 };
 #endif /*  !JPETTASKCHAINEXECUTORUTILS_H */

--- a/JPetTaskChainExecutor/JPetTaskChainExecutorUtils.h
+++ b/JPetTaskChainExecutor/JPetTaskChainExecutorUtils.h
@@ -35,5 +35,10 @@ public:
   void unpackFile(const char* filename, long long nevents);
   bool createScopeTaskAndAddToTaskList(const JPetOptions& options, JPetParamManager* paramMgr, std::list<JPetTaskRunnerInterface*>& tasks);
   static JPetParamManager* generateParamManager(const  JPetOptions& options);
+  /// system(...) is returning integer, 0 when everything went smoothly and error code when not.
+  /// Here I just convert return value into boolean type - Sz.N.
+  inline static bool unzipFile(const char* filename) {
+    return !( system( ( std::string("gzip -d ") + std::string(filename) ).c_str() ) );
+  }
 };
 #endif /*  !JPETTASKCHAINEXECUTORUTILS_H */

--- a/JPetTaskChainExecutor/JPetTaskChainExecutorUtilsTest.cpp
+++ b/JPetTaskChainExecutor/JPetTaskChainExecutorUtilsTest.cpp
@@ -1,0 +1,32 @@
+/**
+ *  @copyright Copyright 2016 The J-PET Framework Authors. All rights reserved.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may find a copy of the License in the LICENCE file.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  @file JPetTaskChainExecutorUtilsTest.cpp
+ */
+
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE JPetTaskChainExecutorUtilsTest
+#include <boost/test/unit_test.hpp>
+#include "../JPetTaskChainExecutor/JPetTaskChainExecutorUtils.h"
+
+BOOST_AUTO_TEST_SUITE(JPetTaskChainExecutorTestSuite)
+
+BOOST_AUTO_TEST_CASE(tryToUnzipSomethingNotExistingFile)
+{
+  BOOST_REQUIRE(!JPetTaskChainExecutorUtils::unzipFile("kiko.gz"));
+  std::string initialPath = boost::filesystem::path(boost::filesystem::current_path()).string();
+  initialPath = initialPath.substr(0, initialPath.find("build") );
+  std::string wrongZipPath = initialPath + "unitTestData/JPetTaskChainExecutorUtilsTest/wrongZip.gz";
+  BOOST_REQUIRE(!JPetTaskChainExecutorUtils::unzipFile( wrongZipPath.c_str() ));
+
+}
+BOOST_AUTO_TEST_SUITE_END()

--- a/JPetTaskIO/JPetTaskIO.cpp
+++ b/JPetTaskIO/JPetTaskIO.cpp
@@ -99,7 +99,7 @@ void JPetTaskIO::terminate()
   fReader->closeFile();
 
 }
-void JPetTaskIO::addSubTask(JPetTaskInterface* subtask)
+void JPetTaskIO::addTask(JPetTaskInterface* subtask)
 {
   fTask = dynamic_cast<JPetTask*>(subtask);
 }

--- a/JPetTaskIO/JPetTaskIO.cpp
+++ b/JPetTaskIO/JPetTaskIO.cpp
@@ -67,7 +67,8 @@ void JPetTaskIO::exec()
   assert(lastEvent >= 0);
   for (auto i = firstEvent; i <= lastEvent; i++) {
 
-    (std::dynamic_pointer_cast<JPetTask>(fTask))->setEvent(&(static_cast<TNamed&>(fReader->getCurrentEvent())));
+    //(std::dynamic_pointer_cast<JPetTask>(fTask))->setEvent(&(static_cast<TNamed&>(fReader->getCurrentEvent())));
+    (dynamic_cast<JPetTask*>(fTask))->setEvent(&(static_cast<TNamed&>(fReader->getCurrentEvent())));
     if (fOptions.isProgressBar()) {
       displayProgressBar(i, lastEvent);
     }
@@ -157,7 +158,8 @@ void JPetTaskIO::createInputObjects(const char* inputFilename)
     fAuxilliaryData = dynamic_cast<JPetAuxilliaryData*>(fReader->getObjectFromFile("Auxilliary Data"));
 
     // add info about this module to the processing stages' history in Tree header
-    auto task = std::dynamic_pointer_cast<JPetTask>(fTask);
+    //auto task = std::dynamic_pointer_cast<JPetTask>(fTask);
+    auto task = dynamic_cast<JPetTask*>(fTask);
     fHeader->addStageInfo(task->GetName(), task->GetTitle(), 0,
                           JPetCommonTools::getTimeString());
 
@@ -172,7 +174,8 @@ void JPetTaskIO::createOutputObjects(const char* outputFilename)
   fWriter = new JPetWriter( outputFilename );
   assert(fWriter);
   if (fTask) {
-    auto task = std::dynamic_pointer_cast<JPetTask>(fTask);
+    //auto task = std::dynamic_pointer_cast<JPetTask>(fTask);
+    auto task = dynamic_cast<JPetTask*>(fTask);
     task->setWriter(fWriter);
     if (!fAuxilliaryData) {
       fAuxilliaryData = new JPetAuxilliaryData();

--- a/JPetTaskIO/JPetTaskIO.cpp
+++ b/JPetTaskIO/JPetTaskIO.cpp
@@ -99,11 +99,13 @@ void JPetTaskIO::terminate()
   fReader->closeFile();
 
 }
-void JPetTaskIO::addTask(JPetTaskInterface* subtask)
+
+void JPetTaskIO::setTask(JPetTaskInterface* subtask)
 {
   fTask = dynamic_cast<JPetTask*>(subtask);
 }
-JPetTask* JPetTaskIO::getSubTask() const
+
+JPetTaskInterface* JPetTaskIO::getTask() const
 {
   return fTask;
 }

--- a/JPetTaskIO/JPetTaskIO.cpp
+++ b/JPetTaskIO/JPetTaskIO.cpp
@@ -14,6 +14,7 @@
  */
 
 #include "JPetTaskIO.h"
+#include <memory>
 #include <cassert>
 #include "../JPetReader/JPetReader.h"
 #include "../JPetTreeHeader/JPetTreeHeader.h"
@@ -24,7 +25,6 @@
 
 
 JPetTaskIO::JPetTaskIO():
-  fTask(0),
   fEventNb(-1),
   fWriter(0),
   fReader(0),
@@ -66,7 +66,8 @@ void JPetTaskIO::exec()
   setUserLimits(fOptions, totalEvents,  firstEvent, lastEvent);
   assert(lastEvent >= 0);
   for (auto i = firstEvent; i <= lastEvent; i++) {
-    fTask->setEvent(&(static_cast<TNamed&>(fReader->getCurrentEvent())));
+
+    (std::dynamic_pointer_cast<JPetTask>(fTask))->setEvent(&(static_cast<TNamed&>(fReader->getCurrentEvent())));
     if (fOptions.isProgressBar()) {
       displayProgressBar(i, lastEvent);
     }
@@ -98,16 +99,6 @@ void JPetTaskIO::terminate()
   fWriter->closeFile();
   fReader->closeFile();
 
-}
-
-void JPetTaskIO::setTask(JPetTaskInterface* subtask)
-{
-  fTask = dynamic_cast<JPetTask*>(subtask);
-}
-
-JPetTaskInterface* JPetTaskIO::getTask() const
-{
-  return fTask;
 }
 
 void JPetTaskIO::setOptions(const JPetOptions& opts)
@@ -166,7 +157,8 @@ void JPetTaskIO::createInputObjects(const char* inputFilename)
     fAuxilliaryData = dynamic_cast<JPetAuxilliaryData*>(fReader->getObjectFromFile("Auxilliary Data"));
 
     // add info about this module to the processing stages' history in Tree header
-    fHeader->addStageInfo(fTask->GetName(), fTask->GetTitle(), 0,
+    auto task = std::dynamic_pointer_cast<JPetTask>(fTask);
+    fHeader->addStageInfo(task->GetName(), task->GetTitle(), 0,
                           JPetCommonTools::getTimeString());
 
   } else {
@@ -180,12 +172,13 @@ void JPetTaskIO::createOutputObjects(const char* outputFilename)
   fWriter = new JPetWriter( outputFilename );
   assert(fWriter);
   if (fTask) {
-    fTask->setWriter(fWriter);
+    auto task = std::dynamic_pointer_cast<JPetTask>(fTask);
+    task->setWriter(fWriter);
     if (!fAuxilliaryData) {
       fAuxilliaryData = new JPetAuxilliaryData();
     }
-    fTask->setStatistics(fStatistics);
-    fTask->setAuxilliaryData(fAuxilliaryData);
+    task->setStatistics(fStatistics);
+    task->setAuxilliaryData(fAuxilliaryData);
   } else {
     WARNING("the subTask does not exist, so Write was not passed to it");
   }
@@ -207,10 +200,6 @@ const JPetParamBank& JPetTaskIO::getParamBank()
 
 JPetTaskIO::~JPetTaskIO()
 {
-  if (fTask) {
-    delete fTask;
-    fTask = 0;
-  }
   if (fWriter) {
     delete fWriter;
     fWriter = 0;

--- a/JPetTaskIO/JPetTaskIO.h
+++ b/JPetTaskIO/JPetTaskIO.h
@@ -36,7 +36,7 @@ class JPetAuxilliaryData;
  * @brief Class representing computing task with input/output operations.
  *
  */
-class JPetTaskIO: public JPetTaskInterface
+class JPetTaskIO: public JPetTaskInterface, public JPetTaskRunnerInterface
 {
 public:
   JPetTaskIO();

--- a/JPetTaskIO/JPetTaskIO.h
+++ b/JPetTaskIO/JPetTaskIO.h
@@ -44,8 +44,9 @@ public:
   virtual void exec();
   virtual void terminate();
   virtual ~JPetTaskIO();
-  virtual void addTask(JPetTaskInterface* subtask);
-  virtual JPetTask* getSubTask() const;
+  virtual void setTask(JPetTaskInterface* subtask);
+  virtual JPetTaskInterface* getTask() const;
+  virtual void runTask() {};
 
   void setOptions(const JPetOptions& opts);
   inline JPetOptions getOptions() const {

--- a/JPetTaskIO/JPetTaskIO.h
+++ b/JPetTaskIO/JPetTaskIO.h
@@ -16,13 +16,14 @@
 #ifndef JPETTASKIO_H
 #define JPETTASKIO_H
 #include "../JPetTaskInterface/JPetTaskInterface.h"
+#include "../JPetTaskRunner/JPetTaskRunner.h"
 #include "../JPetParamManager/JPetParamManager.h"
 #include "../JPetStatistics/JPetStatistics.h"
 #include "../JPetAuxilliaryData/JPetAuxilliaryData.h"
 #include "../JPetOptions/JPetOptions.h"
 #include "../JPetTask/JPetTask.h"
 #include "../JPetProgressBarManager/JPetProgressBarManager.h"
-
+#include <memory>
 
 class JPetWriter;
 class JPetReader;
@@ -36,7 +37,7 @@ class JPetAuxilliaryData;
  * @brief Class representing computing task with input/output operations.
  *
  */
-class JPetTaskIO: public JPetTaskRunnerInterface
+class JPetTaskIO: public JPetTaskRunner
 {
 public:
   JPetTaskIO();
@@ -44,8 +45,6 @@ public:
   virtual void exec();
   virtual void terminate();
   virtual ~JPetTaskIO();
-  virtual void setTask(JPetTaskInterface* subtask);
-  virtual JPetTaskInterface* getTask() const;
   virtual void runTask() {};
 
   void setOptions(const JPetOptions& opts);
@@ -65,7 +64,6 @@ protected:
   const JPetParamBank& getParamBank();
   JPetParamManager& getParamManager();
 
-  JPetTask* fTask;
   int fEventNb;
   JPetOptions fOptions; //options like max num of events, first event, last event, inputFileType, outputFileType
   JPetWriter* fWriter;

--- a/JPetTaskIO/JPetTaskIO.h
+++ b/JPetTaskIO/JPetTaskIO.h
@@ -44,7 +44,7 @@ public:
   virtual void exec();
   virtual void terminate();
   virtual ~JPetTaskIO();
-  virtual void addSubTask(JPetTaskInterface* subtask);
+  virtual void addTask(JPetTaskInterface* subtask);
   virtual JPetTask* getSubTask() const;
 
   void setOptions(const JPetOptions& opts);

--- a/JPetTaskIO/JPetTaskIO.h
+++ b/JPetTaskIO/JPetTaskIO.h
@@ -36,7 +36,7 @@ class JPetAuxilliaryData;
  * @brief Class representing computing task with input/output operations.
  *
  */
-class JPetTaskIO: public JPetTaskInterface, public JPetTaskRunnerInterface
+class JPetTaskIO: public JPetTaskRunnerInterface
 {
 public:
   JPetTaskIO();

--- a/JPetTaskLoader/JPetTaskLoader.cpp
+++ b/JPetTaskLoader/JPetTaskLoader.cpp
@@ -26,10 +26,11 @@ JPetTaskLoader::JPetTaskLoader(const char* in_file_type,
                                const char* out_file_type,
                                JPetTask* taskToExecute):
   JPetTaskIO(),
+
   fInFileType(in_file_type),
   fOutFileType(out_file_type)
 {
-  setTask(taskToExecute);
+  setTask(std::shared_ptr<JPetTaskInterface>(taskToExecute));
 }
 
 

--- a/JPetTaskLoader/JPetTaskLoader.cpp
+++ b/JPetTaskLoader/JPetTaskLoader.cpp
@@ -29,7 +29,7 @@ JPetTaskLoader::JPetTaskLoader(const char* in_file_type,
   fInFileType(in_file_type),
   fOutFileType(out_file_type)
 {
-  addSubTask(taskToExecute);
+  addTask(taskToExecute);
 }
 
 
@@ -46,7 +46,7 @@ void JPetTaskLoader::init(const JPetOptions::Options& opts)
   newOpts.at("outputFile") = outFile;
   newOpts.at("outputFileType") = fOutFileType;
   setOptions(JPetOptions(newOpts));
-  
+
   //here we should call some function to parse options
   std::string inputFilename(fOptions.getInputFile());
   std::string outputPath(fOptions.getOutputPath());
@@ -57,7 +57,7 @@ void JPetTaskLoader::init(const JPetOptions::Options& opts)
 
 std::string JPetTaskLoader::generateProperNameFile(const std::string& srcFilename, const std::string& fileType) const
 {
-  auto baseFileName = getBaseFilePath(srcFilename); 
+  auto baseFileName = getBaseFilePath(srcFilename);
   if (!fileType.empty()) {
     baseFileName = baseFileName + "." + fileType;
   }
@@ -76,7 +76,7 @@ std::string JPetTaskLoader::getBaseFilePath(const std::string& srcName) const
     name.erase( pos );
   }
   boost::filesystem::path bare_name(name);
-  
+
   return (dir / bare_name).native();
 }
 

--- a/JPetTaskLoader/JPetTaskLoader.cpp
+++ b/JPetTaskLoader/JPetTaskLoader.cpp
@@ -30,7 +30,8 @@ JPetTaskLoader::JPetTaskLoader(const char* in_file_type,
   fInFileType(in_file_type),
   fOutFileType(out_file_type)
 {
-  setTask(std::shared_ptr<JPetTaskInterface>(taskToExecute));
+  //setTask(std::shared_ptr<JPetTaskInterface>(taskToExecute));
+  setTask(dynamic_cast<JPetTaskInterface*>(taskToExecute));
 }
 
 

--- a/JPetTaskLoader/JPetTaskLoader.cpp
+++ b/JPetTaskLoader/JPetTaskLoader.cpp
@@ -29,7 +29,7 @@ JPetTaskLoader::JPetTaskLoader(const char* in_file_type,
   fInFileType(in_file_type),
   fOutFileType(out_file_type)
 {
-  addTask(taskToExecute);
+  setTask(taskToExecute);
 }
 
 

--- a/JPetTaskRunner/JPetTaskRunner.cpp
+++ b/JPetTaskRunner/JPetTaskRunner.cpp
@@ -25,12 +25,12 @@ JPetTaskRunner::~JPetTaskRunner()
 {
 }
 
-void JPetTaskRunner::setTask(std::shared_ptr<JPetTaskInterface> subtask)
+void JPetTaskRunner::setTask(JPetTaskInterface* subtask)
 {
   fTask = subtask;
 }
 
-std::shared_ptr<JPetTaskInterface> JPetTaskRunner::getTask() const
+JPetTaskInterface* JPetTaskRunner::getTask() const
 {
   return fTask;
 }

--- a/JPetTaskRunner/JPetTaskRunner.cpp
+++ b/JPetTaskRunner/JPetTaskRunner.cpp
@@ -1,0 +1,37 @@
+/**
+ *  @copyright Copyright 2016 The J-PET Framework Authors. All rights reserved.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may find a copy of the License in the LICENCE file.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  @file JPetTaskRunner.cpp
+ */
+
+#include "./JPetTaskRunner.h"
+#include <cassert>
+#include <iostream>
+
+JPetTaskRunner::JPetTaskRunner(): fTask(0)
+{
+}
+
+JPetTaskRunner::~JPetTaskRunner()
+{
+}
+
+void JPetTaskRunner::setTask(std::shared_ptr<JPetTaskInterface> subtask)
+{
+  fTask = subtask;
+}
+
+std::shared_ptr<JPetTaskInterface> JPetTaskRunner::getTask() const
+{
+  return fTask;
+}
+

--- a/JPetTaskRunner/JPetTaskRunner.h
+++ b/JPetTaskRunner/JPetTaskRunner.h
@@ -10,21 +10,27 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  *
- *  @file JPetTaskRunnerInterface.h
+ *  @file JPetTaskRunner.h
  */
 
-#ifndef JPETTASKRUNNERINTERFACE_H
-#define JPETTASKRUNNERINTERFACE_H
+#ifndef JPETTASKRUNNER_H
+#define JPETTASKRUNNER_H
 
 #include "../JPetTaskInterface/JPetTaskInterface.h"
-#include <memory>
+#include "../JPetTaskRunnerInterface/JPetTaskRunnerInterface.h"
 
-class JPetTaskRunnerInterface
+class JPetTaskRunner: public JPetTaskRunnerInterface
 {
 public:
-  virtual ~JPetTaskRunnerInterface() {};
-  virtual void setTask(std::shared_ptr<JPetTaskInterface>) = 0;
-  virtual std::shared_ptr<JPetTaskInterface> getTask() const = 0;
+  JPetTaskRunner();
+  virtual ~JPetTaskRunner();
+  virtual void setTask(std::shared_ptr<JPetTaskInterface> task);
+  virtual std::shared_ptr<JPetTaskInterface> getTask() const;
   virtual void runTask() = 0;
+protected:
+  std::shared_ptr<JPetTaskInterface> fTask; /// maybe as unique_ptr ?
+private:
+  void operator=(const JPetTaskRunner&);
+  JPetTaskRunner(const JPetTaskRunner&);
 };
-#endif /*  !JPETTASKRUNNERINTERFACE_H */
+#endif /*  !JPETTASKRUNNER_H */

--- a/JPetTaskRunner/JPetTaskRunner.h
+++ b/JPetTaskRunner/JPetTaskRunner.h
@@ -24,11 +24,11 @@ class JPetTaskRunner: public JPetTaskRunnerInterface
 public:
   JPetTaskRunner();
   virtual ~JPetTaskRunner();
-  virtual void setTask(std::shared_ptr<JPetTaskInterface> task);
-  virtual std::shared_ptr<JPetTaskInterface> getTask() const;
+  virtual void setTask(JPetTaskInterface* task);
+  virtual JPetTaskInterface* getTask() const;
   virtual void runTask() = 0;
 protected:
-  std::shared_ptr<JPetTaskInterface> fTask; /// maybe as unique_ptr ?
+  JPetTaskInterface* fTask; /// maybe as unique_ptr ?
 private:
   void operator=(const JPetTaskRunner&);
   JPetTaskRunner(const JPetTaskRunner&);

--- a/JPetTaskRunnerInterface/JPetTaskRunnerInterface.h
+++ b/JPetTaskRunnerInterface/JPetTaskRunnerInterface.h
@@ -22,6 +22,8 @@ class JPetTaskRunnerInterface
 {
 public:
   virtual ~JPetTaskRunnerInterface() {};
-  virtual void addTask(JPetTaskInterface*) = 0;
+  virtual void setTask(JPetTaskInterface*) = 0;
+  virtual JPetTaskInterface* getTask() const = 0;
+  virtual void runTask() = 0;
 };
 #endif /*  !JPETTASKRUNNERINTERFACE_H */

--- a/JPetTaskRunnerInterface/JPetTaskRunnerInterface.h
+++ b/JPetTaskRunnerInterface/JPetTaskRunnerInterface.h
@@ -17,7 +17,6 @@
 #define JPETTASKRUNNERINTERFACE_H
 
 #include "../JPetTaskInterface/JPetTaskInterface.h"
-#include <memory>
 
 class JPetTaskRunnerInterface
 {

--- a/JPetTaskRunnerInterface/JPetTaskRunnerInterface.h
+++ b/JPetTaskRunnerInterface/JPetTaskRunnerInterface.h
@@ -23,8 +23,8 @@ class JPetTaskRunnerInterface
 {
 public:
   virtual ~JPetTaskRunnerInterface() {};
-  virtual void setTask(std::shared_ptr<JPetTaskInterface>) = 0;
-  virtual std::shared_ptr<JPetTaskInterface> getTask() const = 0;
+  virtual void setTask(JPetTaskInterface*) = 0;
+  virtual JPetTaskInterface* getTask() const = 0;
   virtual void runTask() = 0;
 };
 #endif /*  !JPETTASKRUNNERINTERFACE_H */

--- a/JPetTaskRunnerInterface/JPetTaskRunnerInterface.h
+++ b/JPetTaskRunnerInterface/JPetTaskRunnerInterface.h
@@ -10,25 +10,18 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  *
- *  @file JPetTaskInterface.h
+ *  @file JPetTaskRunnerInterface.h
  */
 
-#ifndef JPETTASKINTERFACE_H
-#define JPETTASKINTERFACE_H
+#ifndef JPETTASKRUNNERINTERFACE_H
+#define JPETTASKRUNNERINTERFACE_H
 
-#include <map>
-#include <string>
+#include "../JPetTaskInterface/JPetTaskInterface.h"
 
-class JPetParamManager;
-
-class JPetTaskInterface
+class JPetTaskRunnerInterface
 {
 public:
-  typedef std::map<std::string, std::string> Options;
-  virtual ~JPetTaskInterface() {}
-  virtual void init(const Options& options) = 0;
-  virtual void exec() = 0;
-  virtual void terminate() = 0;
-  virtual void setParamManager(JPetParamManager* paramManager) = 0;
+  virtual ~JPetTaskRunnerInterface() {};
+  virtual void addSubTask(JPetTaskInterface*) = 0;
 };
-#endif /*  !JPETTASKINTERFACE_H */
+#endif /*  !JPETTASKRUNNERINTERFACE_H */

--- a/JPetTaskRunnerInterface/JPetTaskRunnerInterface.h
+++ b/JPetTaskRunnerInterface/JPetTaskRunnerInterface.h
@@ -17,13 +17,14 @@
 #define JPETTASKRUNNERINTERFACE_H
 
 #include "../JPetTaskInterface/JPetTaskInterface.h"
+#include <memory>
 
 class JPetTaskRunnerInterface
 {
 public:
   virtual ~JPetTaskRunnerInterface() {};
-  virtual void setTask(JPetTaskInterface*) = 0;
-  virtual JPetTaskInterface* getTask() const = 0;
+  virtual void setTask(std::shared_ptr<JPetTaskInterface>) = 0;
+  virtual std::shared_ptr<JPetTaskInterface> getTask() const = 0;
   virtual void runTask() = 0;
 };
 #endif /*  !JPETTASKRUNNERINTERFACE_H */

--- a/JPetTaskRunnerInterface/JPetTaskRunnerInterface.h
+++ b/JPetTaskRunnerInterface/JPetTaskRunnerInterface.h
@@ -22,6 +22,6 @@ class JPetTaskRunnerInterface
 {
 public:
   virtual ~JPetTaskRunnerInterface() {};
-  virtual void addSubTask(JPetTaskInterface*) = 0;
+  virtual void addTask(JPetTaskInterface*) = 0;
 };
 #endif /*  !JPETTASKRUNNERINTERFACE_H */

--- a/JPetTimeWindow/JPetTimeWindow.h
+++ b/JPetTimeWindow/JPetTimeWindow.h
@@ -31,8 +31,7 @@ class JPetTimeWindow: public TNamed
 {
 public:
 /// @todo think about changing TClonesArray to something else ? what about cleaning
-  JPetTimeWindow()
-  {
+  JPetTimeWindow(): fIndex(-1) {
     SetName("JPetTimeWindow");
   }
 
@@ -64,14 +63,18 @@ public:
    * Each TSlot (time window) in a HLD file is assigned an index number, counting from first TSlot in the file. This number may be useful if empty TSlots are skipped during analysis.
    * @oaram index a squential number of this TSlot counting from sirst TSlot in a HLD file
    */
-  inline unsigned int getIndex() const { return fIndex; }
+  inline unsigned int getIndex() const {
+    return fIndex;
+  }
 
-  inline void setIndex(unsigned int index) { fIndex = index; }
+  inline void setIndex(unsigned int index) {
+    fIndex = index;
+  }
 
   ClassDef(JPetTimeWindow, 2);
 
 private:
-  std::vector<JPetSigCh> fSigChannels; 
+  std::vector<JPetSigCh> fSigChannels;
   unsigned int fIndex; ///< sequential number of this TSlot in the HLD file
 };
 

--- a/JPetTimeWindow/JPetTimeWindow.h
+++ b/JPetTimeWindow/JPetTimeWindow.h
@@ -31,7 +31,7 @@ class JPetTimeWindow: public TNamed
 {
 public:
 /// @todo think about changing TClonesArray to something else ? what about cleaning
-  JPetTimeWindow(): fIndex(-1) {
+  JPetTimeWindow() {
     SetName("JPetTimeWindow");
   }
 
@@ -75,7 +75,7 @@ public:
 
 private:
   std::vector<JPetSigCh> fSigChannels;
-  unsigned int fIndex; ///< sequential number of this TSlot in the HLD file
+  unsigned int fIndex = 0; ///< sequential number of this TSlot in the HLD file
 };
 
 #endif


### PR DESCRIPTION
Please have a look @alekgajos 
This is reopened PR #41 
Those changes should be transparent to Framework users.
The main changes:
1.Rename JPetTaskExecutor to JPetTaskChainExecutor.
2. The role of the JPetTaskChainExecutor is to execute task chain, all other "things" are delegated to JPetTaskChainExecutorUtils via preprocess() method. JPetTaskChainExecutorUtils contains all the "preprocessing tasks" e.g. unzipping, unpacking, generateParamManager (from file)
3.Add JPetOptionInterface -> JPetOptions is now a subtype of it
4.Small corrections e.g. missing initializations in JPetTimeWindow, JPetHLDReader, remove unused code, formatting
5.Remove inheritance JPetTaskInterface <--JPetTaskIO, and partially change the inheritance scheme that was bad anyway. We have two type of classes with Task in name which has nothing to do with each other. JPetTask is a "real" task (computing component/algorithm), while JPetTaskIO, JPetTaskLoader are more like manager which handle the tasks.
6.Refactor our task scheme to introduce properly Strategy pattern. It was implemented but not correctly (probably by accident).
See e.g. https://en.wikipedia.org/wiki/Strategy_pattern
JPetTaskRunner is a context of the strategy pattern. JPetTaskInterface corresponds to the Strategy interface and JPetTasks are concrete realizations of different Strategies.

This is the preparation for the second part of refactoring, but this will break some user interfaces, so I leave it for the future.