### PR TITLE
Fix the dictionary generation problem for some ROOT version.

### DIFF
--- a/JPetBarrelSlot/JPetBarrelSlot.cpp
+++ b/JPetBarrelSlot/JPetBarrelSlot.cpp
@@ -37,4 +37,59 @@ JPetBarrelSlot::JPetBarrelSlot(bool isNull) :
   SetName("JPetBarrelSlot");
 }
 
+bool JPetBarrelSlot::operator==(const JPetBarrelSlot& bslot) const
+{
+  return getID() == bslot.getID();
+}
+bool JPetBarrelSlot::operator!=(const JPetBarrelSlot& bslot) const
+{
+  return getID() != bslot.getID();
+}
+
+int JPetBarrelSlot::getID() const
+{
+  return fId;
+}
+float JPetBarrelSlot::getTheta() const
+{
+  return fTheta;
+}
+bool JPetBarrelSlot::isActive() const
+{
+  return fIsActive;
+}
+std::string JPetBarrelSlot::getName() const
+{
+  return fName;
+}
+int JPetBarrelSlot::getInFrameID() const
+{
+  return fInFrameID;
+}
+const JPetLayer& JPetBarrelSlot::getLayer() const
+{
+  if (fTRefLayer.GetObject()) return static_cast<JPetLayer&>(*(fTRefLayer.GetObject()));
+  else  {
+    ERROR("No JPetLayer slot set, Null object will be returned");
+    return JPetLayer::getDummyResult();
+  }
+}
+
+bool JPetBarrelSlot::isNullObject() const
+{
+  return fIsNullObject;
+}
+
+JPetBarrelSlot& JPetBarrelSlot::getDummyResult()
+{
+  static JPetBarrelSlot DummyResult(true);
+  return DummyResult;
+}
+
+
+void JPetBarrelSlot::setLayer(JPetLayer& p_layer)
+{
+  fTRefLayer = &p_layer;
+}
+
 ClassImp(JPetBarrelSlot);

--- a/JPetBarrelSlot/JPetBarrelSlot.h
+++ b/JPetBarrelSlot/JPetBarrelSlot.h
@@ -28,40 +28,31 @@
  */
 class JPetBarrelSlot: public TNamed
 {
+
 public:
-  /// Default constructor sets fId, fTheta to -1. 
   JPetBarrelSlot();
   JPetBarrelSlot(int id, bool isActive, std::string name, float theta, int inFrameID);
-  JPetBarrelSlot(bool isNull);
-  inline bool operator==(const JPetBarrelSlot& bslot) const { return getID() == bslot.getID(); }
-  inline bool operator!=(const JPetBarrelSlot& bslot) const { return getID() != bslot.getID(); }
+  explicit JPetBarrelSlot(bool isNull);
 
-  inline int getID() const { return fId; }
-  inline float getTheta() const { return fTheta; }
-  inline bool isActive() const { return fIsActive; }
-  inline std::string getName() const { return fName; }
-  inline int getInFrameID() const {return fInFrameID; }
-  inline const JPetLayer & getLayer() const {
-    if(fTRefLayer.GetObject()) return static_cast<JPetLayer&>(*(fTRefLayer.GetObject()));
-    else  {
-      ERROR("No JPetLayer slot set, Null object will be returned");
-      return JPetLayer::getDummyResult();
-    }
-  }
+  bool operator==(const JPetBarrelSlot& bslot) const;
+  bool operator!=(const JPetBarrelSlot& bslot) const;
 
-  inline bool isNullObject() const { return fIsNullObject; }
-  static inline JPetBarrelSlot& getDummyResult() {
-    static JPetBarrelSlot DummyResult(true);
-    return DummyResult; 
-  }
-  
-  void setLayer(JPetLayer &p_layer)
-  {
-    fTRefLayer = &p_layer;
-  }
+  int getID() const;
+  float getTheta() const;
+  bool isActive() const;
+  std::string getName() const;
+  int getInFrameID() const;
+  const JPetLayer& getLayer() const;
 
-private:
-  
+  bool isNullObject() const;
+  static  JPetBarrelSlot& getDummyResult();
+
+  void setLayer(JPetLayer& p_layer);
+
+protected:
+  void clearTRefLayer();
+
+#ifndef __CINT__
   int fId = -1;
   bool fIsActive = false;
   std::string fName = "";
@@ -69,12 +60,16 @@ private:
   int fInFrameID = -1;
   TRef fTRefLayer;
   bool fIsNullObject = false;
-  
-protected:
-  void clearTRefLayer()
-  {
-    fTRefLayer = NULL;
-  }
+#else
+  int fId;
+  bool fIsActive;
+  std::string fName;
+  float fTheta;
+  int fInFrameID;
+  TRef fTRefLayer;
+  bool fIsNullObject;
+#endif
+
 
   ClassDef(JPetBarrelSlot, 4);
 };

--- a/JPetFEB/JPetFEB.cpp
+++ b/JPetFEB/JPetFEB.cpp
@@ -23,16 +23,16 @@ JPetFEB::JPetFEBInput::JPetFEBInput(int p_FEBId) : JPetFEBChannel(), m_FEBId(p_F
 }
 
 JPetFEB::JPetFEBOutput::JPetFEBOutput(bool p_passedInformationIsTime,
-				    std::string p_passedInformation, 
-				    int p_FEBId, 
-				    int p_inputId, 
-				    int p_FEBInputId ) : 
-						      JPetFEBChannel(),
-						      m_passedInformationIsTime(p_passedInformationIsTime),
-						      m_passedInformation(p_passedInformation),
-						      m_FEBId(p_FEBId),
-						      m_inputId(p_inputId),
-						      m_FEBInputId(p_FEBInputId)
+                                      std::string p_passedInformation,
+                                      int p_FEBId,
+                                      int p_inputId,
+                                      int p_FEBInputId ) :
+  JPetFEBChannel(),
+  m_passedInformationIsTime(p_passedInformationIsTime),
+  m_passedInformation(p_passedInformation),
+  m_FEBId(p_FEBId),
+  m_inputId(p_inputId),
+  m_FEBInputId(p_FEBInputId)
 {
 }
 
@@ -46,28 +46,28 @@ JPetFEB::JPetFEB(int id) : m_id(id)
   SetName("JPetFEB");
 }
 
-JPetFEB::JPetFEB(int p_id, 
-	       bool p_isActive, 
-	       std::string p_status, 
-	       std::string p_description, 
-	       int p_version, 
-	       int p_userId,
-	       int p_n_time_outputs_per_input,
-	       int p_n_notime_outputs_per_input) :
-				      m_id(p_id),
-				      m_isActive(p_isActive),
-				      m_status(p_status),
-				      m_description(p_description),
-				      m_version(p_version),
-				      m_userId(p_userId),
-				      m_n_time_outputs_per_input(p_n_time_outputs_per_input),
-				      m_n_notime_outputs_per_input(p_n_notime_outputs_per_input) 
+JPetFEB::JPetFEB(int p_id,
+                 bool p_isActive,
+                 std::string p_status,
+                 std::string p_description,
+                 int p_version,
+                 int p_userId,
+                 int p_n_time_outputs_per_input,
+                 int p_n_notime_outputs_per_input) :
+  m_id(p_id),
+  m_isActive(p_isActive),
+  m_status(p_status),
+  m_description(p_description),
+  m_version(p_version),
+  m_userId(p_userId),
+  m_n_time_outputs_per_input(p_n_time_outputs_per_input),
+  m_n_notime_outputs_per_input(p_n_notime_outputs_per_input)
 {
   SetName("JPetFEB");
 }
 
 JPetFEB::JPetFEB(bool isNull) :
-							fIsNullObject(isNull)
+  fIsNullObject(isNull)
 {
   SetName("JPetFEB");
 }
@@ -118,4 +118,49 @@ int JPetFEB::getNtimeOutsPerInput(void) const
 int JPetFEB::getNnotimeOutsPerInput(void) const
 {
   return m_n_notime_outputs_per_input;
+}
+
+int JPetFEB::getCreator() const
+{
+  return m_userId;
+}
+
+const JPetTRB& JPetFEB::getTRB() const
+{
+  if (fTRefTRBs.GetObject()) return (JPetTRB&) * fTRefTRBs.GetObject();
+  else {
+    ERROR("No JPetTRB slot set, Null object will be returned");
+    return JPetTRB::getDummyResult();
+  }
+}
+
+void JPetFEB::setTRB(JPetTRB& p_TRB)
+{
+  fTRefTRBs = &p_TRB;
+}
+
+bool JPetFEB::operator==(const JPetFEB& feb)
+{
+  return getID() == feb.getID();
+}
+bool JPetFEB::operator!=(const JPetFEB& feb)
+{
+  return getID() != feb.getID();
+}
+
+bool JPetFEB::isNullObject() const
+{
+  return fIsNullObject;
+}
+
+JPetFEB& JPetFEB::getDummyResult()
+{
+  static JPetFEB DummyResult(true);
+  return DummyResult;
+}
+
+
+void JPetFEB::clearTRefTRBs()
+{
+  fTRefTRBs = NULL;
 }

--- a/JPetFEB/JPetFEB.h
+++ b/JPetFEB/JPetFEB.h
@@ -29,102 +29,87 @@
 class JPetFEB: public TNamed
 {
 protected:
-  struct JPetFEBChannel
-  {
+  struct JPetFEBChannel {
     int m_id;
     bool m_isActive;
     std::string m_status;
     int m_portNumber;
     std::string m_description;
   };
-  
-  struct JPetFEBInput : public JPetFEBChannel
-  {
+
+  struct JPetFEBInput : public JPetFEBChannel {
     JPetFEBInput(int p_FEBId);
-    
+
     int m_FEBId;
   };
 
-  struct JPetFEBOutput : public JPetFEBChannel
-  {
+  struct JPetFEBOutput : public JPetFEBChannel {
     JPetFEBOutput(bool p_passedInformationIsTime, std::string p_passedInformation, int p_FEBId, int p_inputId, int p_FEBInputId);
-    
+
     bool m_passedInformationIsTime;
     std::string m_passedInformation;
     int m_FEBId;
     int m_inputId;
     int m_FEBInputId;
   };
-  
-  int m_id = 0;
-  bool m_isActive = false;
-  std::string m_status = "";
-  std::string m_description = "";
-  const int m_version = 0;
-  //JPetUser &m_JPetUser;		//creatorId
-  const int m_userId = 0;		// creatorId 
-  /// @todo userId is inaccesible!!!
-  int m_n_time_outputs_per_input = 0;
-  int m_n_notime_outputs_per_input = 0;
-  
-  
+
 public:
+  static JPetFEB& getDummyResult();
+
   JPetFEB();
-  JPetFEB(int id);
+  explicit JPetFEB(int id);
+  explicit JPetFEB(bool isNull);
   JPetFEB(int p_id, bool p_isActive, std::string p_status, std::string p_description,
-	  int p_version, int p_userId, int p_n_time_outputs_per_input,
-	  int p_n_notime_outputs_per_input);
-  JPetFEB(bool isNull);
+          int p_version, int p_userId, int p_n_time_outputs_per_input,
+          int p_n_notime_outputs_per_input);
   virtual ~JPetFEB(void);
-  
+
+  bool operator==(const JPetFEB& feb);
+  bool operator!=(const JPetFEB& feb);
+
   virtual int getID(void) const;
   virtual bool isActive(void) const;
   virtual std::string status(void) const;
   virtual std::string description(void) const;
   virtual int version(void) const;
-  inline int getCreator() const {return m_userId;}
+  int getCreator() const;
   virtual int getNtimeOutsPerInput(void) const;
   virtual int getNnotimeOutsPerInput(void) const;
-  
-  const JPetTRB & getTRB() const
-  {
-    if(fTRefTRBs.GetObject()) return (JPetTRB&)*fTRefTRBs.GetObject();
-    else {
-      ERROR("No JPetTRB slot set, Null object will be returned");
-      return JPetTRB::getDummyResult();
-    }
-  }
-  
-  void setTRB(JPetTRB &p_TRB)
-  {
-    fTRefTRBs = &p_TRB;
-  }
-
-  inline bool operator==(const JPetFEB& feb) { return getID() == feb.getID(); }
-  inline bool operator!=(const JPetFEB& feb) { return getID() != feb.getID(); }
-
-  inline bool isNullObject() const { return fIsNullObject; }
-
-  static inline JPetFEB& getDummyResult() {
-    static JPetFEB DummyResult(true);
-    return DummyResult;
-  }
-
+  const JPetTRB& getTRB() const;
+  void setTRB(JPetTRB& p_TRB);
+  bool isNullObject() const;
 
 protected:
-  TRef fTRefTRBs;
-  
-  void clearTRefTRBs()
-  {
-    fTRefTRBs = NULL;
-  }
-  
-  
-private:
+  void clearTRefTRBs();
+
+#ifndef __CINT__
+  int m_id = 0;
+  bool m_isActive = false;
+  std::string m_status = "";
+  std::string m_description = "";
+  const int m_version = 0;
+  const int m_userId = 0;		// creatorId
+  /// @todo userId is inaccesible!!!
+  int m_n_time_outputs_per_input = 0;
+  int m_n_notime_outputs_per_input = 0;
   bool fIsNullObject = false;
-  ClassDef(JPetFEB, 2);
-  
+#else
+  int m_id;
+  bool m_isActive;
+  std::string m_status;
+  std::string m_description;
+  const int m_version;
+  const int m_userId;		// creatorId
+  /// @todo userId is inaccesible!!!
+  int m_n_time_outputs_per_input;
+  int m_n_notime_outputs_per_input;
+  bool fIsNullObject;
+#endif
+  TRef fTRefTRBs;
+
   friend class JPetParamManager;
+
+  ClassDef(JPetFEB, 2);
 };
 
 #endif // JPET_FEB_H

--- a/JPetFrame/JPetFrame.cpp
+++ b/JPetFrame/JPetFrame.cpp
@@ -20,7 +20,7 @@ JPetFrame::JPetFrame()
 {
   SetName("JPetFrame");
 }
-  
+
 JPetFrame::JPetFrame(int id, bool isActive, std::string status, std::string description, int version, int creator_id) :
   fId(id),
   fIsActive(isActive),
@@ -36,6 +36,49 @@ JPetFrame::JPetFrame(bool isNull) :
   fIsNullObject(isNull)
 {
   SetName("JPetFrame");
+}
+bool JPetFrame::operator==(const JPetFrame& frame)
+{
+  return getID() == frame.getID();
+}
+bool JPetFrame::operator!=(const JPetFrame& frame)
+{
+  return getID() != frame.getID();
+}
+int JPetFrame::getID() const
+{
+  return fId;
+}
+bool JPetFrame::getIsActive() const
+{
+  return fIsActive;
+}
+std::string JPetFrame::getStatus() const
+{
+  return fStatus;
+}
+std::string JPetFrame::getDescription() const
+{
+  return fDescription;
+}
+int JPetFrame::getVersion() const
+{
+  return fVersion;
+}
+int JPetFrame::getCreator() const
+{
+  return fCreator_id;
+}
+
+bool JPetFrame::isNullObject() const
+{
+  return fIsNullObject;
+}
+
+JPetFrame& JPetFrame::getDummyResult()
+{
+  static JPetFrame DummyResult(true);
+  return DummyResult;
 }
 
 ClassImp(JPetFrame);

--- a/JPetFrame/JPetFrame.h
+++ b/JPetFrame/JPetFrame.h
@@ -26,40 +26,42 @@
  */
 class JPetFrame: public TNamed
 {
- protected:
+public:
+
+  JPetFrame();
+  JPetFrame(int id, bool isActive, std::string status, std::string description, int version, int creator_id);
+  explicit JPetFrame(bool isNull);
+
+  bool operator==(const JPetFrame& frame);
+  bool operator!=(const JPetFrame& frame);
+  int getID() const;
+  bool getIsActive() const;
+  std::string getStatus() const;
+  std::string getDescription() const;
+  int getVersion() const;
+  int getCreator() const;
+  bool isNullObject() const;
+  static JPetFrame& getDummyResult();
+
+protected:
+#ifndef __CINT__
   const int fId = -1;
   bool fIsActive = false;
   std::string fStatus = "";
   std::string fDescription = "";
   const int fVersion = -1;
   const int fCreator_id = -1;
-  
- public:
+  bool fIsNullObject = false;
+#else
+  const int fId;
+  bool fIsActive;
+  std::string fStatus;
+  std::string fDescription;
+  const int fVersion;
+  const int fCreator_id;
+  bool fIsNullObject;
+#endif
 
-  /// The default constructor sets fId, fVersion, fCreator_id to -1.  
-  JPetFrame();
-  JPetFrame(int id, bool isActive, std::string status, std::string description, int version, int creator_id);
-  JPetFrame(bool isNull);
-
-  inline bool operator==(const JPetFrame& frame) { return getID() == frame.getID(); }
-  inline bool operator!=(const JPetFrame& frame) { return getID() != frame.getID(); }
-  int getID() const { return fId; }
-  bool getIsActive() const { return fIsActive; }
-  std::string getStatus() const { return fStatus; }
-  std::string getDescription() const { return fDescription; }
-  int getVersion() const { return fVersion; }
-  int getCreator() const { return fCreator_id; }
-
-  inline bool isNullObject() const { return fIsNullObject; }
-
-  static inline JPetFrame& getDummyResult() {
-    static JPetFrame DummyResult(true);
-    return DummyResult;
-  }
-
- private:
- bool fIsNullObject = false;
   ClassDef(JPetFrame, 2);
 };
-
 #endif // JPET_FRAME_H

--- a/JPetLayer/JPetLayer.cpp
+++ b/JPetLayer/JPetLayer.cpp
@@ -55,5 +55,49 @@ bool JPetLayer::operator!=(const JPetLayer& layer) const
   return ! (*this == layer);
 }
 
+int JPetLayer::getID() const
+{
+  return fId;
+}
+bool JPetLayer::getIsActive() const
+{
+  return fIsActive;
+}
+std::string JPetLayer::getName() const
+{
+  return fName;
+}
+float JPetLayer::getRadius() const
+{
+  return fRadius;
+}
+const JPetFrame& JPetLayer::getFrame() const
+{
+  if (fTRefFrame.GetObject()) return static_cast<JPetFrame&>(*(fTRefFrame.GetObject()));
+  else {
+    ERROR("No JPetFrame slot set, Null object will be returned");
+    return JPetFrame::getDummyResult();
+  }
+}
+void JPetLayer::setFrame(JPetFrame& frame)
+{
+  fTRefFrame = &frame;
+}
+
+bool JPetLayer::isNullObject() const
+{
+  return fIsNullObject;
+}
+
+JPetLayer& JPetLayer::getDummyResult()
+{
+  static JPetLayer DummyResult(true);
+  return DummyResult;
+}
+
+void JPetLayer::clearTRefFrame()
+{
+  fTRefFrame = NULL;
+}
 
 ClassImp(JPetLayer);

--- a/JPetLayer/JPetLayer.h
+++ b/JPetLayer/JPetLayer.h
@@ -29,60 +29,42 @@
  */
 class JPetLayer: public TNamed
 {
+public:
+  JPetLayer();
+  JPetLayer(int id, bool isActive, std::string name, float radius);
+  explicit JPetLayer(bool isNull);
+
+  bool operator==(const JPetLayer& layer) const;
+  bool operator!=(const JPetLayer& layer) const;
+
+  int getID() const;
+  bool getIsActive() const;
+  std::string getName() const;
+  float getRadius() const;
+  const JPetFrame& getFrame() const;
+  void setFrame(JPetFrame& frame);
+  bool isNullObject() const;
+  static  JPetLayer& getDummyResult();
+
 protected:
+  void clearTRefFrame();
+
+#ifndef __CINT__
   const int fId = -1;
   bool fIsActive = false;
   std::string fName = "";
   float fRadius = -1.f;
   TRef fTRefFrame = NULL;
-
-public:
-  JPetLayer();
-  JPetLayer(int id, bool isActive, std::string name, float radius);
-  JPetLayer(bool isNull);
-
-  bool operator==(const JPetLayer& layer) const;
-  bool operator!=(const JPetLayer& layer) const;
-
-  inline int getID() const {
-    return fId;
-  }
-  inline bool getIsActive() const {
-    return fIsActive;
-  }
-  inline std::string getName() const {
-    return fName;
-  }
-  inline float getRadius() const {
-    return fRadius;
-  }
-  inline const JPetFrame& getFrame() const 
-  {
-    if(fTRefFrame.GetObject()) return static_cast<JPetFrame&>(*(fTRefFrame.GetObject()));
-    else { 
-      ERROR("No JPetFrame slot set, Null object will be returned");
-      return JPetFrame::getDummyResult();
-    }
-  }
-  inline void setFrame(JPetFrame& frame) {
-    fTRefFrame = &frame;
-  }
-
-  inline bool isNullObject() const { return fIsNullObject; }
-
-  static inline JPetLayer& getDummyResult() {
-    static JPetLayer DummyResult(true);
-    return DummyResult; 
-  }
-
-protected:
-  void clearTRefFrame() {
-    fTRefFrame = NULL;
-  }
-
-private:
   bool fIsNullObject = false;
+#else
+  const int fId;
+  bool fIsActive;
+  std::string fName;
+  float fRadius;
+  TRef fTRefFrame;
+  bool fIsNullObject;
+#endif
+
   ClassDef(JPetLayer, 4);
 };
-
 #endif // JPET_LAYER_H

--- a/JPetPM/JPetPM.cpp
+++ b/JPetPM/JPetPM.cpp
@@ -17,9 +17,9 @@
 #include <cassert>
 
 JPetPM::JPetPM() :
-  fHVgain(std::make_pair(0.0, 0.0)) // it is possible to initialize pair in header by 
-                                    // std::pair<float, float> fHVgain {0.0 , 0.0}; 
-                                    // but then there is some error generating dictionary for file
+  fHVgain(std::make_pair(0.0, 0.0)) // it is possible to initialize pair in header by
+  // std::pair<float, float> fHVgain {0.0 , 0.0};
+  // but then there is some error generating dictionary for file
 {
   SetName("JPetPM");
 }
@@ -31,11 +31,11 @@ JPetPM::JPetPM(int id) :
   SetName("JPetPM");
 }
 
-JPetPM::JPetPM(Side side, 
-         int id, 
-         int HVset, 
-         int HVopt, 
-         std::pair<float, float> HVgainNumber):
+JPetPM::JPetPM(Side side,
+               int id,
+               int HVset,
+               int HVopt,
+               std::pair<float, float> HVgainNumber):
   fSide(side),
   fID(id),
   fHVset(HVset),
@@ -47,7 +47,7 @@ JPetPM::JPetPM(Side side,
 
 JPetPM::JPetPM(bool isNull) :
   fHVgain(std::make_pair(0.0, 0.0)),
-  fIsNullObject(isNull) 
+  fIsNullObject(isNull)
 {
   SetName("JPetPM");
 }
@@ -56,20 +56,131 @@ JPetPM::~JPetPM()
 {
 }
 
-bool JPetPM::operator==(const JPetPM& pm) const {
-  if( getID() == pm.getID() ){
-    assert(getSide()==pm.getSide());
-    assert(getHVopt()==pm.getHVopt());
-    assert(getHVset()==pm.getHVset());
+bool JPetPM::operator==(const JPetPM& pm) const
+{
+  if ( getID() == pm.getID() ) {
+    assert(getSide() == pm.getSide());
+    assert(getHVopt() == pm.getHVopt());
+    assert(getHVset() == pm.getHVset());
     return true;
   }
-  
+
   return false;
 }
 
-bool JPetPM::operator!=(const JPetPM& pm) const {
-  return !(*this==pm);
+bool JPetPM::operator!=(const JPetPM& pm) const
+{
+  return !(*this == pm);
 }
 
+void JPetPM::clearTRefFEBs()
+{
+  fTRefFEB = NULL;
+}
+void JPetPM::clearTRefScin()
+{
+  fTRefScin = NULL;
+}
+void JPetPM::clearTRefBarrelSlot()
+{
+  fTRefBarrelSlot = NULL;
+}
+
+JPetPM::Side JPetPM::getSide() const
+{
+  return fSide;
+}
+int JPetPM::getID() const
+{
+  return fID;
+}
+int JPetPM::getHVset() const
+{
+  return fHVset;
+}
+int JPetPM::getHVopt() const
+{
+  return fHVopt;
+}
+float JPetPM::getHVgain(GainNumber nr)
+{
+  return (nr == kFirst) ? fHVgain.first : fHVgain.second;
+}
+std::pair<float, float> JPetPM::getHVgain()
+{
+  return fHVgain;
+}
+void JPetPM::setSide(JPetPM::Side side)
+{
+  fSide = side;
+}
+void JPetPM::setHVset(int set)
+{
+  fHVset = set;
+}
+void JPetPM::setHVopt(int opt)
+{
+  fHVopt = opt;
+}
+void JPetPM::setHVgain(float g1, float g2)
+{
+  fHVgain.first = g1;
+  fHVgain.second = g2;
+}
+void JPetPM::setHVgain(const std::pair<float, float>& gain)
+{
+  fHVgain = gain;
+}
+
+void JPetPM::setFEB(JPetFEB& p_FEB)
+{
+  fTRefFEB = &p_FEB;
+}
+
+const JPetFEB& JPetPM::getFEB() const
+{
+  if (fTRefFEB.GetObject()) return (JPetFEB&) * (fTRefFEB.GetObject());
+  else {
+    ERROR("No JPetFEB slot set, Null object will be returned");
+    return JPetFEB::getDummyResult();
+  }
+}
+
+void JPetPM::setScin(JPetScin& p_scin)
+{
+  fTRefScin = &p_scin;
+}
+JPetScin& JPetPM::getScin() const
+{
+  if (fTRefScin.GetObject()) return (JPetScin&) * (fTRefScin.GetObject());
+  else {
+    ERROR("No JPetScin slot set, Null object will be returned");
+    return JPetScin::getDummyResult();
+  }
+}
+
+void JPetPM::setBarrelSlot(JPetBarrelSlot& p_barrelSlot)
+{
+  fTRefBarrelSlot = &p_barrelSlot;
+}
+JPetBarrelSlot& JPetPM::getBarrelSlot() const
+{
+  if (fTRefBarrelSlot.GetObject()) return (JPetBarrelSlot&) * (fTRefBarrelSlot.GetObject());
+  else {
+    ERROR("No JPetBarrelSlot slot set, Null object will be returned");
+    return JPetBarrelSlot::getDummyResult();
+  }
+}
+
+bool JPetPM::isNullObject() const
+{
+  return fIsNullObject;
+}
+
+JPetPM& JPetPM::getDummyResult()
+{
+  static JPetPM DummyResult(true);
+  return DummyResult;
+}
 
 ClassImp(JPetPM);

--- a/JPetPM/JPetPM.h
+++ b/JPetPM/JPetPM.h
@@ -30,122 +30,74 @@ class JPetScin;
  * @brief Parametric class representing database information on parameters of a photomultiplier.
  *
  */
-class JPetPM: public TNamed 
+class JPetPM: public TNamed
 {
- public:
+public:
   enum Side {SideA, SideB};
   enum GainNumber {kFirst, kSecond};
 
+  static  JPetPM& getDummyResult();
+
   JPetPM();
-  JPetPM(int id);
+  explicit JPetPM(int id);
+  explicit JPetPM(bool isNull);
   JPetPM(Side side,
-	 int id,
-	 int HVset,
-	 int HVopt,
-	 std::pair<float, float> HVgainNumber);
-  JPetPM(bool isNull);
+         int id,
+         int HVset,
+         int HVopt,
+         std::pair<float, float> HVgainNumber);
   ~JPetPM();
 
-  inline Side getSide() const { return fSide; }
-  inline int getID() const { return fID; }
-  inline int getHVset() const { return fHVset; }
-  inline int getHVopt() const { return fHVopt; }
-  inline float getHVgain(GainNumber nr) { return (nr == kFirst) ? fHVgain.first : fHVgain.second; }
-  inline std::pair<float, float> getHVgain() { return fHVgain; }
-  inline void setSide(Side side) { fSide = side; }
-  inline void setHVset(int set) { fHVset = set; }
-  inline void setHVopt(int opt) { fHVopt= opt; }
-  inline void setHVgain(float g1, float g2) { fHVgain.first = g1; fHVgain.second = g2; }
-  inline void setHVgain(const std::pair<float,float>& gain) { fHVgain = gain; }
-
-  void setFEB(JPetFEB &p_FEB) { fTRefFEB = &p_FEB; }
-  const JPetFEB &getFEB() const
-  {
-    if (fTRefFEB.GetObject()) return (JPetFEB &)*(fTRefFEB.GetObject());
-    else {
-      ERROR("No JPetFEB slot set, Null object will be returned");
-      return JPetFEB::getDummyResult();
-    }
-  }
-
-  void setScin(JPetScin &p_scin) { fTRefScin = &p_scin; }
-  JPetScin &getScin() const
-  {
-    if (fTRefScin.GetObject()) return (JPetScin &)*(fTRefScin.GetObject());
-    else {
-      ERROR("No JPetScin slot set, Null object will be returned");
-      return JPetScin::getDummyResult();
-    }
-  }
-
-  void setBarrelSlot(JPetBarrelSlot &p_barrelSlot) { fTRefBarrelSlot = &p_barrelSlot; }
-  JPetBarrelSlot &getBarrelSlot() const 
-  {
-    if(fTRefBarrelSlot.GetObject()) return (JPetBarrelSlot &)*(fTRefBarrelSlot.GetObject());
-    else {
-      ERROR("No JPetBarrelSlot slot set, Null object will be returned");
-      return JPetBarrelSlot::getDummyResult();
-    } 
-  }
-
-  inline bool isNullObject() const { return fIsNullObject; }
-
-  static inline JPetPM& getDummyResult() {
-    static JPetPM DummyResult(true);
-    return DummyResult;
-  }
-  
   bool operator==(const JPetPM& pm) const;
   bool operator!=(const JPetPM& pm) const;
-  
-  /*std::vector<TRef> getTRefKBs() const { return fTRefKBs; }
 
-  JPetFEB* getTRefKB(int p_index)
-  {
-    if(p_index < fTRefKBs.size())
-    {
-      return (JPetFEB*)fTRefKBs[p_index].GetObject();
-    }
-    return NULL;
-  }
-  
-  void setTRefKBs(std::vector<TRef> &p_TRefKBs)
-  {
-    fTRefKBs = p_TRefKBs;
-  }
-  
-  void addTRefKB(JPetFEB &p_KB)
-  {
-    fTRefKBs.push_back(&p_KB);
-  }*/
-  
- private:
+  Side getSide() const;
+  int getID() const;
+  int getHVset() const;
+  int getHVopt() const;
+  float getHVgain(GainNumber nr);
+  std::pair<float, float> getHVgain();
+  void setSide(Side side);
+  void setHVset(int set);
+  void setHVopt(int opt);
+  void setHVgain(float g1, float g2);
+  void setHVgain(const std::pair<float, float>& gain);
+  void setFEB(JPetFEB& p_FEB);
+  const JPetFEB& getFEB() const;
+  void setScin(JPetScin& p_scin);
+  JPetScin& getScin() const;
+  void setBarrelSlot(JPetBarrelSlot& p_barrelSlot);
+  JPetBarrelSlot& getBarrelSlot() const;
+  bool isNullObject() const;
+
+
+protected:
+  void clearTRefFEBs();
+  void clearTRefScin();
+  void clearTRefBarrelSlot();
+
+#ifndef __CINT__
   Side fSide = SideA;
   int fID = 0;
   int fHVset = 0;
   int fHVopt = 0;
   std::pair<float, float> fHVgain;
-
-  ClassDef(JPetPM, 5);
-  
-protected:
+  bool fIsNullObject = false;
+#else
+  Side fSide;
+  int fID;
+  int fHVset;
+  int fHVopt;
+  std::pair<float, float> fHVgain;
+  bool fIsNullObject;
+#endif
   TRef fTRefFEB;
   TRef fTRefScin;
   TRef fTRefBarrelSlot;
-  bool fIsNullObject = false;
 
-  void clearTRefFEBs() { fTRefFEB = NULL; }
-  void clearTRefScin() { fTRefScin = NULL; }
-  void clearTRefBarrelSlot() { fTRefBarrelSlot = NULL; }
-  
-  /*std::vector<TRef> fTRefKBs;
-  
-  void clearTRefKBs()
-  {
-    fTRefKBs.clear();
-  }*/
-  
   friend class JPetParamManager;
+
+  ClassDef(JPetPM, 5);
 };
 
 #endif

--- a/JPetScin/JPetScin.cpp
+++ b/JPetScin/JPetScin.cpp
@@ -88,3 +88,68 @@ void JPetScin::setScinSize(JPetScin::Dimension dim, float value)
     assert(1 == 0);
   }
 }
+
+bool JPetScin::operator==(const JPetScin& scin) const
+{
+  return getID() == scin.getID();
+}
+
+bool JPetScin::operator!=(const JPetScin& scin) const
+{
+  return getID() != scin.getID();
+}
+
+int JPetScin::getID() const
+{
+  return fID;
+}
+
+float JPetScin::getAttenLen() const
+{
+  return fAttenLen;
+}
+
+JPetScin::ScinDimensions JPetScin::getScinSize() const
+{
+  return fScinSize;
+}
+float JPetScin::getScinSize(Dimension dim) const;
+void JPetScin::setAttenLen(float attenLen)
+{
+  fAttenLen = attenLen;
+}
+void JPetScin::setScinSize(ScinDimensions size)
+{
+  fScinSize = size;
+}
+void JPetScin::setScinSize(Dimension dim, float value);
+
+void JPetScin::setBarrelSlot(JPetBarrelSlot& p_barrelSlot)
+{
+  fTRefBarrelSlot = &p_barrelSlot;
+}
+
+JPetBarrelSlot& JPetScin::getBarrelSlot() const
+{
+  if (fTRefBarrelSlot.GetObject()) return (JPetBarrelSlot&) * (fTRefBarrelSlot.GetObject());
+  else {
+    ERROR("No JPetBarrelSlot slot set, Null object will be returned");
+    return JPetBarrelSlot::getDummyResult();
+  }
+}
+
+bool JPetScin::isNullObject() const
+{
+  return fIsNullObject;
+}
+
+JPetScin& JPetScin::getDummyResult()
+{
+  static JPetScin DummyResult(true);
+  return DummyResult;
+}
+
+void JPetScin::clearTRefBarrelSlot()
+{
+  fTRefBarrelSlot = NULL;
+}

--- a/JPetScin/JPetScin.h
+++ b/JPetScin/JPetScin.h
@@ -20,7 +20,6 @@
 #include <TRef.h>
 #include "../JPetBarrelSlot/JPetBarrelSlot.h"
 #include "../JPetLoggerInclude.h"
-//#include "../JPetPM/JPetPM.h"
 
 
 /**
@@ -29,91 +28,56 @@
  */
 class JPetScin: public TNamed
 {
- public:
+public:
   enum Dimension {kLength, kHeight, kWidth};
-  struct ScinDimensions
-  {
-    ScinDimensions():fLength(0), fHeight(0), fWidth(0) { }
-    ScinDimensions(float len, float h, float w):fLength(len), fHeight(h), fWidth(w) { }
+  struct ScinDimensions {
+    ScinDimensions(): fLength(0), fHeight(0), fWidth(0) { }
+    ScinDimensions(float len, float h, float w): fLength(len), fHeight(h), fWidth(w) { }
     float fLength;
     float fHeight;
     float fWidth;
   };
 
   JPetScin();
-  JPetScin(int id);
+  explicit JPetScin(int id);
   JPetScin(int id, float attenLen, float length, float height, float width);
-  JPetScin(bool isNull);
+  explicit JPetScin(bool isNull);
   ~JPetScin();
 
-  inline int getID() const { return fID; }
-  inline float getAttenLen() const { return fAttenLen; }
-  inline ScinDimensions getScinSize() const { return fScinSize; }
+  bool operator==(const JPetScin& scin) const;
+  bool operator!=(const JPetScin& scin) const;
+
+  int getID() const;
+  float getAttenLen() const;
+  ScinDimensions getScinSize() const;
   float getScinSize(Dimension dim) const;
-  inline void setAttenLen(float attenLen) { fAttenLen = attenLen; }
-  inline void setScinSize(ScinDimensions size) { fScinSize = size; }
+  void setAttenLen(float attenLen);
+  void setScinSize(ScinDimensions size);
   void setScinSize(Dimension dim, float value);
+  void setBarrelSlot(JPetBarrelSlot& p_barrelSlot);
+  JPetBarrelSlot& getBarrelSlot() const;
+  bool isNullObject() const;
+  static JPetScin& getDummyResult();
 
-  void setBarrelSlot(JPetBarrelSlot &p_barrelSlot){ fTRefBarrelSlot = &p_barrelSlot; }
-  JPetBarrelSlot& getBarrelSlot() const {
-    if(fTRefBarrelSlot.GetObject()) return (JPetBarrelSlot&)*(fTRefBarrelSlot.GetObject());
-    else {
-      ERROR("No JPetBarrelSlot slot set, Null object will be returned");
-      return JPetBarrelSlot::getDummyResult();
-    }
-  }
+protected:
+  void clearTRefBarrelSlot();
 
-  inline bool isNullObject() const { return fIsNullObject; }
-
-  static inline JPetScin& getDummyResult() {
-    static JPetScin DummyResult(true);
-    return DummyResult;
-  }
-  
-  inline bool operator==(const JPetScin& scin) const { return getID() == scin.getID(); }
-  inline bool operator!=(const JPetScin& scin) const { return getID() != scin.getID(); }
-
-  /*
-  JPetPM* getTRefPMLeft() { return (JPetPM*)fTRefPMLeft.GetObject(); }
-  JPetPM* getTRefPMRight(){ return (JPetPM*)fTRefPMRight.GetObject(); }
-  
-  void setTRefPMs(JPetPM &p_leftPM, JPetPM &p_rightPM)
-  {    
-    fTRefPMLeft = &p_leftPM;
-    fTRefPMRight = &p_rightPM;
-  }
-  void setLeftTRefPM(JPetPM &p_PM)
-  {
-    fTRefPMLeft = &p_PM;
-  }
-  void setRightTRefPM(JPetPM &p_PM)
-  {
-    fTRefPMRight = &p_PM;
-  }
-  */
- private:
+#ifndef __CINT__
   int fID = 0;
   float fAttenLen = 0.0;  /// attenuation length
   ScinDimensions fScinSize; /// @todo check if there is no problem with the ROOT dictionnary
   bool fIsNullObject = false;
-  ClassDef(JPetScin, 4);
-  
-protected:
+#else
+  int fID;
+  float fAttenLen;  /// attenuation length
+  ScinDimensions fScinSize; /// @todo check if there is no problem with the ROOT dictionnary
+  bool fIsNullObject;
+#endif
   TRef fTRefBarrelSlot;
-  
-  void clearTRefBarrelSlot() { fTRefBarrelSlot = NULL; }
-  /*
-  TRef fTRefPMLeft;
-  TRef fTRefPMRight;
-  
-  void clearTRefPMs()
-  {
-    fTRefPMLeft = NULL;
-    fTRefPMRight = NULL;
-  }
-  */
 
   friend class JPetParamManager;
+
+  ClassDef(JPetScin, 4);
 };
 
 #endif

--- a/JPetTOMBChannel/JPetTOMBChannel.cpp
+++ b/JPetTOMBChannel/JPetTOMBChannel.cpp
@@ -13,7 +13,6 @@
  *  @file JPetTOMBChannel.cpp
  */
 
-
 #include "JPetTOMBChannel.h"
 
 ClassImp(JPetTOMBChannel);
@@ -30,7 +29,7 @@ JPetTOMBChannel::JPetTOMBChannel(unsigned int p_channel): fChannel(p_channel)
 
 JPetTOMBChannel::JPetTOMBChannel(int p_channel): fChannel(p_channel)
 {
-  if(p_channel < 0) {
+  if (p_channel < 0) {
     ERROR("p_channel cannot be negative"); //
   }
   SetName("JPetTOMBChannel");
@@ -45,3 +44,105 @@ JPetTOMBChannel::~JPetTOMBChannel()
 {
 }
 
+void JPetTOMBChannel::setFEB(JPetFEB& p_FEB)
+{
+  fFEB = &p_FEB;
+}
+
+void JPetTOMBChannel::setTRB(JPetTRB& p_TRB)
+{
+  fTRB = &p_TRB;
+}
+
+void JPetTOMBChannel::setPM(JPetPM& p_PM)
+{
+  fPM = &p_PM;
+}
+
+void JPetTOMBChannel::setThreshold(float p_threshold)
+{
+  fThreshold = p_threshold;
+}
+
+const JPetFEB& JPetTOMBChannel::getFEB()const
+{
+  if (fFEB.GetObject()) return (JPetFEB&) * fFEB.GetObject();
+  else {
+    ERROR("No JPetFEB slot set, Null object will be returned");
+    return JPetFEB::getDummyResult();
+  }
+}
+
+const JPetTRB& JPetTOMBChannel::getTRB()const
+{
+  if (fTRB.GetObject()) return (JPetTRB&) * fTRB.GetObject();
+  else {
+    ERROR("No JPetTRB slot set, Null object will be returned");
+    return JPetTRB::getDummyResult();
+  }
+}
+
+const JPetPM& JPetTOMBChannel::getPM()const
+{
+  if (fPM.GetObject()) return (JPetPM&) * fPM.GetObject();
+  else {
+    ERROR("No JPetPM slot set, Null object will be returned");
+    return JPetPM::getDummyResult();
+  }
+}
+
+float JPetTOMBChannel::getThreshold()const
+{
+  return fThreshold;
+}
+
+int JPetTOMBChannel::getChannel()const
+{
+  return fChannel;
+}
+
+std::string JPetTOMBChannel::getDescription()const
+{
+  return m_description;
+}
+
+bool JPetTOMBChannel::operator==(const JPetTOMBChannel& channel)
+{
+  return getChannel() == channel.getChannel();
+}
+
+bool JPetTOMBChannel::operator!=(const JPetTOMBChannel& channel)
+{
+  return getChannel() != channel.getChannel();
+}
+
+unsigned int JPetTOMBChannel::getLocalChannelNumber() const
+{
+  return fLocalChannelNumber;
+}
+
+void JPetTOMBChannel::setLocalChannelNumber(unsigned int lcn)
+{
+  fLocalChannelNumber = lcn;
+}
+
+unsigned int JPetTOMBChannel::getFEBInputNumber() const
+{
+  return fFEBInputNumber;
+}
+
+void JPetTOMBChannel::setFEBInputNumber(unsigned int fin)
+{
+  fFEBInputNumber = fin;
+}
+
+bool JPetTOMBChannel::isNullObject() const
+{
+  return fIsNullObject;
+}
+
+JPetTOMBChannel& JPetTOMBChannel::getDummyResult()
+{
+  static JPetTOMBChannel DummyResult(true);
+  return DummyResult;
+}

--- a/JPetTOMBChannel/JPetTOMBChannel.h
+++ b/JPetTOMBChannel/JPetTOMBChannel.h
@@ -32,50 +32,28 @@
  */
 class JPetTOMBChannel: public TNamed
 {
-protected:
-  
-  int m_id;
-  std::string m_description;
-  
+
 public:
   JPetTOMBChannel();
-  JPetTOMBChannel(unsigned int p_channel);
-  JPetTOMBChannel(int p_channel);
-  JPetTOMBChannel(bool isNull);
+  explicit JPetTOMBChannel(unsigned int p_channel);
+  explicit JPetTOMBChannel(int p_channel);
+  explicit JPetTOMBChannel(bool isNull);
   virtual ~JPetTOMBChannel(void);
-  
-  void setFEB(JPetFEB& p_FEB){ fFEB = &p_FEB; }
-  void setTRB(JPetTRB& p_TRB){ fTRB = &p_TRB; }
-  void setPM(JPetPM& p_PM){ fPM = &p_PM; }
-  void setThreshold(float p_threshold){ fThreshold = p_threshold; }
-  
-  const JPetFEB & getFEB()const{
-    if(fFEB.GetObject()) return (JPetFEB&)*fFEB.GetObject();
-    else {
-      ERROR("No JPetFEB slot set, Null object will be returned");
-      return JPetFEB::getDummyResult();
-    }
-  }
-  const JPetTRB & getTRB()const{
-    if(fTRB.GetObject()) return (JPetTRB&)*fTRB.GetObject();
-    else {
-      ERROR("No JPetTRB slot set, Null object will be returned");
-      return JPetTRB::getDummyResult();
-    }
-  }
-  const JPetPM & getPM()const{
-    if(fPM.GetObject()) return (JPetPM&)*fPM.GetObject();
-    else {
-      ERROR("No JPetPM slot set, Null object will be returned");
-      return JPetPM::getDummyResult();
-    }
-  }
-  float getThreshold()const{ return fThreshold; }
-  int getChannel()const{ return fChannel; }
-  std::string getDescription()const{ return m_description; }
 
-  inline bool operator==(const JPetTOMBChannel& channel) { return getChannel() == channel.getChannel(); }
-  inline bool operator!=(const JPetTOMBChannel& channel) { return getChannel() != channel.getChannel(); }
+  void setFEB(JPetFEB& p_FEB);
+  void setTRB(JPetTRB& p_TRB);
+  void setPM(JPetPM& p_PM);
+  void setThreshold(float p_threshold);
+
+  const JPetFEB& getFEB() const;
+  const JPetTRB& getTRB() const;
+  const JPetPM& getPM() const;
+  float getThreshold() const;
+  int getChannel() const;
+  std::string getDescription() const;
+
+  bool operator==(const JPetTOMBChannel& channel);
+  bool operator!=(const JPetTOMBChannel& channel);
 
   /**
    * @brief Get a local number of the channel corresponding to this TOMBChannel, w.r.t. a single PM.
@@ -83,27 +61,25 @@ public:
    * All thresholds (together on leading and trailing edge) applied to a single PM signal can be ordered starting from 1, with an order corresponding to ascending order of DAQ channels assigned to the thresholds.
    * Therefore, if there are 4 thresholds applied to each signal edge, the local channel number should be between 1 and 8.
    */
-  unsigned int getLocalChannelNumber() const { return fLocalChannelNumber; }
-  void setLocalChannelNumber(unsigned int lcn) { fLocalChannelNumber = lcn; }
+  unsigned int getLocalChannelNumber() const;
+  void setLocalChannelNumber(unsigned int lcn);
 
   /**
    * @brief Get the number of input channel (Numbering starts from 1) of the FEB which corresponds to this TOMB channel
    */
-  unsigned int getFEBInputNumber() const { return fFEBInputNumber; }
+  unsigned int getFEBInputNumber() const;
 
   /**
    * @brief Set the number of input channel (Numbering starts from 1) of the FEB which corresponds to this TOMB channel
    */
-  void setFEBInputNumber(unsigned int fin) { fFEBInputNumber = fin; }
+  void setFEBInputNumber(unsigned int fin);
+  bool isNullObject() const;
+  static  JPetTOMBChannel& getDummyResult();
 
-  inline bool isNullObject() const { return fIsNullObject; }
-
-  static inline JPetTOMBChannel& getDummyResult() {
-    static JPetTOMBChannel DummyResult(true);
-    return DummyResult;
-  }
-  
-private:
+protected:
+  int m_id;
+  std::string m_description;
+#ifndef __CINT__
   unsigned int fChannel = 0;
   TRef fFEB = NULL;
   TRef fTRB = NULL;
@@ -114,7 +90,19 @@ private:
   unsigned int fLocalChannelNumber = 0; ///< number of the threshold
   unsigned int fFEBInputNumber = 0; ///< number of input of the FEB from which this channel comes
   bool fIsNullObject = false;
-  
+#else
+  unsigned int fChannel;
+  TRef fFEB;
+  TRef fTRB;
+  TRef fPM;
+  TRef fScin; // @todo: add setters && getters for scin and slot
+  TRef fBarrelSlot;
+  float fThreshold;
+  unsigned int fLocalChannelNumber; ///< number of the threshold
+  unsigned int fFEBInputNumber; ///< number of input of the FEB from which this channel comes
+  bool fIsNullObject;
+#endif
+
   ClassDef(JPetTOMBChannel, 4);
 };
 

--- a/JPetTRB/JPetTRB.cpp
+++ b/JPetTRB/JPetTRB.cpp
@@ -27,8 +27,8 @@ JPetTRB::JPetTRB(int id) : fID(id)
   SetName("JPetTRB");
 }
 
-JPetTRB::JPetTRB(int id, int type, int ch): 
-  fID(id), 
+JPetTRB::JPetTRB(int id, int type, int ch):
+  fID(id),
   fType(type),
   fChannel(ch)
 {
@@ -43,4 +43,45 @@ JPetTRB::JPetTRB(bool isNull):
 
 JPetTRB::~JPetTRB()
 {
+}
+
+int JPetTRB::getID() const
+{
+  return fID;
+}
+int JPetTRB::getType() const
+{
+  return fType;
+}
+int JPetTRB::getChannel() const
+{
+  return fChannel;
+}
+void JPetTRB::setType(int type)
+{
+  fType = type;
+}
+void JPetTRB::setChannel(int ch)
+{
+  fChannel = ch;
+}
+
+bool JPetTRB::operator==(const JPetTRB& trb) const
+{
+  return getID() == trb.getID();
+}
+bool JPetTRB::operator!=(const JPetTRB& trb) const
+{
+  return getID() != trb.getID();
+}
+
+bool JPetTRB::isNullObject() const
+{
+  return fIsNullObject;
+}
+
+JPetTRB& JPetTRB::getDummyResult()
+{
+  static JPetTRB DummyResult(true);
+  return DummyResult;
 }

--- a/JPetTRB/JPetTRB.h
+++ b/JPetTRB/JPetTRB.h
@@ -24,44 +24,40 @@
  */
 class JPetTRB: public TNamed
 {
- public:
+public:
+
+  static  JPetTRB& getDummyResult();
+
   JPetTRB();
-  JPetTRB(int id);
+  explicit JPetTRB(int id);
+  explicit JPetTRB(bool isNull);
   JPetTRB(int id, int type, int channel);
-  JPetTRB(bool isNull);
   ~JPetTRB();
 
-  inline int getID() const { return fID; }
-  inline int getType() const { return fType; }
-  inline int getChannel() const { return fChannel; }
-  inline void setType(int type) { fType = type; }
-  inline void setChannel(int ch) { fChannel = ch; }
+  bool operator==(const JPetTRB& trb) const;
+  bool operator!=(const JPetTRB& trb) const;
+  int getID() const;
+  int getType() const;
+  int getChannel() const;
+  void setType(int type);
+  void setChannel(int ch);
+  bool isNullObject() const;
 
-  inline bool operator==(const JPetTRB& trb) const { return getID() == trb.getID(); }
-  inline bool operator!=(const JPetTRB& trb) const { return getID() != trb.getID(); }
-  
-  inline bool isNullObject() const { return fIsNullObject; }
-
-  static inline JPetTRB& getDummyResult() {
-    static JPetTRB DummyResult(true);
-    return DummyResult;
-  }
-
- private:
+protected:
+#ifndef __CINT__
   int fID = 0;
   int fType = 0;
   int fChannel = 0;
   bool fIsNullObject = false;
-  /// @todo do implementacji
-  //JPetFEB* KBId;
-  //KBType;
-  //KBChan;
-  //
-  ClassDef(JPetTRB, 3);
-  
-protected:
-  
+#else
+  int fID;
+  int fType;
+  int fChannel;
+  bool fIsNullObject;
+#endif
+
   friend class JPetParamManager;
+  ClassDef(JPetTRB, 3);
 };
 
 #endif


### PR DESCRIPTION
The PR 'Add return dummy class when reference is not set' #60 included
c++11-style  member initialization in the class definition.
Unfortunately for some ROOT version rootcint was not able to generate
dictionaries. Therefore __CINT__ guards have been added. Also, some code
clean-up has been done.