### PR TITLE
Refactoring of JPetRecoImageTools

### DIFF
--- a/modules/JPetRecoImageTools/JPetRecoImageTools.cpp
+++ b/modules/JPetRecoImageTools/JPetRecoImageTools.cpp
@@ -1,3 +1,18 @@
+/**
+ *  @copyright Copyright 2016 The J-PET Framework Authors. All rights reserved.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may find a copy of the License in the LICENCE file.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  @file JPetRecoImageTools.cpp
+ */
+
 #include "./JPetRecoImageTools.h"
 #include "../../JPetLoggerInclude.h"
 #include <vector>

--- a/modules/JPetRecoImageTools/JPetRecoImageTools.cpp
+++ b/modules/JPetRecoImageTools/JPetRecoImageTools.cpp
@@ -156,15 +156,15 @@ void JPetRecoImageTools::rescale(Matrix2DProj& matrix, double minCutoff, double 
         datamin = matrix[k][j];
     }
   }
-
-  if (datamax == 0.) {
+  /// datamin represents the constant background factor.
+  if ((datamax - datamin) == 0.) {
     WARNING("Maximum value in the matrix to rescale is 0. No rescaling performed.");
     return;
   }
 
   for (unsigned int k = 0; k < matrix.size(); k++) {
     for (unsigned int j = 0; j < matrix[0].size(); j++) {
-      matrix[k][j] = (matrix[k][j] - datamin) * rescaleFactor / datamax;
+      matrix[k][j] = (matrix[k][j] - datamin) * rescaleFactor / (datamax - datamin);
     }
   }
 }

--- a/modules/JPetRecoImageTools/JPetRecoImageTools.cpp
+++ b/modules/JPetRecoImageTools/JPetRecoImageTools.cpp
@@ -27,34 +27,19 @@ JPetRecoImageTools::JPetRecoImageTools() {}
 JPetRecoImageTools::~JPetRecoImageTools() {}
 
 //nearest neighbour
-double JPetRecoImageTools::nearestNeighbour2( int i, double y, std::function<double(int, int)>& func)
+double JPetRecoImageTools::nearestNeighbour( int i, double y, std::function<double(int, int)>& func)
 {
   int j = std::round(y);
   return func (i, j);
 }
 
-double JPetRecoImageTools::linear2(int i, double y, std::function<double(int, int)>& func)
+double JPetRecoImageTools::linear(int i, double y, std::function<double(int, int)>& func)
 {
   int j = std::round(y);
   double weight = std::abs(y - std::ceil(y));
   return (1 - weight) * func(i, j) + weight * func(i, j + 1);
 }
 
-double JPetRecoImageTools::nearestNeighbour(const Matrix2D& emissionMatrix, double a, double b,
-    int center, int x, int y, bool sang)
-{
-  if (sang) {
-    y = (int)std::round(a * x + b) + center;
-    if (y >= 0 && y < (int) emissionMatrix[0].size())
-      return emissionMatrix[x + center][y];
-    else return 0;
-  } else {
-    x = (int)std::round(a * y + b) + center + 1; // not really know why need to +1 to x, but it works
-    if (x >= 0 && x < (int)emissionMatrix.size())
-      return emissionMatrix[x][y + center];
-    else return 0;
-  }
-}
 
 std::function<double(int, int)> JPetRecoImageTools::getValue(const Matrix2D& emissionMatrix)
 {
@@ -78,57 +63,10 @@ std::function<double(int, int)> JPetRecoImageTools::getValue2(const Matrix2D& em
   };
 }
 
-double JPetRecoImageTools::linear3(std::function<double(int, int)>& matrixGet, double a, double b,
-                                   int center, int i)
-{
-  //if (sang) {
-  return linear2(i + center , a * i + b + center, matrixGet);
-  //y = (int)std::round(a * x + b) + center;
-  //double weight = std::abs((a * x + b) - std::ceil(a * x + b));
-  //if (y >= 0 && y < (int)emissionMatrix[0].size()) {
-  //return (1 - weight) * emissionMatrix[x + center][y] + weight * emissionMatrix[x + center][y + 1];
-  //} else return 0;
-
-  //} else {
-  //return linear2(y + center, a * y + b + center , matrixGet);
-  //x = (int)std::round(a * y + b) + center + 1; // not really know why need to +1 to x, but it works
-  //double weight = std::abs((a * y + b) - std::ceil(a * y + b));
-  //if (x >= 0 && x + 1 < (int)emissionMatrix.size()) {
-  //if (weight == 0)
-  //return emissionMatrix[x][y + center];
-  //else
-  //return (1 - weight) * emissionMatrix[x][y + center] + weight * emissionMatrix[x + 1][y + center];
-  //} else return 0;
-  //}
-}
-
-double JPetRecoImageTools::linear(const Matrix2D& emissionMatrix, double a, double b,
-                                  int center, int x, int y, bool sang)
-{
-  if (sang) {
-    y = (int)std::round(a * x + b) + center;
-    double weight = std::abs((a * x + b) - std::ceil(a * x + b));
-    if (y >= 0 && y < (int)emissionMatrix[0].size()) {
-      return (1 - weight) * emissionMatrix[x + center][y] + weight * emissionMatrix[x + center][y + 1];
-    } else return 0;
-  } else {
-    x = (int)std::round(a * y + b) + center + 1; // not really know why need to +1 to x, but it works
-    double weight = std::abs((a * y + b) - std::ceil(a * y + b));
-    if (x >= 0 && x + 1 < (int)emissionMatrix.size()) {
-      if (weight == 0)
-        return emissionMatrix[x][y + center];
-      else
-        return (1 - weight) * emissionMatrix[x][y + center] + weight * emissionMatrix[x + 1][y + center];
-    } else return 0;
-  }
-}
-
-
-
 JPetRecoImageTools::Matrix2DProj JPetRecoImageTools::sinogram(Matrix2D& emissionMatrix,
     int nViews, int nScans,
     double angleBeg, double angleEnd,
-    InterpolationFunc2 interpolationFunction,
+    InterpolationFunc interpolationFunction,
     RescaleFunc rescaleFunc,
     int minCutoff,
     int scaleFactor
@@ -162,7 +100,7 @@ JPetRecoImageTools::Matrix2DProj JPetRecoImageTools::sinogram(Matrix2D& emission
 }
 
 double JPetRecoImageTools::calculateProjection(Matrix2D& emissionMatrix, double phi, int scanNumber, int nScans,
-    InterpolationFunc2& interpolationFunction)
+    InterpolationFunc& interpolationFunction)
 {
   int N = scanNumber - nScans / 2;
   const int kInputMatrixSize = emissionMatrix.size();

--- a/modules/JPetRecoImageTools/JPetRecoImageTools.cpp
+++ b/modules/JPetRecoImageTools/JPetRecoImageTools.cpp
@@ -66,8 +66,12 @@ double JPetRecoImageTools::linear(const Matrix2D& emissionMatrix, double a, doub
 
 JPetRecoImageTools::Matrix2DProj JPetRecoImageTools::sinogram(Matrix2D& emissionMatrix,
     int nViews, int nScans,
+    double angleBeg, double angleEnd,
     InterpolationFunc interpolationFunction,
-    double angleBeg, double angleEnd, bool scaleResult, int min, int max)
+    RescaleFunc rescaleFunc,
+    int min,
+    int max
+                                                             )
 {
   assert(emissionMatrix.size() > 0);
   assert(emissionMatrix.size() == emissionMatrix[0].size());
@@ -128,10 +132,7 @@ JPetRecoImageTools::Matrix2DProj JPetRecoImageTools::sinogram(Matrix2D& emission
     viewIndex++;
   }
 
-  if (scaleResult) {
-    JPetRecoImageTools::rescale(proj, min, max);
-  }
-
+  rescaleFunc(proj, min, max);
   return proj;
 }
 

--- a/modules/JPetRecoImageTools/JPetRecoImageTools.cpp
+++ b/modules/JPetRecoImageTools/JPetRecoImageTools.cpp
@@ -86,17 +86,11 @@ JPetRecoImageTools::Matrix2DProj JPetRecoImageTools::sinogram(Matrix2D& emission
   float stepsize = (angleEnd - angleBeg) / nViews;
   assert(stepsize > 0); //maybe != 0 ?
 
-  const int kInputMatrixSize = emissionMatrix.size();
-
-  //if no. nScans is greater than the image width, then scale will be <1
-  const double scale = kInputMatrixSize / nScans;
-
   int viewIndex = 0;
   for (auto phi = angleBeg; phi < angleEnd; phi = phi + stepsize) {
     for (auto scanNumber = 0; scanNumber < nScans; scanNumber++) {
-      int N = scanNumber - nScans / 2;
       proj[viewIndex][nScans - 1 - scanNumber] = JPetRecoImageTools::calculateProjection(emissionMatrix,
-          N, phi, scale,
+          phi, scanNumber, nScans,
           interpolationFunction);
     }
     viewIndex++;
@@ -106,9 +100,13 @@ JPetRecoImageTools::Matrix2DProj JPetRecoImageTools::sinogram(Matrix2D& emission
   return proj;
 }
 
-double JPetRecoImageTools::calculateProjection(Matrix2D& emissionMatrix, int N, double phi, double scale,
+double JPetRecoImageTools::calculateProjection(Matrix2D& emissionMatrix, double phi, int scanNumber, int nScans,
     InterpolationFunc& interpolationFunction)
 {
+  int N = scanNumber - nScans / 2;
+  const int kInputMatrixSize = emissionMatrix.size();
+  //if no. nScans is greater than the image width, then scale will be <1
+  const double scale = kInputMatrixSize / nScans;
   const double kSin45deg = std::sqrt(2) / 2; /// sin(45) deg
   const double kEpsilon = 0.0000001;
   const double kDegToRad = M_PI / 180.;

--- a/modules/JPetRecoImageTools/JPetRecoImageTools.cpp
+++ b/modules/JPetRecoImageTools/JPetRecoImageTools.cpp
@@ -10,8 +10,8 @@ JPetRecoImageTools::JPetRecoImageTools() {}
 
 JPetRecoImageTools::~JPetRecoImageTools() {}
 
-double JPetRecoImageTools::nearestNeighbour(std::vector<std::vector<int>> &emissionMatrix, double a, double b,
-                                            int center, int x, int y, bool sang)
+double JPetRecoImageTools::nearestNeighbour(Matrix2D& emissionMatrix, double a, double b,
+    int center, int x, int y, bool sang)
 {
   if (sang) {
     y = (int)std::round(a * x + b) + center;
@@ -21,49 +21,37 @@ double JPetRecoImageTools::nearestNeighbour(std::vector<std::vector<int>> &emiss
   } else {
     x = (int)std::round(a * y + b) + center + 1; // not really know why need to +1 to x, but it works
     if (x >= 0 && x < (int)emissionMatrix.size())
-      return emissionMatrix[x][y + center]; 
+      return emissionMatrix[x][y + center];
     else return 0;
   }
 }
 
-double JPetRecoImageTools::linear(std::vector<std::vector<int>> &emissionMatrix, double a, double b,
+double JPetRecoImageTools::linear(Matrix2D& emissionMatrix, double a, double b,
                                   int center, int x, int y, bool sang)
 {
   if (sang) {
     y = (int)std::round(a * x + b) + center;
     double weight = std::abs((a * x + b) - std::ceil(a * x + b));
     if (y >= 0 && y < (int)emissionMatrix[0].size()) {
-        return (1 - weight) * emissionMatrix[x + center][y] + weight * emissionMatrix[x + center][y + 1];
+      return (1 - weight) * emissionMatrix[x + center][y] + weight * emissionMatrix[x + center][y + 1];
     } else return 0;
   } else {
     x = (int)std::round(a * y + b) + center + 1; // not really know why need to +1 to x, but it works
     double weight = std::abs((a * y + b) - std::ceil(a * y + b));
     if (x >= 0 && x + 1 < (int)emissionMatrix.size()) {
-      if(weight == 0)
+      if (weight == 0)
         return emissionMatrix[x][y + center];
-      else 
+      else
         return (1 - weight) * emissionMatrix[x][y + center] + weight * emissionMatrix[x + 1][y + center];
     } else return 0;
   }
 }
 
-/*! \brief Function returning vector of vectors with value of sinogram 
- *  \param emissionMatrix matrix, need to be NxN
- *  \param views number of views on object, degree step is calculated as (ang2 - ang1) / views
- *  \param scans number of scans on object, step is calculated as emissionMatrix[0].size() / scans
- *  \param interpolationFunction function to interpolate values (Optional, default linear)
- *  \param ang1 start angle for projection (Optional, default 0)
- *  \param ang2 end angle for projection (Optional, default 180) 
- *  \param scaleResult if set to true, scale result to <min, max> (Optional, default false)
- *  \param min minimum value in returned sinogram (Optional, default 0)
- *  \param max maximum value in returned sinogram (Optional, default 255)
-*/
 
-std::vector<std::vector<double>> JPetRecoImageTools::sinogram(std::vector<std::vector<int>> &emissionMatrix,
-                                                              int views,int scans, 
-                                                              std::function<double(std::vector<std::vector<int>>&,
-                                                              double, double, int, int, int, bool)> interpolationFunction,
-                                                              float ang1, float ang2, bool scaleResult, int min, int max)
+JPetRecoImageTools::Matrix2DProj JPetRecoImageTools::sinogram(Matrix2D& emissionMatrix,
+    int views, int scans,
+    InterpolationFunc interpolationFunction,
+    float ang1, float ang2, bool scaleResult, int min, int max)
 {
   assert(emissionMatrix.size() > 0);
   assert(emissionMatrix.size() == emissionMatrix[0].size());
@@ -92,44 +80,40 @@ std::vector<std::vector<double>> JPetRecoImageTools::sinogram(std::vector<std::v
   double sinValue = 0., cosValue = 0.;
   double a = 0., aa = 0.;
 
-  for (phi = ang1; phi < ang2; phi = phi + stepsize)
-  {
+  for (phi = ang1; phi < ang2; phi = phi + stepsize) {
     sinValue = std::sin((double)phi * M_PI / 180 - M_PI / 2);
     cosValue = std::cos((double)phi * M_PI / 180 - M_PI / 2);
-    if(std::abs(sinValue) < 0.0000001) {
+    if (std::abs(sinValue) < 0.0000001) {
       sinValue = 0;
     }
-    if(std::abs(cosValue) < 0.0000001) {
+    if (std::abs(cosValue) < 0.0000001) {
       cosValue = 0;
     }
     a = -cosValue / sinValue;
-    if(std::isinf(a) || std::isinf(-a) || std::abs(a) < 0.0000001) {
+    if (std::isinf(a) || std::isinf(-a) || std::abs(a) < 0.0000001) {
       a = 0;
       aa = 0;
     } else aa = 1 / a;
-    for (int scanNumber = 0; scanNumber < scans; scanNumber++)
-    {
+    for (int scanNumber = 0; scanNumber < scans; scanNumber++) {
       N = scanNumber - scans / 2;
       proj[i][scans - 1 - scanNumber] = JPetRecoImageTools::calculateValue(emissionMatrix, std::abs(sinValue) > sang,
-                                                               N, cosValue, sinValue, scale, center,
-                                                               interpolationFunction, a, aa);
+                                        N, cosValue, sinValue, scale, center,
+                                        interpolationFunction, a, aa);
     }
     i++;
   }
 
-  if (scaleResult)
-  {
+  if (scaleResult) {
     JPetRecoImageTools::scale(proj, min, max);
   }
 
   return proj;
 }
 
-double JPetRecoImageTools::calculateValue(std::vector<std::vector<int>> &emissionMatrix, bool sang, int N, double cos,
-                                          double sin, double scale, int center,
-                                          std::function<double(std::vector<std::vector<int>> &,
-                                          double, double, int, int, int, bool)> &interpolationFunction,
-                                          double a, double aa)
+double JPetRecoImageTools::calculateValue(Matrix2D& emissionMatrix, bool sang, int N, double cos,
+    double sin, double scale, int center,
+    InterpolationFunc& interpolationFunction,
+    double a, double aa)
 {
   double b = 0.;
   if (sang)
@@ -140,18 +124,13 @@ double JPetRecoImageTools::calculateValue(std::vector<std::vector<int>> &emissio
   double value = 0.;
   int x = 0;
   int y = 0;
-  if (sang)
-  {
-    for (x = -center; x < center; x++)
-    {
+  if (sang) {
+    for (x = -center; x < center; x++) {
       value += interpolationFunction(emissionMatrix, a, b, center, x, y, sang);
     }
     value /= std::abs(sin);
-  }
-  else
-  {
-    for (y = -center; y < center; y++)
-    {
+  } else {
+    for (y = -center; y < center; y++) {
       value += interpolationFunction(emissionMatrix, aa, b, center, x, y, sang);
     }
     value /= std::abs(cos);
@@ -159,14 +138,14 @@ double JPetRecoImageTools::calculateValue(std::vector<std::vector<int>> &emissio
   return value;
 }
 
-void JPetRecoImageTools::scale(std::vector<std::vector<double>> &v, int min, int max)
+void JPetRecoImageTools::scale(Matrix2DProj& v, int min, int max)
 {
+
   double datamax = v[0][0];
   double datamin = v[0][0];
-  for (unsigned int k = 0; k < v.size(); k++)
-  {
-    for (unsigned int j = 0; j < v[0].size(); j++)
-    {
+  //auto datamin = *std::min(v.begin(), v.end(), [] (const std::vector<double> & a, const std::vector<double>& b) { return std::min(a.begin(), a.end()) <std::min(b.begin(), b.end());});
+  for (unsigned int k = 0; k < v.size(); k++) {
+    for (unsigned int j = 0; j < v[0].size(); j++) {
       if (v[k][j] < min)
         v[k][j] = min;
       if (v[k][j] > datamax)
@@ -179,10 +158,8 @@ void JPetRecoImageTools::scale(std::vector<std::vector<double>> &v, int min, int
   if (datamax == 0.) // if max value is 0, no need to scale
     return;
 
-  for (unsigned int k = 0; k < v.size(); k++)
-  {
-    for (unsigned int j = 0; j < v[0].size(); j++)
-    {
+  for (unsigned int k = 0; k < v.size(); k++) {
+    for (unsigned int j = 0; j < v[0].size(); j++) {
       v[k][j] = (double)((v[k][j] - datamin) * max / datamax);
     }
   }

--- a/modules/JPetRecoImageTools/JPetRecoImageTools.cpp
+++ b/modules/JPetRecoImageTools/JPetRecoImageTools.cpp
@@ -26,7 +26,7 @@ JPetRecoImageTools::JPetRecoImageTools() {}
 
 JPetRecoImageTools::~JPetRecoImageTools() {}
 
-double JPetRecoImageTools::nearestNeighbour(Matrix2D& emissionMatrix, double a, double b,
+double JPetRecoImageTools::nearestNeighbour(const Matrix2D& emissionMatrix, double a, double b,
     int center, int x, int y, bool sang)
 {
   if (sang) {
@@ -42,7 +42,7 @@ double JPetRecoImageTools::nearestNeighbour(Matrix2D& emissionMatrix, double a, 
   }
 }
 
-double JPetRecoImageTools::linear(Matrix2D& emissionMatrix, double a, double b,
+double JPetRecoImageTools::linear(const Matrix2D& emissionMatrix, double a, double b,
                                   int center, int x, int y, bool sang)
 {
   if (sang) {

--- a/modules/JPetRecoImageTools/JPetRecoImageTools.h
+++ b/modules/JPetRecoImageTools/JPetRecoImageTools.h
@@ -25,10 +25,10 @@ class JPetRecoImageTools
 public:
   using Matrix2D = std::vector<std::vector<int>>;
   using Matrix2DProj = std::vector<std::vector<double>>;
-  using InterpolationFunc = std::function<double(Matrix2D&, double, double, int, int, int, bool)>;
-  static double nearestNeighbour(Matrix2D& emissionMatrix,
+  using InterpolationFunc = std::function<double(const Matrix2D&, double, double, int, int, int, bool)>;
+  static double nearestNeighbour(const Matrix2D& emissionMatrix,
                                  double a, double b, int center, int x, int y, bool sang);
-  static double linear(Matrix2D& emissionMatrix,
+  static double linear(const Matrix2D& emissionMatrix,
                        double a, double b, int center, int x, int y, bool sang);
 
   /*! \brief Function returning sinogram matrix.

--- a/modules/JPetRecoImageTools/JPetRecoImageTools.h
+++ b/modules/JPetRecoImageTools/JPetRecoImageTools.h
@@ -1,4 +1,3 @@
-
 /**
  *  @copyright Copyright 2016 The J-PET Framework Authors. All rights reserved.
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,11 +28,27 @@ public:
   using InterpolationFunc = std::function<double(int i, double y, std::function<double(int, int)>&)>;
   using RescaleFunc = std::function<void(Matrix2DProj& v, double minCutoff, double rescaleFactor)>;
 
+  /// Returns a matrixGetter, that can be used to return matrix elements in the following way:
+  /// if isTransposed is set to false, matrixGetter returns matrix[i][j]
+  /// else matrixGetter returns matrix[j][i].
+  /// In addition if the indices goes outside of the matrix range 0 is retuned.
+  /// It is assumed that the input matrix is quadratic.
+  /// The produced functions can be used as an input to interpolation functions.
+  static std::function<double(int, int)> matrixGetterFactory(const Matrix2D& emissionMatrix, bool isTransposed = false);
+
+  /*! \brief function returning func(i,j) where j is the  nearest neighbour index with respect to y.
+   *  \param i discrete index being the first parameter of the function func.
+   *  \param y the double value for which the nearste neighoubring discrete index is calculated.
+   *  \param func function that returns double value based on two discrete i,j.
+  */
   static double nearestNeighbour(int i, double y, std::function<double(int, int)>& func);
+  /*! \brief Linear interpolation function returning (1-t)*func(i,j) + t* func(i,j+1).
+   *  \param i discrete index being the first parameter of the function func.
+   *  \param y the double value for which the j index  and t parameters are calculated.
+   *  \param func function that returns double value based on two discrete i,j.
+  */
   static double linear(int i, double y, std::function<double(int, int)>& func);
 
-  static std::function<double(int, int)> getValue(const Matrix2D& emissionMatrix);
-  static std::function<double(int, int)> getValue2(const Matrix2D& emissionMatrix);
 
   /// Rescale the Matrix in the following way:
   /// 1. All the values less than minCutoff are set to minCutoff
@@ -63,18 +78,18 @@ public:
                                int rescaleMinCutoff = 0,
                                int rescaleFactor = 255
                               );
+  static double calculateProjection(const Matrix2D& emissionMatrix,
+                                    double phi,
+                                    int scanNumber,
+                                    int nScans,
+                                    InterpolationFunc& interpolationFunction
+                                   );
 private:
   JPetRecoImageTools();
   ~JPetRecoImageTools();
   JPetRecoImageTools(const JPetRecoImageTools&) = delete;
   JPetRecoImageTools& operator=(const JPetRecoImageTools&) = delete;
 
-  static double calculateProjection(Matrix2D& emissionMatrix,
-                                    double phi,
-                                    int scanNumber,
-                                    int nScans,
-                                    InterpolationFunc& interpolationFunction
-                                   );
   static inline double setToZeroIfSmall(double value, double epsilon) {
     if (std::abs(value) < epsilon) return 0;
     else return value;

--- a/modules/JPetRecoImageTools/JPetRecoImageTools.h
+++ b/modules/JPetRecoImageTools/JPetRecoImageTools.h
@@ -1,3 +1,4 @@
+
 /**
  *  @copyright Copyright 2016 The J-PET Framework Authors. All rights reserved.
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -58,8 +59,8 @@ private:
   JPetRecoImageTools(const JPetRecoImageTools&) = delete;
   JPetRecoImageTools& operator=(const JPetRecoImageTools&) = delete;
 
-  static double calculateProjection(Matrix2D& emissionMatrix, bool sang, int N, double cos, double sin,
-                                    double scale, int center,
+  static double calculateProjection(Matrix2D& emissionMatrix, int N, double cos, double sin,
+                                    double scale,
                                     InterpolationFunc& interpolationFunction, double a, double aa);
 };
 

--- a/modules/JPetRecoImageTools/JPetRecoImageTools.h
+++ b/modules/JPetRecoImageTools/JPetRecoImageTools.h
@@ -27,10 +27,22 @@ public:
   using Matrix2D = std::vector<std::vector<int>>;
   using Matrix2DProj = std::vector<std::vector<double>>;
   using InterpolationFunc = std::function<double(const Matrix2D&, double, double, int, int, int, bool)>;
+  using RescaleFunc = std::function<void(Matrix2DProj& v, double minCutoff, double rescaleFactor)>;
+
   static double nearestNeighbour(const Matrix2D& emissionMatrix,
                                  double a, double b, int center, int x, int y, bool sang);
   static double linear(const Matrix2D& emissionMatrix,
                        double a, double b, int center, int x, int y, bool sang);
+  /// Rescale the Matrix in the following way:
+  /// 1. All the values less than minCutoff are set to minCutoff
+  /// 2. Removes the common backgroud term. So the values start at zero
+  /// 3. Rescales all values by rescaleFactor/maxElement
+  /// The final value range is from 0 to rescaleFactor
+  static void rescale(Matrix2DProj& v, double minCutoff, double rescaleFactor);
+  /// PseudoRescale which does nothing
+  static void nonRescale(Matrix2DProj&, double, double) {
+    return;
+  }
 
   /*! \brief Function returning sinogram matrix.
    *  \param emissionMatrix matrix,  needs to be NxN
@@ -39,21 +51,16 @@ public:
    *  \param interpolationFunction function to interpolate values (Optional, default linear)
    *  \param angleBeg start angle for projection in deg (Optional, default 0)
    *  \param angleEnd end angle for projection in deg(Optional, default 180)
-   *  \param scaleResult if set to true, scale result to <min, max> (Optional, default false)
-   *  \param min minimum value in returned sinogram (Optional, default 0)
-   *  \param max maximum value in returned sinogram (Optional, default 255)
+   *  \param rescaleFunc function that rescales the final result (Optional, default no rescaling)
   */
   static Matrix2DProj sinogram(Matrix2D& emissionMatrix,
                                int nViews, int nScans,
+                               double angleBeg = 0, double angleEnd = 180,
                                InterpolationFunc interpolationFunction = linear,
-                               double angleBeg = 0, double angleEnd = 180, bool scaleResult = false,
-                               int min = 0, int max = 255);
-  /// Rescale the Matrix in the following way:
-  /// 1. All the values less than minCutoff are set to minCutoff
-  /// 2. Removes the common backgroud term. So the values start at zero
-  /// 3. Rescales all values by rescaleFactor/maxElement
-  /// The final value range is from 0 to rescaleFactor
-  static void rescale(Matrix2DProj& v, double minCutoff, double rescaleFactor);
+                               RescaleFunc rescaleFunc = nonRescale,
+                               int rescaleMinCutoff = 0,
+                               int rescaleFactor = 255
+                              );
 private:
   JPetRecoImageTools();
   ~JPetRecoImageTools();

--- a/modules/JPetRecoImageTools/JPetRecoImageTools.h
+++ b/modules/JPetRecoImageTools/JPetRecoImageTools.h
@@ -1,3 +1,17 @@
+/**
+ *  @copyright Copyright 2016 The J-PET Framework Authors. All rights reserved.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may find a copy of the License in the LICENCE file.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  @file JPetRecoImageTools.h
+ */
 
 #ifndef _JPetRecoImageTools_H_
 #define _JPetRecoImageTools_H_

--- a/modules/JPetRecoImageTools/JPetRecoImageTools.h
+++ b/modules/JPetRecoImageTools/JPetRecoImageTools.h
@@ -69,12 +69,9 @@ private:
 
   static double calculateProjection(Matrix2D& emissionMatrix,
                                     int N,
-                                    double cos,
-                                    double sin,
+                                    double phi,
                                     double scale,
-                                    InterpolationFunc& interpolationFunction,
-                                    double a,
-                                    double aa
+                                    InterpolationFunc& interpolationFunction
                                    );
   static inline double setToZeroIfSmall(double value, double epsilon) {
     if (std::abs(value) < epsilon) return 0;

--- a/modules/JPetRecoImageTools/JPetRecoImageTools.h
+++ b/modules/JPetRecoImageTools/JPetRecoImageTools.h
@@ -18,6 +18,7 @@
 #define _JPetRecoImageTools_H_
 
 #include <vector>
+#include <cmath>
 #include <functional>
 
 class JPetRecoImageTools
@@ -45,7 +46,7 @@ public:
   static Matrix2DProj sinogram(Matrix2D& emissionMatrix,
                                int nViews, int nScans,
                                InterpolationFunc interpolationFunction = linear,
-                               float angleBeg = 0, float angleEnd = 180, bool scaleResult = false,
+                               double angleBeg = 0, double angleEnd = 180, bool scaleResult = false,
                                int min = 0, int max = 255);
   /// Rescale the Matrix in the following way:
   /// 1. All the values less than minCutoff are set to minCutoff
@@ -59,9 +60,19 @@ private:
   JPetRecoImageTools(const JPetRecoImageTools&) = delete;
   JPetRecoImageTools& operator=(const JPetRecoImageTools&) = delete;
 
-  static double calculateProjection(Matrix2D& emissionMatrix, int N, double cos, double sin,
+  static double calculateProjection(Matrix2D& emissionMatrix,
+                                    int N,
+                                    double cos,
+                                    double sin,
                                     double scale,
-                                    InterpolationFunc& interpolationFunction, double a, double aa);
+                                    InterpolationFunc& interpolationFunction,
+                                    double a,
+                                    double aa
+                                   );
+  static inline double setToZeroIfSmall(double value, double epsilon) {
+    if (std::abs(value) < epsilon) return 0;
+    else return value;
+  }
 };
 
 #endif

--- a/modules/JPetRecoImageTools/JPetRecoImageTools.h
+++ b/modules/JPetRecoImageTools/JPetRecoImageTools.h
@@ -32,14 +32,18 @@ public:
                                InterpolationFunc interpolationFunction = linear,
                                float ang1 = 0, float ang2 = 180, bool scaleResult = false,
                                int min = 0, int max = 255);
-
+  /// Rescale the Matrix in the following way:
+  /// 1. All the values less than minCutoff are set to minCutoff
+  /// 2. Removes the common backgroud term. So the values start at zero
+  /// 3. Rescales all values by rescaleFactor/maxElement
+  /// The final value range is from 0 to rescaleFactor
+  static void rescale(Matrix2DProj& v, double minCutoff, double rescaleFactor);
 private:
   JPetRecoImageTools();
   ~JPetRecoImageTools();
   JPetRecoImageTools(const JPetRecoImageTools&) = delete;
   JPetRecoImageTools& operator=(const JPetRecoImageTools&) = delete;
 
-  static void scale(Matrix2DProj& v, int min, int max);
   static double calculateValue(Matrix2D& emissionMatrix, bool sang, int N, double cos, double sin,
                                double scale, int center,
                                InterpolationFunc& interpolationFunction, double a, double aa);

--- a/modules/JPetRecoImageTools/JPetRecoImageTools.h
+++ b/modules/JPetRecoImageTools/JPetRecoImageTools.h
@@ -68,9 +68,9 @@ private:
   JPetRecoImageTools& operator=(const JPetRecoImageTools&) = delete;
 
   static double calculateProjection(Matrix2D& emissionMatrix,
-                                    int N,
                                     double phi,
-                                    double scale,
+                                    int scanNumber,
+                                    int nScans,
                                     InterpolationFunc& interpolationFunction
                                    );
   static inline double setToZeroIfSmall(double value, double epsilon) {

--- a/modules/JPetRecoImageTools/JPetRecoImageTools.h
+++ b/modules/JPetRecoImageTools/JPetRecoImageTools.h
@@ -3,35 +3,46 @@
 #define _JPetRecoImageTools_H_
 
 #include <vector>
-#include <utility>
 #include <functional>
 
 class JPetRecoImageTools
 {
 public:
-  static double nearestNeighbour(std::vector<std::vector<int>> &emissionMatrix,
+  using Matrix2D = std::vector<std::vector<int>>;
+  using Matrix2DProj = std::vector<std::vector<double>>;
+  using InterpolationFunc = std::function<double(Matrix2D&, double, double, int, int, int, bool)>;
+  static double nearestNeighbour(Matrix2D& emissionMatrix,
                                  double a, double b, int center, int x, int y, bool sang);
-  static double linear(std::vector<std::vector<int>> &emissionMatrix,
+  static double linear(Matrix2D& emissionMatrix,
                        double a, double b, int center, int x, int y, bool sang);
 
-  static std::vector<std::vector<double>> sinogram(std::vector<std::vector<int>> &emissionMatrix,
-                                                   int views, int scans,
-                                                   std::function<double(std::vector<std::vector<int>> &,
-                                                   double, double, int, int, int, bool)> interpolationFunction = linear,
-                                                   float ang1 = 0, float ang2 = 180, bool scaleResult = false,
-                                                   int min = 0, int max = 255);
+  /*! \brief Function returning vector of vectors with value of sinogram
+   *  \param emissionMatrix matrix, need to be NxN
+   *  \param views number of views on object, degree step is calculated as (ang2 - ang1) / views
+   *  \param scans number of scans on object, step is calculated as emissionMatrix[0].size() / scans
+   *  \param interpolationFunction function to interpolate values (Optional, default linear)
+   *  \param ang1 start angle for projection (Optional, default 0)
+   *  \param ang2 end angle for projection (Optional, default 180)
+   *  \param scaleResult if set to true, scale result to <min, max> (Optional, default false)
+   *  \param min minimum value in returned sinogram (Optional, default 0)
+   *  \param max maximum value in returned sinogram (Optional, default 255)
+  */
+  static Matrix2DProj sinogram(Matrix2D& emissionMatrix,
+                               int views, int scans,
+                               InterpolationFunc interpolationFunction = linear,
+                               float ang1 = 0, float ang2 = 180, bool scaleResult = false,
+                               int min = 0, int max = 255);
 
 private:
   JPetRecoImageTools();
   ~JPetRecoImageTools();
-  JPetRecoImageTools(const JPetRecoImageTools &) = delete;
-  JPetRecoImageTools &operator=(const JPetRecoImageTools &) = delete;
+  JPetRecoImageTools(const JPetRecoImageTools&) = delete;
+  JPetRecoImageTools& operator=(const JPetRecoImageTools&) = delete;
 
-  static void scale(std::vector<std::vector<double>> &v, int min, int max);
-  static double calculateValue(std::vector<std::vector<int>> &emissionMatrix, bool sang, int N, double cos, double sin,
+  static void scale(Matrix2DProj& v, int min, int max);
+  static double calculateValue(Matrix2D& emissionMatrix, bool sang, int N, double cos, double sin,
                                double scale, int center,
-                               std::function<double(std::vector<std::vector<int>> &,
-                               double, double, int, int, int, bool)> &interpolationFunction, double a, double aa);
+                               InterpolationFunc& interpolationFunction, double a, double aa);
 };
 
 #endif

--- a/modules/JPetRecoImageTools/JPetRecoImageTools.h
+++ b/modules/JPetRecoImageTools/JPetRecoImageTools.h
@@ -27,7 +27,16 @@ public:
   using Matrix2D = std::vector<std::vector<int>>;
   using Matrix2DProj = std::vector<std::vector<double>>;
   using InterpolationFunc = std::function<double(const Matrix2D&, double, double, int, int, int, bool)>;
+  using InterpolationFunc2 = std::function<double(int i, double y, std::function<double(int, int)>&)>;
   using RescaleFunc = std::function<void(Matrix2DProj& v, double minCutoff, double rescaleFactor)>;
+
+  static double nearestNeighbour2(int i, double y, std::function<double(int, int)>& func);
+  static double linear2(int i, double y, std::function<double(int, int)>& func);
+
+  static double linear3(std::function<double(int, int)>& getValue, double a, double b,
+                        int center, int i);
+  static std::function<double(int, int)> getValue(const Matrix2D& emissionMatrix);
+  static std::function<double(int, int)> getValue2(const Matrix2D& emissionMatrix);
 
   static double nearestNeighbour(const Matrix2D& emissionMatrix,
                                  double a, double b, int center, int x, int y, bool sang);
@@ -56,7 +65,7 @@ public:
   static Matrix2DProj sinogram(Matrix2D& emissionMatrix,
                                int nViews, int nScans,
                                double angleBeg = 0, double angleEnd = 180,
-                               InterpolationFunc interpolationFunction = linear,
+                               InterpolationFunc2 interpolationFunction = linear2,
                                RescaleFunc rescaleFunc = nonRescale,
                                int rescaleMinCutoff = 0,
                                int rescaleFactor = 255
@@ -71,7 +80,7 @@ private:
                                     double phi,
                                     int scanNumber,
                                     int nScans,
-                                    InterpolationFunc& interpolationFunction
+                                    InterpolationFunc2& interpolationFunction
                                    );
   static inline double setToZeroIfSmall(double value, double epsilon) {
     if (std::abs(value) < epsilon) return 0;

--- a/modules/JPetRecoImageTools/JPetRecoImageTools.h
+++ b/modules/JPetRecoImageTools/JPetRecoImageTools.h
@@ -26,22 +26,15 @@ class JPetRecoImageTools
 public:
   using Matrix2D = std::vector<std::vector<int>>;
   using Matrix2DProj = std::vector<std::vector<double>>;
-  using InterpolationFunc = std::function<double(const Matrix2D&, double, double, int, int, int, bool)>;
-  using InterpolationFunc2 = std::function<double(int i, double y, std::function<double(int, int)>&)>;
+  using InterpolationFunc = std::function<double(int i, double y, std::function<double(int, int)>&)>;
   using RescaleFunc = std::function<void(Matrix2DProj& v, double minCutoff, double rescaleFactor)>;
 
-  static double nearestNeighbour2(int i, double y, std::function<double(int, int)>& func);
-  static double linear2(int i, double y, std::function<double(int, int)>& func);
+  static double nearestNeighbour(int i, double y, std::function<double(int, int)>& func);
+  static double linear(int i, double y, std::function<double(int, int)>& func);
 
-  static double linear3(std::function<double(int, int)>& getValue, double a, double b,
-                        int center, int i);
   static std::function<double(int, int)> getValue(const Matrix2D& emissionMatrix);
   static std::function<double(int, int)> getValue2(const Matrix2D& emissionMatrix);
 
-  static double nearestNeighbour(const Matrix2D& emissionMatrix,
-                                 double a, double b, int center, int x, int y, bool sang);
-  static double linear(const Matrix2D& emissionMatrix,
-                       double a, double b, int center, int x, int y, bool sang);
   /// Rescale the Matrix in the following way:
   /// 1. All the values less than minCutoff are set to minCutoff
   /// 2. Removes the common backgroud term. So the values start at zero
@@ -65,7 +58,7 @@ public:
   static Matrix2DProj sinogram(Matrix2D& emissionMatrix,
                                int nViews, int nScans,
                                double angleBeg = 0, double angleEnd = 180,
-                               InterpolationFunc2 interpolationFunction = linear2,
+                               InterpolationFunc interpolationFunction = linear,
                                RescaleFunc rescaleFunc = nonRescale,
                                int rescaleMinCutoff = 0,
                                int rescaleFactor = 255
@@ -80,7 +73,7 @@ private:
                                     double phi,
                                     int scanNumber,
                                     int nScans,
-                                    InterpolationFunc2& interpolationFunction
+                                    InterpolationFunc& interpolationFunction
                                    );
   static inline double setToZeroIfSmall(double value, double epsilon) {
     if (std::abs(value) < epsilon) return 0;

--- a/modules/JPetRecoImageTools/JPetRecoImageTools.h
+++ b/modules/JPetRecoImageTools/JPetRecoImageTools.h
@@ -16,21 +16,21 @@ public:
   static double linear(Matrix2D& emissionMatrix,
                        double a, double b, int center, int x, int y, bool sang);
 
-  /*! \brief Function returning vector of vectors with value of sinogram
-   *  \param emissionMatrix matrix, need to be NxN
-   *  \param views number of views on object, degree step is calculated as (ang2 - ang1) / views
-   *  \param scans number of scans on object, step is calculated as emissionMatrix[0].size() / scans
+  /*! \brief Function returning sinogram matrix.
+   *  \param emissionMatrix matrix,  needs to be NxN
+   *  \param nViews number of views on object, degree step is calculated as (angleEnd - angleBeg) / nViews
+   *  \param nScans number of scans on object, step is calculated as emissionMatrix[0].size() / nScans
    *  \param interpolationFunction function to interpolate values (Optional, default linear)
-   *  \param ang1 start angle for projection (Optional, default 0)
-   *  \param ang2 end angle for projection (Optional, default 180)
+   *  \param angleBeg start angle for projection in deg (Optional, default 0)
+   *  \param angleEnd end angle for projection in deg(Optional, default 180)
    *  \param scaleResult if set to true, scale result to <min, max> (Optional, default false)
    *  \param min minimum value in returned sinogram (Optional, default 0)
    *  \param max maximum value in returned sinogram (Optional, default 255)
   */
   static Matrix2DProj sinogram(Matrix2D& emissionMatrix,
-                               int views, int scans,
+                               int nViews, int nScans,
                                InterpolationFunc interpolationFunction = linear,
-                               float ang1 = 0, float ang2 = 180, bool scaleResult = false,
+                               float angleBeg = 0, float angleEnd = 180, bool scaleResult = false,
                                int min = 0, int max = 255);
   /// Rescale the Matrix in the following way:
   /// 1. All the values less than minCutoff are set to minCutoff
@@ -44,9 +44,9 @@ private:
   JPetRecoImageTools(const JPetRecoImageTools&) = delete;
   JPetRecoImageTools& operator=(const JPetRecoImageTools&) = delete;
 
-  static double calculateValue(Matrix2D& emissionMatrix, bool sang, int N, double cos, double sin,
-                               double scale, int center,
-                               InterpolationFunc& interpolationFunction, double a, double aa);
+  static double calculateProjection(Matrix2D& emissionMatrix, bool sang, int N, double cos, double sin,
+                                    double scale, int center,
+                                    InterpolationFunc& interpolationFunction, double a, double aa);
 };
 
 #endif

--- a/modules/JPetRecoImageTools/JPetRecoImageToolsTest.cpp
+++ b/modules/JPetRecoImageTools/JPetRecoImageToolsTest.cpp
@@ -108,7 +108,7 @@ BOOST_AUTO_TEST_CASE(ONE_POINT_MATRIX_NOT_IN_CENTER_2)
   m[2][2] = 100;
   int views = 2;
   int scans = 4;
-  std::vector<std::vector<double>> result2 = JPetRecoImageTools::sinogram(m, views, scans, 0, 180,  JPetRecoImageTools::nearestNeighbour);
+  std::vector<std::vector<double>> result2 = JPetRecoImageTools::sinogram(m, views, scans, 0, 180,  JPetRecoImageTools::nearestNeighbour2);
   for (int i = 0; i < views; i++) {
     for (int j = 0; j < scans; j++) {
       if ((i == 0 && j == 2) || (i == 1 && j == 1))
@@ -144,7 +144,7 @@ BOOST_AUTO_TEST_CASE(sinogram)
   }
   int views = 180;
   int scans = 256;
-  std::vector<std::vector<double>> result = JPetRecoImageTools::sinogram(m, views, scans, 0, 180, JPetRecoImageTools::linear, JPetRecoImageTools::rescale);
+  std::vector<std::vector<double>> result = JPetRecoImageTools::sinogram(m, views, scans, 0, 180, JPetRecoImageTools::linear2, JPetRecoImageTools::rescale);
   /// save sinogram
   std::ofstream res(outFile);
   res << "P2" << std::endl;

--- a/modules/JPetRecoImageTools/JPetRecoImageToolsTest.cpp
+++ b/modules/JPetRecoImageTools/JPetRecoImageToolsTest.cpp
@@ -63,61 +63,140 @@ BOOST_AUTO_TEST_CASE(rescale_3)
   BOOST_REQUIRE_CLOSE(matrix[1][0], 0 * 8. / 3., epsilon );
   BOOST_REQUIRE_CLOSE(matrix[1][1], 0, epsilon );
 }
+BOOST_AUTO_TEST_CASE(matrixGetterFactoryTest)
+{
+  double epsilon = 0.00001;
+  JPetRecoImageTools::Matrix2D matrix = {{1, 2}, {3, 4}};
+  auto getter =  JPetRecoImageTools::matrixGetterFactory(matrix, false);
+  BOOST_REQUIRE_CLOSE(getter(0, 0), 1, epsilon);
+  BOOST_REQUIRE_CLOSE(getter(0, 1), 2, epsilon);
+  BOOST_REQUIRE_CLOSE(getter(1, 0), 3, epsilon);
+  BOOST_REQUIRE_CLOSE(getter(1, 1), 4, epsilon);
+  BOOST_REQUIRE_CLOSE(getter(3, 3), 0, epsilon); /// out of range should return 0
+  auto getterT =  JPetRecoImageTools::matrixGetterFactory(matrix, true); /// transposed
+  BOOST_REQUIRE_CLOSE(getterT(0, 0), 1, epsilon);
+  BOOST_REQUIRE_CLOSE(getterT(0, 1), 3, epsilon);
+  BOOST_REQUIRE_CLOSE(getterT(1, 0), 2, epsilon);
+  BOOST_REQUIRE_CLOSE(getterT(1, 1), 4, epsilon);
+  BOOST_REQUIRE_CLOSE(getterT(3, 3), 0, epsilon); /// out of range should return 0
+}
 
-//BOOST_AUTO_TEST_CASE(nearestNeighbours)
+BOOST_AUTO_TEST_CASE(nearestNeighbour)
+{
+  double epsilon = 0.00001;
+  JPetRecoImageTools::Matrix2D matrix = {{1, 2}, {3, 4}};
+  auto getter =  JPetRecoImageTools::matrixGetterFactory(matrix, false);
+  /// first argument is i second j  (i,j)
+  BOOST_REQUIRE_CLOSE(JPetRecoImageTools::nearestNeighbour(0, 0, getter), 1, epsilon);
+  BOOST_REQUIRE_CLOSE(JPetRecoImageTools::nearestNeighbour(1, 0, getter), 3, epsilon);
+  BOOST_REQUIRE_CLOSE(JPetRecoImageTools::nearestNeighbour(0, 0.6, getter), 2, epsilon); // (0,1)
+  BOOST_REQUIRE_CLOSE(JPetRecoImageTools::nearestNeighbour(0, 0.4, getter), 1, epsilon); // (0,0)
+  BOOST_REQUIRE_CLOSE(JPetRecoImageTools::nearestNeighbour(1, 0.4, getter), 3, epsilon); // (0,0)
+  BOOST_REQUIRE_CLOSE(JPetRecoImageTools::nearestNeighbour(1, 0.8, getter), 4, epsilon); // (0,0)
+  auto getterT =  JPetRecoImageTools::matrixGetterFactory(matrix, true); /// transposed
+  /// first argument is j second i  (j,i)
+  BOOST_REQUIRE_CLOSE(JPetRecoImageTools::nearestNeighbour(0, 0, getterT), 1, epsilon);
+  BOOST_REQUIRE_CLOSE(JPetRecoImageTools::nearestNeighbour(1, 0, getterT), 2, epsilon);
+  BOOST_REQUIRE_CLOSE(JPetRecoImageTools::nearestNeighbour(0, 0.6, getterT), 3, epsilon); // (1,0)
+  BOOST_REQUIRE_CLOSE(JPetRecoImageTools::nearestNeighbour(0, 0.4, getterT), 1, epsilon); // (0,0)
+  BOOST_REQUIRE_CLOSE(JPetRecoImageTools::nearestNeighbour(1, 0.4, getterT), 2, epsilon); // (0,1)
+  BOOST_REQUIRE_CLOSE(JPetRecoImageTools::nearestNeighbour(1, 0.8, getterT), 4, epsilon); // (1,1)
+}
+
+
+BOOST_AUTO_TEST_CASE(linear)
+{
+  double epsilon = 0.00001;
+  JPetRecoImageTools::Matrix2D matrix = {{1, 2}, {3, 4}};
+  auto getter =  JPetRecoImageTools::matrixGetterFactory(matrix, false);
+  /// first argument is i second j  (i,j)
+  BOOST_REQUIRE_CLOSE(JPetRecoImageTools::linear(0, 0, getter), 1, epsilon);
+  BOOST_REQUIRE_CLOSE(JPetRecoImageTools::linear(0, 1, getter), 2, epsilon);
+  BOOST_REQUIRE_CLOSE(JPetRecoImageTools::linear(0, 0.9, getter), 1.9, epsilon);
+  BOOST_REQUIRE_CLOSE(JPetRecoImageTools::linear(1, 0, getter), 3, epsilon);
+  BOOST_REQUIRE_CLOSE(JPetRecoImageTools::linear(0, 0.4, getter), 1.4, epsilon); // 1 * 0.6 + 2 * 0.4
+  BOOST_REQUIRE_CLOSE(JPetRecoImageTools::linear(1, 0.4, getter), 3.4, epsilon); //  3* 0.6 + 4 * 0.4
+  auto getterT =  JPetRecoImageTools::matrixGetterFactory(matrix, true); /// transposed
+  /// first argument is j second i  (j,i)
+  BOOST_REQUIRE_CLOSE(JPetRecoImageTools::linear(0, 0, getterT), 1, epsilon);
+  BOOST_REQUIRE_CLOSE(JPetRecoImageTools::linear(1, 0, getterT), 2, epsilon);
+  BOOST_REQUIRE_CLOSE(JPetRecoImageTools::linear(0, 0.6, getterT), 2.2, epsilon); //1*0.4 +  3  *0.6
+}
+
+//BOOST_AUTO_TEST_CASE(calculateProjection)
 //{
-//JPetRecoImageTools::Matrix2D matrix = { {1, 2}, {3, 4}};
-//auto result = JPetRecoImageTools::nearestNeighbour(matrix, 0, 0, 0, 0 , 0, true);
-//std::cout << "result=" << result << std::endl;
-//result = JPetRecoImageTools::nearestNeighbour(matrix, 0, 0, 0, 0 , 0, false);
-//std::cout << "result=" << result << std::endl;
-//result = JPetRecoImageTools::nearestNeighbour(matrix, 1, 1, 1, 1 , 1, true);
-//std::cout << "result=" << result << std::endl;
+//double epsilon = 0.00001;
+//JPetRecoImageTools::Matrix2D matrix = {{4}};
+////static double calculateProjection(const Matrix2D& emissionMatrix,
+////double phi,
+////int scanNumber,
+////int nScans,
+////InterpolationFunc& interpolationFunction
+////);
+///// first argument is i second j  (i,j)
+//JPetRecoImageTools::InterpolationFunc func = JPetRecoImageTools::nearestNeighbour;
+//BOOST_REQUIRE_CLOSE(JPetRecoImageTools::calculateProjection(matrix,0,0,1, func), 4, epsilon);
 //}
 
-BOOST_AUTO_TEST_CASE(ONE_POINT_MATRIX_NOT_IN_CENTER)
-{
-  std::vector<std::vector<int>> m(4, std::vector<int>(4));
-  for (unsigned int i = 0; i < 4; i++) {
-    for (unsigned int j = 0; j < 4; j++) {
-      m[i][j] = 0;
-    }
-  }
-  m[2][2] = 100;
-  int views = 2;
-  int scans = 4;
-  std::vector<std::vector<double>> result = JPetRecoImageTools::sinogram(m, views, scans);
-  for (int i = 0; i < views; i++) {
-    for (int j = 0; j < scans; j++) {
-      if ((i == 0 && j == 2) || (i == 1 && j == 1))
-        BOOST_REQUIRE_EQUAL(result[i][j], 100);
-      else
-        BOOST_REQUIRE_EQUAL(result[i][j], 0);
-    }
-  }
-}
+//BOOST_AUTO_TEST_CASE(calculateProjection2)
+//{
+//double epsilon = 0.00001;
+//JPetRecoImageTools::Matrix2D matrix = {{1, 2}, {3, 4}};
+////static double calculateProjection(const Matrix2D& emissionMatrix,
+////double phi,
+////int scanNumber,
+////int nScans,
+////InterpolationFunc& interpolationFunction
+////);
+///// first argument is i second j  (i,j)
+//JPetRecoImageTools::InterpolationFunc func = JPetRecoImageTools::linear;
+//BOOST_REQUIRE_CLOSE(JPetRecoImageTools::calculateProjection(matrix,0,0,1, func), 4, epsilon);
+//}
 
-BOOST_AUTO_TEST_CASE(ONE_POINT_MATRIX_NOT_IN_CENTER_2)
-{
-  std::vector<std::vector<int>> m(4, std::vector<int>(4));
-  for (unsigned int i = 0; i < 4; i++) {
-    for (unsigned int j = 0; j < 4; j++) {
-      m[i][j] = 0;
-    }
-  }
-  m[2][2] = 100;
-  int views = 2;
-  int scans = 4;
-  std::vector<std::vector<double>> result2 = JPetRecoImageTools::sinogram(m, views, scans, 0, 180,  JPetRecoImageTools::nearestNeighbour);
-  for (int i = 0; i < views; i++) {
-    for (int j = 0; j < scans; j++) {
-      if ((i == 0 && j == 2) || (i == 1 && j == 1))
-        BOOST_REQUIRE_EQUAL(result2[i][j], 100);
-      else
-        BOOST_REQUIRE_EQUAL(result2[i][j], 0);
-    }
-  }
-}
+
+//BOOST_AUTO_TEST_CASE(ONE_POINT_MATRIX_NOT_IN_CENTER)
+//{
+//std::vector<std::vector<int>> m(4, std::vector<int>(4));
+//for (unsigned int i = 0; i < 4; i++) {
+//for (unsigned int j = 0; j < 4; j++) {
+//m[i][j] = 0;
+//}
+//}
+//m[2][2] = 100;
+//int views = 2;
+//int scans = 4;
+//std::vector<std::vector<double>> result = JPetRecoImageTools::sinogram(m, views, scans);
+//for (int i = 0; i < views; i++) {
+//for (int j = 0; j < scans; j++) {
+//if ((i == 0 && j == 2) || (i == 1 && j == 1))
+//BOOST_REQUIRE_EQUAL(result[i][j], 100);
+//else
+//BOOST_REQUIRE_EQUAL(result[i][j], 0);
+//}
+//}
+//}
+
+//BOOST_AUTO_TEST_CASE(ONE_POINT_MATRIX_NOT_IN_CENTER_2)
+//{
+//std::vector<std::vector<int>> m(4, std::vector<int>(4));
+//for (unsigned int i = 0; i < 4; i++) {
+//for (unsigned int j = 0; j < 4; j++) {
+//m[i][j] = 0;
+//}
+//}
+//m[2][2] = 100;
+//int views = 2;
+//int scans = 4;
+//std::vector<std::vector<double>> result2 = JPetRecoImageTools::sinogram(m, views, scans, 0, 180,  JPetRecoImageTools::nearestNeighbour);
+//for (int i = 0; i < views; i++) {
+//for (int j = 0; j < scans; j++) {
+//if ((i == 0 && j == 2) || (i == 1 && j == 1))
+//BOOST_REQUIRE_EQUAL(result2[i][j], 100);
+//else
+//BOOST_REQUIRE_EQUAL(result2[i][j], 0);
+//}
+//}
+//}
 
 /// This test takes a Shepp-Logan phantom and creates a sinogram.
 BOOST_AUTO_TEST_CASE(sinogram)

--- a/modules/JPetRecoImageTools/JPetRecoImageToolsTest.cpp
+++ b/modules/JPetRecoImageTools/JPetRecoImageToolsTest.cpp
@@ -7,6 +7,7 @@
 #include <iostream>
 
 #include "./JPetRecoImageTools.h"
+#include "../../JPetCommonTools/JPetCommonTools.h"
 
 BOOST_AUTO_TEST_SUITE(FirstSuite)
 
@@ -94,7 +95,19 @@ BOOST_AUTO_TEST_CASE(ONE_POINT_MATRIX_NOT_IN_CENTER)
         BOOST_REQUIRE_EQUAL(result[i][j], 0);
     }
   }
+}
 
+BOOST_AUTO_TEST_CASE(ONE_POINT_MATRIX_NOT_IN_CENTER_2)
+{
+  std::vector<std::vector<int>> m(4, std::vector<int>(4));
+  for (unsigned int i = 0; i < 4; i++) {
+    for (unsigned int j = 0; j < 4; j++) {
+      m[i][j] = 0;
+    }
+  }
+  m[2][2] = 100;
+  int views = 2;
+  int scans = 4;
   std::vector<std::vector<double>> result2 = JPetRecoImageTools::sinogram(m, views, scans, JPetRecoImageTools::nearestNeighbour);
   for (int i = 0; i < views; i++) {
     for (int j = 0; j < scans; j++) {
@@ -106,16 +119,16 @@ BOOST_AUTO_TEST_CASE(ONE_POINT_MATRIX_NOT_IN_CENTER)
   }
 }
 
+/// This test takes a Shepp-Logan phantom and creates a sinogram.
 BOOST_AUTO_TEST_CASE(sinogram)
 {
-
-  std::ifstream in;
-  in.open("unitTestData/JPetRecoImageToolsTest/phantom.pgm");
+  const auto inFile = "unitTestData/JPetSinogramTest/phantom.pgm";
+  const auto outFile = "sinogram.ppm";
+  /// read phantom
+  std::ifstream in(inFile);
+  BOOST_REQUIRE(in);
   std::string line;
   getline(in, line);
-  if (line != "P2") {
-  }
-
   unsigned int width;
   unsigned int height;
   in >> width;
@@ -132,20 +145,18 @@ BOOST_AUTO_TEST_CASE(sinogram)
   int views = 180;
   int scans = 256;
   std::vector<std::vector<double>> result = JPetRecoImageTools::sinogram(m, views, scans, JPetRecoImageTools::linear, 0, 180, true, 0, 255);
-  std::ofstream res;
-  res.open("unitTestData/JPetRecoImageToolsTest/sinogram.ppm");
+  /// save sinogram
+  std::ofstream res(outFile);
   res << "P2" << std::endl;
   res << scans << " " << views << std::endl;
   res << "255" << std::endl;
-
   for (int i = 0; i < views; i++) {
     for (int j = 0; j < scans; j++) {
-      res << (int)result[i][j] << " ";
+      res << static_cast<int>(result[i][j]) << " ";
     }
     res << std::endl;
   }
-
   res.close();
+  BOOST_REQUIRE(JPetCommonTools::ifFileExisting(outFile));
 }
-
 BOOST_AUTO_TEST_SUITE_END()

--- a/modules/JPetRecoImageTools/JPetRecoImageToolsTest.cpp
+++ b/modules/JPetRecoImageTools/JPetRecoImageToolsTest.cpp
@@ -63,6 +63,17 @@ BOOST_AUTO_TEST_CASE(rescale_3)
   BOOST_REQUIRE_CLOSE(matrix[1][1], 0, epsilon );
 }
 
+BOOST_AUTO_TEST_CASE(nearestNeighbours)
+{
+  JPetRecoImageTools::Matrix2D matrix = { {1, 2}, {3, 4}};
+  auto result = JPetRecoImageTools::nearestNeighbour(matrix, 0, 0, 0, 0 , 0, true);
+  std::cout << "result=" << result << std::endl;
+  result = JPetRecoImageTools::nearestNeighbour(matrix, 0, 0, 0, 0 , 0, false);
+  std::cout << "result=" << result << std::endl;
+  result = JPetRecoImageTools::nearestNeighbour(matrix, 1, 1, 1, 1 , 1, true);
+  std::cout << "result=" << result << std::endl;
+}
+
 BOOST_AUTO_TEST_CASE(ONE_POINT_MATRIX_NOT_IN_CENTER)
 {
   std::vector<std::vector<int>> m(4, std::vector<int>(4));

--- a/modules/JPetRecoImageTools/JPetRecoImageToolsTest.cpp
+++ b/modules/JPetRecoImageTools/JPetRecoImageToolsTest.cpp
@@ -108,7 +108,7 @@ BOOST_AUTO_TEST_CASE(ONE_POINT_MATRIX_NOT_IN_CENTER_2)
   m[2][2] = 100;
   int views = 2;
   int scans = 4;
-  std::vector<std::vector<double>> result2 = JPetRecoImageTools::sinogram(m, views, scans, JPetRecoImageTools::nearestNeighbour);
+  std::vector<std::vector<double>> result2 = JPetRecoImageTools::sinogram(m, views, scans, 0, 180,  JPetRecoImageTools::nearestNeighbour);
   for (int i = 0; i < views; i++) {
     for (int j = 0; j < scans; j++) {
       if ((i == 0 && j == 2) || (i == 1 && j == 1))
@@ -144,7 +144,7 @@ BOOST_AUTO_TEST_CASE(sinogram)
   }
   int views = 180;
   int scans = 256;
-  std::vector<std::vector<double>> result = JPetRecoImageTools::sinogram(m, views, scans, JPetRecoImageTools::linear, 0, 180, true, 0, 255);
+  std::vector<std::vector<double>> result = JPetRecoImageTools::sinogram(m, views, scans, 0, 180, JPetRecoImageTools::linear);
   /// save sinogram
   std::ofstream res(outFile);
   res << "P2" << std::endl;

--- a/modules/JPetRecoImageTools/JPetRecoImageToolsTest.cpp
+++ b/modules/JPetRecoImageTools/JPetRecoImageToolsTest.cpp
@@ -108,7 +108,7 @@ BOOST_AUTO_TEST_CASE(ONE_POINT_MATRIX_NOT_IN_CENTER_2)
   m[2][2] = 100;
   int views = 2;
   int scans = 4;
-  std::vector<std::vector<double>> result2 = JPetRecoImageTools::sinogram(m, views, scans, 0, 180,  JPetRecoImageTools::nearestNeighbour2);
+  std::vector<std::vector<double>> result2 = JPetRecoImageTools::sinogram(m, views, scans, 0, 180,  JPetRecoImageTools::nearestNeighbour);
   for (int i = 0; i < views; i++) {
     for (int j = 0; j < scans; j++) {
       if ((i == 0 && j == 2) || (i == 1 && j == 1))
@@ -144,7 +144,7 @@ BOOST_AUTO_TEST_CASE(sinogram)
   }
   int views = 180;
   int scans = 256;
-  std::vector<std::vector<double>> result = JPetRecoImageTools::sinogram(m, views, scans, 0, 180, JPetRecoImageTools::linear2, JPetRecoImageTools::rescale);
+  std::vector<std::vector<double>> result = JPetRecoImageTools::sinogram(m, views, scans, 0, 180, JPetRecoImageTools::linear, JPetRecoImageTools::rescale);
   /// save sinogram
   std::ofstream res(outFile);
   res << "P2" << std::endl;

--- a/modules/JPetRecoImageTools/JPetRecoImageToolsTest.cpp
+++ b/modules/JPetRecoImageTools/JPetRecoImageToolsTest.cpp
@@ -144,7 +144,7 @@ BOOST_AUTO_TEST_CASE(sinogram)
   }
   int views = 180;
   int scans = 256;
-  std::vector<std::vector<double>> result = JPetRecoImageTools::sinogram(m, views, scans, 0, 180, JPetRecoImageTools::linear);
+  std::vector<std::vector<double>> result = JPetRecoImageTools::sinogram(m, views, scans, 0, 180, JPetRecoImageTools::linear, JPetRecoImageTools::rescale);
   /// save sinogram
   std::ofstream res(outFile);
   res << "P2" << std::endl;

--- a/modules/JPetRecoImageTools/JPetRecoImageToolsTest.cpp
+++ b/modules/JPetRecoImageTools/JPetRecoImageToolsTest.cpp
@@ -10,6 +10,19 @@
 
 BOOST_AUTO_TEST_SUITE(FirstSuite)
 
+BOOST_AUTO_TEST_CASE(rescale_0)
+{
+  JPetRecoImageTools::Matrix2DProj matrix = { {3, 0}, {0, 0}};
+  double resFact = 5;
+  double minCutoff = 0;
+  double epsilon = 0.00001;
+  JPetRecoImageTools::rescale(matrix, minCutoff, resFact);
+  BOOST_REQUIRE_CLOSE(matrix[0][0], 5, epsilon );
+  BOOST_REQUIRE_CLOSE(matrix[0][1], 0, epsilon );
+  BOOST_REQUIRE_CLOSE(matrix[1][0], 0, epsilon );
+  BOOST_REQUIRE_CLOSE(matrix[1][1], 0, epsilon );
+}
+
 BOOST_AUTO_TEST_CASE(rescale)
 {
   JPetRecoImageTools::Matrix2DProj matrix = { {2, 1}, {1, 1}};
@@ -17,15 +30,10 @@ BOOST_AUTO_TEST_CASE(rescale)
   double minCutoff = 0;
   double epsilon = 0.00001;
   JPetRecoImageTools::rescale(matrix, minCutoff, resFact);
-  BOOST_REQUIRE_CLOSE(matrix[0][0], 1, epsilon );
+  BOOST_REQUIRE_CLOSE(matrix[0][0], 2, epsilon );
   BOOST_REQUIRE_CLOSE(matrix[0][1], 0, epsilon );
   BOOST_REQUIRE_CLOSE(matrix[1][0], 0, epsilon );
   BOOST_REQUIRE_CLOSE(matrix[1][1], 0, epsilon );
-  for (const auto & col : matrix) {
-    for (const auto & el : col) {
-      std::cout << el << std::endl;
-    }
-  }
 }
 
 BOOST_AUTO_TEST_CASE(rescale_2)
@@ -38,12 +46,21 @@ BOOST_AUTO_TEST_CASE(rescale_2)
   BOOST_REQUIRE_CLOSE(matrix[0][0], 2, epsilon );
   BOOST_REQUIRE_CLOSE(matrix[0][1], 0.5, epsilon );
   BOOST_REQUIRE_CLOSE(matrix[1][0], 0., epsilon );
-  BOOST_REQUIRE_CLOSE(matrix[1][1], 0., epsilon );
-  for (const auto & col : matrix) {
-    for (const auto & el : col) {
-      std::cout << el << std::endl;
-    }
-  }
+  BOOST_REQUIRE_CLOSE(matrix[1][1], 0.5, epsilon );
+}
+
+BOOST_AUTO_TEST_CASE(rescale_3)
+{
+  JPetRecoImageTools::Matrix2DProj matrix = { {5, 3}, {1, 2}};
+  double resFact = 8;
+  double minCutoff = 2; /// -> 5, 3 , 2, 2
+  /// after background subtraction 3, 1, 0,0
+  double epsilon = 0.00001;
+  JPetRecoImageTools::rescale(matrix, minCutoff, resFact);
+  BOOST_REQUIRE_CLOSE(matrix[0][0], 8, epsilon );
+  BOOST_REQUIRE_CLOSE(matrix[0][1], 1. * 8. / 3., epsilon );
+  BOOST_REQUIRE_CLOSE(matrix[1][0], 0 * 8. / 3., epsilon );
+  BOOST_REQUIRE_CLOSE(matrix[1][1], 0, epsilon );
 }
 
 BOOST_AUTO_TEST_CASE(ONE_POINT_MATRIX_NOT_IN_CENTER)

--- a/modules/JPetRecoImageTools/JPetRecoImageToolsTest.cpp
+++ b/modules/JPetRecoImageTools/JPetRecoImageToolsTest.cpp
@@ -63,16 +63,16 @@ BOOST_AUTO_TEST_CASE(rescale_3)
   BOOST_REQUIRE_CLOSE(matrix[1][1], 0, epsilon );
 }
 
-BOOST_AUTO_TEST_CASE(nearestNeighbours)
-{
-  JPetRecoImageTools::Matrix2D matrix = { {1, 2}, {3, 4}};
-  auto result = JPetRecoImageTools::nearestNeighbour(matrix, 0, 0, 0, 0 , 0, true);
-  std::cout << "result=" << result << std::endl;
-  result = JPetRecoImageTools::nearestNeighbour(matrix, 0, 0, 0, 0 , 0, false);
-  std::cout << "result=" << result << std::endl;
-  result = JPetRecoImageTools::nearestNeighbour(matrix, 1, 1, 1, 1 , 1, true);
-  std::cout << "result=" << result << std::endl;
-}
+//BOOST_AUTO_TEST_CASE(nearestNeighbours)
+//{
+//JPetRecoImageTools::Matrix2D matrix = { {1, 2}, {3, 4}};
+//auto result = JPetRecoImageTools::nearestNeighbour(matrix, 0, 0, 0, 0 , 0, true);
+//std::cout << "result=" << result << std::endl;
+//result = JPetRecoImageTools::nearestNeighbour(matrix, 0, 0, 0, 0 , 0, false);
+//std::cout << "result=" << result << std::endl;
+//result = JPetRecoImageTools::nearestNeighbour(matrix, 1, 1, 1, 1 , 1, true);
+//std::cout << "result=" << result << std::endl;
+//}
 
 BOOST_AUTO_TEST_CASE(ONE_POINT_MATRIX_NOT_IN_CENTER)
 {
@@ -106,51 +106,46 @@ BOOST_AUTO_TEST_CASE(ONE_POINT_MATRIX_NOT_IN_CENTER)
   }
 }
 
-//BOOST_AUTO_TEST_CASE(sinogram)
-//{
+BOOST_AUTO_TEST_CASE(sinogram)
+{
 
-//std::ifstream in;
-//in.open("unitTestData/JPetRecoImageToolsTest/phantom.pgm");
-//std::string line;
-//getline(in, line);
-//if (line != "P2")
-//{
-//}
+  std::ifstream in;
+  in.open("unitTestData/JPetRecoImageToolsTest/phantom.pgm");
+  std::string line;
+  getline(in, line);
+  if (line != "P2") {
+  }
 
-//unsigned int width;
-//unsigned int height;
-//in >> width;
-//in >> height;
-//int val;
-//in >> val; // skip max val
-//std::vector<std::vector<int>> m(width, std::vector<int>(height));
-//for (unsigned int i = 0; i < width; i++)
-//{
-//for (unsigned int j = 0; j < height; j++)
-//{
-//in >> val;
-//m[i][j] = val;
-//}
-//}
-//int views = 180;
-//int scans = 256;
-//std::vector<std::vector<double>> result = JPetRecoImageTools::sinogram(m, views, scans, JPetRecoImageTools::linear, 0, 180, true, 0, 255);
-//std::ofstream res;
-//res.open("unitTestData/JPetRecoImageToolsTest/sinogram.ppm");
-//res << "P2" << std::endl;
-//res << scans << " " << views << std::endl;
-//res << "255" << std::endl;
+  unsigned int width;
+  unsigned int height;
+  in >> width;
+  in >> height;
+  int val;
+  in >> val; // skip max val
+  std::vector<std::vector<int>> m(width, std::vector<int>(height));
+  for (unsigned int i = 0; i < width; i++) {
+    for (unsigned int j = 0; j < height; j++) {
+      in >> val;
+      m[i][j] = val;
+    }
+  }
+  int views = 180;
+  int scans = 256;
+  std::vector<std::vector<double>> result = JPetRecoImageTools::sinogram(m, views, scans, JPetRecoImageTools::linear, 0, 180, true, 0, 255);
+  std::ofstream res;
+  res.open("unitTestData/JPetRecoImageToolsTest/sinogram.ppm");
+  res << "P2" << std::endl;
+  res << scans << " " << views << std::endl;
+  res << "255" << std::endl;
 
-//for (int i = 0; i < views; i++)
-//{
-//for (int j = 0; j < scans; j++)
-//{
-//res << (int)result[i][j] << " ";
-//}
-//res << std::endl;
-//}
+  for (int i = 0; i < views; i++) {
+    for (int j = 0; j < scans; j++) {
+      res << (int)result[i][j] << " ";
+    }
+    res << std::endl;
+  }
 
-//res.close();
-//}
+  res.close();
+}
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/modules/JPetRecoImageTools/JPetRecoImageToolsTest.cpp
+++ b/modules/JPetRecoImageTools/JPetRecoImageToolsTest.cpp
@@ -103,7 +103,6 @@ BOOST_AUTO_TEST_CASE(nearestNeighbour)
   BOOST_REQUIRE_CLOSE(JPetRecoImageTools::nearestNeighbour(1, 0.8, getterT), 4, epsilon); // (1,1)
 }
 
-
 BOOST_AUTO_TEST_CASE(linear)
 {
   double epsilon = 0.00001;
@@ -138,70 +137,83 @@ BOOST_AUTO_TEST_CASE(linear)
 //BOOST_REQUIRE_CLOSE(JPetRecoImageTools::calculateProjection(matrix,0,0,1, func), 4, epsilon);
 //}
 
+
 //BOOST_AUTO_TEST_CASE(calculateProjection2)
 //{
 //double epsilon = 0.00001;
 //JPetRecoImageTools::Matrix2D matrix = {{1, 2}, {3, 4}};
-////static double calculateProjection(const Matrix2D& emissionMatrix,
-////double phi,
-////int scanNumber,
-////int nScans,
-////InterpolationFunc& interpolationFunction
-////);
-///// first argument is i second j  (i,j)
-//JPetRecoImageTools::InterpolationFunc func = JPetRecoImageTools::linear;
-//BOOST_REQUIRE_CLOSE(JPetRecoImageTools::calculateProjection(matrix,0,0,1, func), 4, epsilon);
+///// 1 2
+///// 3 4
+///// angle = 0
+///// nScans = 2
+//JPetRecoImageTools::InterpolationFunc func = JPetRecoImageTools::nearestNeighbour;
+//const int kNScans = 2;
+//auto angle = 0.0;
+//BOOST_REQUIRE_CLOSE(JPetRecoImageTools::calculateProjection(matrix,angle,0,kNScans, func), 4, epsilon);
+//BOOST_REQUIRE_CLOSE(JPetRecoImageTools::calculateProjection(matrix,angle,1,kNScans, func), 4, epsilon);
+////BOOST_REQUIRE_CLOSE(JPetRecoImageTools::calculateProjection(matrix,angle,1,kNScans, func), 6, epsilon);
+////BOOST_REQUIRE_CLOSE(JPetRecoImageTools::calculateProjection(matrix,45,0,1, func), 4, epsilon);
+////BOOST_REQUIRE_CLOSE(JPetRecoImageTools::calculateProjection(matrix,90,0,kNScans, func), 3, epsilon);
+////BOOST_REQUIRE_CLOSE(JPetRecoImageTools::calculateProjection(matrix,125,0,1, func), 4, epsilon);
+////BOOST_REQUIRE_CLOSE(JPetRecoImageTools::calculateProjection(matrix,180,0,1, func), 4, epsilon);
 //}
 
-
-//BOOST_AUTO_TEST_CASE(ONE_POINT_MATRIX_NOT_IN_CENTER)
+//BOOST_AUTO_TEST_CASE(calculateProjection3)
 //{
-//std::vector<std::vector<int>> m(4, std::vector<int>(4));
-//for (unsigned int i = 0; i < 4; i++) {
-//for (unsigned int j = 0; j < 4; j++) {
-//m[i][j] = 0;
-//}
-//}
-//m[2][2] = 100;
-//int views = 2;
-//int scans = 4;
-//std::vector<std::vector<double>> result = JPetRecoImageTools::sinogram(m, views, scans);
-//for (int i = 0; i < views; i++) {
-//for (int j = 0; j < scans; j++) {
-//if ((i == 0 && j == 2) || (i == 1 && j == 1))
-//BOOST_REQUIRE_EQUAL(result[i][j], 100);
-//else
-//BOOST_REQUIRE_EQUAL(result[i][j], 0);
-//}
-//}
+//double epsilon = 0.00001;
+//JPetRecoImageTools::Matrix2D matrix = {{1, 2, 3}, {4, 5, 6}, {7,8,9}};
+///// 1 2 3
+///// 4 5 6
+///// 7 8 9
+///// angle = 0
+///// nScans = 3
+//JPetRecoImageTools::InterpolationFunc func = JPetRecoImageTools::nearestNeighbour;
+//const int kNScans = 3;
+//auto angle = 0.0;
+////BOOST_REQUIRE_CLOSE(JPetRecoImageTools::calculateProjection(matrix,angle,0,kNScans, func), 12, epsilon);
+//BOOST_REQUIRE_CLOSE(JPetRecoImageTools::calculateProjection(matrix,angle,1,kNScans, func), 15, epsilon);
+////BOOST_REQUIRE_CLOSE(JPetRecoImageTools::calculateProjection(matrix,angle,1,kNScans, func), 6, epsilon);
+////BOOST_REQUIRE_CLOSE(JPetRecoImageTools::calculateProjection(matrix,45,0,1, func), 4, epsilon);
+////BOOST_REQUIRE_CLOSE(JPetRecoImageTools::calculateProjection(matrix,90,0,kNScans, func), 3, epsilon);
+////BOOST_REQUIRE_CLOSE(JPetRecoImageTools::calculateProjection(matrix,125,0,1, func), 4, epsilon);
+////BOOST_REQUIRE_CLOSE(JPetRecoImageTools::calculateProjection(matrix,180,0,1, func), 4, epsilon);
 //}
 
-//BOOST_AUTO_TEST_CASE(ONE_POINT_MATRIX_NOT_IN_CENTER_2)
+//BOOST_AUTO_TEST_CASE(sinogram1)
 //{
-//std::vector<std::vector<int>> m(4, std::vector<int>(4));
-//for (unsigned int i = 0; i < 4; i++) {
-//for (unsigned int j = 0; j < 4; j++) {
-//m[i][j] = 0;
-//}
-//}
-//m[2][2] = 100;
-//int views = 2;
-//int scans = 4;
-//std::vector<std::vector<double>> result2 = JPetRecoImageTools::sinogram(m, views, scans, 0, 180,  JPetRecoImageTools::nearestNeighbour);
-//for (int i = 0; i < views; i++) {
-//for (int j = 0; j < scans; j++) {
-//if ((i == 0 && j == 2) || (i == 1 && j == 1))
-//BOOST_REQUIRE_EQUAL(result2[i][j], 100);
-//else
-//BOOST_REQUIRE_EQUAL(result2[i][j], 0);
-//}
-//}
+//double epsilon = 0.00001;
+//JPetRecoImageTools::Matrix2D matrix = {{1, 2, 3}, {4, 5, 6}, {7,8,9}};
+///// 1 2 3
+///// 4 5 6
+///// 7 8 9
+//JPetRecoImageTools::InterpolationFunc func = JPetRecoImageTools::nearestNeighbour;
+//JPetRecoImageTools::RescaleFunc func2= JPetRecoImageTools::nonRescale;
+//const int kNScans = 3;
+//const int kNViews = 2;
+//auto results = JPetRecoImageTools::sinogram(matrix,kNViews,kNScans, 0 , 90,  func, func2);
+//for (auto i: results)
+//for (auto j: i)
+//std::cout <<j <<std::endl;
 //}
 
-/// This test takes a Shepp-Logan phantom and creates a sinogram.
+//BOOST_AUTO_TEST_CASE(sinogram2)
+//{
+//double epsilon = 0.00001;
+//JPetRecoImageTools::Matrix2D matrix = {{0, 0, 0}, {0, 10, 0}, {0,0,0}};
+//JPetRecoImageTools::InterpolationFunc func = JPetRecoImageTools::nearestNeighbour;
+//JPetRecoImageTools::RescaleFunc func2= JPetRecoImageTools::nonRescale;
+//const int kNScans = 3;
+//const int kNViews = 4;
+//auto results = JPetRecoImageTools::sinogram(matrix,kNViews,kNScans, 0 , 180,  func, func2);
+//for (auto i: results)
+//for (auto j: i)
+//std::cout <<j <<std::endl;
+//}
+
+// This test takes a Shepp-Logan phantom and creates a sinogram.
 BOOST_AUTO_TEST_CASE(sinogram)
 {
-  const auto inFile = "unitTestData/JPetSinogramTest/phantom.pgm";
+  const auto inFile = "unitTestData/JPetRecoImageToolsTest/phantom.pgm";
   const auto outFile = "sinogram.ppm";
   /// read phantom
   std::ifstream in(inFile);

--- a/modules/JPetRecoImageTools/JPetRecoImageToolsTest.cpp
+++ b/modules/JPetRecoImageTools/JPetRecoImageToolsTest.cpp
@@ -10,13 +10,47 @@
 
 BOOST_AUTO_TEST_SUITE(FirstSuite)
 
+BOOST_AUTO_TEST_CASE(rescale)
+{
+  JPetRecoImageTools::Matrix2DProj matrix = { {2, 1}, {1, 1}};
+  double resFact = 2;
+  double minCutoff = 0;
+  double epsilon = 0.00001;
+  JPetRecoImageTools::rescale(matrix, minCutoff, resFact);
+  BOOST_REQUIRE_CLOSE(matrix[0][0], 1, epsilon );
+  BOOST_REQUIRE_CLOSE(matrix[0][1], 0, epsilon );
+  BOOST_REQUIRE_CLOSE(matrix[1][0], 0, epsilon );
+  BOOST_REQUIRE_CLOSE(matrix[1][1], 0, epsilon );
+  for (const auto & col : matrix) {
+    for (const auto & el : col) {
+      std::cout << el << std::endl;
+    }
+  }
+}
+
+BOOST_AUTO_TEST_CASE(rescale_2)
+{
+  JPetRecoImageTools::Matrix2DProj matrix = { {5, 2}, {1, 2}};
+  double resFact = 2;
+  double minCutoff = 0;
+  double epsilon = 0.00001;
+  JPetRecoImageTools::rescale(matrix, minCutoff, resFact);
+  BOOST_REQUIRE_CLOSE(matrix[0][0], 2, epsilon );
+  BOOST_REQUIRE_CLOSE(matrix[0][1], 0.5, epsilon );
+  BOOST_REQUIRE_CLOSE(matrix[1][0], 0., epsilon );
+  BOOST_REQUIRE_CLOSE(matrix[1][1], 0., epsilon );
+  for (const auto & col : matrix) {
+    for (const auto & el : col) {
+      std::cout << el << std::endl;
+    }
+  }
+}
+
 BOOST_AUTO_TEST_CASE(ONE_POINT_MATRIX_NOT_IN_CENTER)
 {
   std::vector<std::vector<int>> m(4, std::vector<int>(4));
-  for (unsigned int i = 0; i < 4; i++)
-  {
-    for (unsigned int j = 0; j < 4; j++)
-    {
+  for (unsigned int i = 0; i < 4; i++) {
+    for (unsigned int j = 0; j < 4; j++) {
       m[i][j] = 0;
     }
   }
@@ -24,75 +58,71 @@ BOOST_AUTO_TEST_CASE(ONE_POINT_MATRIX_NOT_IN_CENTER)
   int views = 2;
   int scans = 4;
   std::vector<std::vector<double>> result = JPetRecoImageTools::sinogram(m, views, scans);
-  for (int i = 0; i < views; i++)
-  {
-    for (int j = 0; j < scans; j++)
-    {
-      if((i == 0 && j == 2) || (i == 1 && j == 1))
+  for (int i = 0; i < views; i++) {
+    for (int j = 0; j < scans; j++) {
+      if ((i == 0 && j == 2) || (i == 1 && j == 1))
         BOOST_REQUIRE_EQUAL(result[i][j], 100);
       else
-        BOOST_REQUIRE_EQUAL(result[i][j], 0); 
+        BOOST_REQUIRE_EQUAL(result[i][j], 0);
     }
   }
 
   std::vector<std::vector<double>> result2 = JPetRecoImageTools::sinogram(m, views, scans, JPetRecoImageTools::nearestNeighbour);
-  for (int i = 0; i < views; i++)
-  {
-    for (int j = 0; j < scans; j++)
-    {
-      if((i == 0 && j == 2) || (i == 1 && j == 1))
+  for (int i = 0; i < views; i++) {
+    for (int j = 0; j < scans; j++) {
+      if ((i == 0 && j == 2) || (i == 1 && j == 1))
         BOOST_REQUIRE_EQUAL(result2[i][j], 100);
       else
-        BOOST_REQUIRE_EQUAL(result2[i][j], 0); 
+        BOOST_REQUIRE_EQUAL(result2[i][j], 0);
     }
   }
 }
 
-BOOST_AUTO_TEST_CASE(sinogram)
-{
+//BOOST_AUTO_TEST_CASE(sinogram)
+//{
 
-  std::ifstream in;
-  in.open("unitTestData/JPetRecoImageToolsTest/phantom.pgm");
-  std::string line;
-  getline(in, line);
-  if (line != "P2")
-  { 
-  }
+//std::ifstream in;
+//in.open("unitTestData/JPetRecoImageToolsTest/phantom.pgm");
+//std::string line;
+//getline(in, line);
+//if (line != "P2")
+//{
+//}
 
-  unsigned int width;
-  unsigned int height;
-  in >> width;
-  in >> height;
-  int val;
-  in >> val; // skip max val
-  std::vector<std::vector<int>> m(width, std::vector<int>(height));
-  for (unsigned int i = 0; i < width; i++)
-  {
-    for (unsigned int j = 0; j < height; j++)
-    {
-      in >> val;
-      m[i][j] = val;
-    }
-  }
-  int views = 180;
-  int scans = 256;
-  std::vector<std::vector<double>> result = JPetRecoImageTools::sinogram(m, views, scans, JPetRecoImageTools::linear, 0, 180, true, 0, 255);
-  std::ofstream res;
-  res.open("unitTestData/JPetRecoImageToolsTest/sinogram.ppm");
-  res << "P2" << std::endl;
-  res << scans << " " << views << std::endl;
-  res << "255" << std::endl;
+//unsigned int width;
+//unsigned int height;
+//in >> width;
+//in >> height;
+//int val;
+//in >> val; // skip max val
+//std::vector<std::vector<int>> m(width, std::vector<int>(height));
+//for (unsigned int i = 0; i < width; i++)
+//{
+//for (unsigned int j = 0; j < height; j++)
+//{
+//in >> val;
+//m[i][j] = val;
+//}
+//}
+//int views = 180;
+//int scans = 256;
+//std::vector<std::vector<double>> result = JPetRecoImageTools::sinogram(m, views, scans, JPetRecoImageTools::linear, 0, 180, true, 0, 255);
+//std::ofstream res;
+//res.open("unitTestData/JPetRecoImageToolsTest/sinogram.ppm");
+//res << "P2" << std::endl;
+//res << scans << " " << views << std::endl;
+//res << "255" << std::endl;
 
-  for (int i = 0; i < views; i++)
-  {
-    for (int j = 0; j < scans; j++)
-    {
-      res << (int)result[i][j] << " ";
-    }
-    res << std::endl;
-  }
+//for (int i = 0; i < views; i++)
+//{
+//for (int j = 0; j < scans; j++)
+//{
+//res << (int)result[i][j] << " ";
+//}
+//res << std::endl;
+//}
 
-  res.close();
-}
+//res.close();
+//}
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Refactoring of JPetRecoImageTools including renaming variables, introducing typedef, and extracting some helper functions. Removing the discontinuity bug
Still some tests are missing (e.g. projections and sinograms). 
