### PR TITLE
Extend zip option

### DIFF
--- a/JPetCommonTools/JPetCommonTools.h
+++ b/JPetCommonTools/JPetCommonTools.h
@@ -98,6 +98,10 @@ public:
   inline static std::string stripFileNameSuffix(const std::string& filename) {
     return  boost::filesystem::change_extension(filename, "").string();
   }
+  inline static std::string exctractFileNameSuffix(const std::string& filename){
+    return boost::filesystem::extension(filename);
+  }
+  
   inline static std::string currentFullPath() {
     return boost::filesystem::path( boost::filesystem::current_path() ).string();
   }

--- a/JPetCommonTools/JPetCommonToolsTest.cpp
+++ b/JPetCommonTools/JPetCommonToolsTest.cpp
@@ -107,6 +107,14 @@ BOOST_AUTO_TEST_CASE(stripFileNameSuffixTest)
   BOOST_REQUIRE_EQUAL(stripFileNameSuffix == "run_tests", true);
 }
 
+BOOST_AUTO_TEST_CASE(extractFileNameSuffixTest)
+{
+  std::string fileTest = "run_tests.pl";
+
+  std::string stripFileNameSuffix = JPetCommonTools::stripFileNameSuffix(fileTest);
+  BOOST_REQUIRE_EQUAL(stripFileNameSuffix == ".pl", true);
+}
+
 BOOST_AUTO_TEST_CASE(currentFullPathTest)
 {
   std::string currentFullPathTest = boost::filesystem::path(boost::filesystem::current_path()).string();

--- a/JPetCommonTools/JPetCommonToolsTest.cpp
+++ b/JPetCommonTools/JPetCommonToolsTest.cpp
@@ -112,7 +112,7 @@ BOOST_AUTO_TEST_CASE(extractFileNameSuffixTest)
   std::string fileTest = "run_tests.pl";
 
   std::string stripFileNameSuffix = JPetCommonTools::stripFileNameSuffix(fileTest);
-  BOOST_REQUIRE_EQUAL(stripFileNameSuffix == ".pl", true);
+  BOOST_REQUIRE_EQUAL(stripFileNameSuffix, ".pl");
 }
 
 BOOST_AUTO_TEST_CASE(currentFullPathTest)

--- a/JPetTaskChainExecutor/JPetTaskChainExecutorUtils.h
+++ b/JPetTaskChainExecutor/JPetTaskChainExecutorUtils.h
@@ -40,9 +40,9 @@ public:
   /// Here I just convert return value into boolean type - Sz.N.
   inline static bool unzipFile(const char* filename) {
     if( JPetCommonTools::exctractFileNameSuffix(filename) == ".gz")
-      return !( system( ( std::string("gzip -d ") + std::string(filename) ).c_str() ) );
+      return !( system( ( std::string("gzip -dk ") + std::string(filename) ).c_str() ) );
     else if( JPetCommonTools::exctractFileNameSuffix(filename) == ".xz" )
-      return !( system( (std::string("xz -d ") + std::string(filename) ).c_str() ) );
+      return !( system( (std::string("xz -dk ") + std::string(filename) ).c_str() ) );
     else
       return false;
   }

--- a/JPetTaskChainExecutor/JPetTaskChainExecutorUtils.h
+++ b/JPetTaskChainExecutor/JPetTaskChainExecutorUtils.h
@@ -20,6 +20,7 @@
 #include "../JPetOptions/JPetOptions.h"
 #include "../JPetParamManager/JPetParamManager.h"
 #include "../JPetScopeLoader/JPetScopeLoader.h"
+#include <boost/concept_check.hpp>
 
 /**
  * JPetTaskChainExecutorUtils contains methods that can be used by JPetTaskExecutor
@@ -38,7 +39,12 @@ public:
   /// system(...) is returning integer, 0 when everything went smoothly and error code when not.
   /// Here I just convert return value into boolean type - Sz.N.
   inline static bool unzipFile(const char* filename) {
-    return !( system( ( std::string("gzip -d ") + std::string(filename) ).c_str() ) );
+    if( JPetCommonTools::exctractFileNameSuffix(filename) == ".gz")
+      return !( system( ( std::string("gzip -d ") + std::string(filename) ).c_str() ) );
+    else if( JPetCommonTools::exctractFileNameSuffix(filename) == ".xz" )
+      return !( system( (std::string("xz -d ") + std::string(filename) ).c_str() ) );
+    else
+      return false;
   }
 };
 #endif /*  !JPETTASKCHAINEXECUTORUTILS_H */

--- a/JPetTaskChainExecutor/JPetTaskChainExecutorUtilsTest.cpp
+++ b/JPetTaskChainExecutor/JPetTaskChainExecutorUtilsTest.cpp
@@ -22,11 +22,22 @@ BOOST_AUTO_TEST_SUITE(JPetTaskChainExecutorTestSuite)
 
 BOOST_AUTO_TEST_CASE(tryToUnzipSomethingNotExistingFile)
 {
-  BOOST_REQUIRE(!JPetTaskChainExecutorUtils::unzipFile("kiko.gz"));
+  BOOST_REQUIRE(JPetTaskChainExecutorUtils::unzipFile("unitTestData/JPetTaskChainExecutorUtilsTest/goodZip.gz"));
   std::string initialPath = boost::filesystem::path(boost::filesystem::current_path()).string();
   initialPath = initialPath.substr(0, initialPath.find("build") );
-  std::string wrongZipPath = initialPath + "unitTestData/JPetTaskChainExecutorUtilsTest/wrongZip.gz";
+  std::string wrongZipPath = initialPath + "wrongZip.gz";
   BOOST_REQUIRE(!JPetTaskChainExecutorUtils::unzipFile( wrongZipPath.c_str() ));
-
+  BOOST_REQUIRE(!JPetTaskChainExecutorUtils::unzipFile( "unitTestData/JPetTaskChainExecutorUtilsTest/wrongZip.gz" ));
 }
+
+BOOST_AUTO_TEST_CASE(tryToUnzipSomethingNotExistingFileWithXz)
+{
+  BOOST_REQUIRE(JPetTaskChainExecutorUtils::unzipFile("unitTestData/JPetTaskChainExecutorUtilsTest/goodXZ.xz"));
+  std::string initialPath = boost::filesystem::path(boost::filesystem::current_path()).string();
+  initialPath = initialPath.substr(0, initialPath.find("build") );
+  std::string wrongZipPath = initialPath + "unitTestData/JPetTaskChainExecutorUtilsTest/wrongZip.Xz";
+  BOOST_REQUIRE(!JPetTaskChainExecutorUtils::unzipFile( wrongZipPath.c_str() ));
+  BOOST_REQUIRE(!JPetTaskChainExecutorUtils::unzipFile( "unitTestData/JPetTaskChainExecutorUtilsTest/wrongXZ.xz" ));
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
I have added handling of new format of zipped files - ".xz"
Additionally I have changed unzipping flag, now the file in zip format is not deleted. 
To make checking of suffixes easier I have added new tool function in JPetCommonTools.