### PR TITLE
Handling of Unpacker-related command line parameters

### DIFF
--- a/JPetCmdParser/JPetCmdParser.h
+++ b/JPetCmdParser/JPetCmdParser.h
@@ -101,6 +101,20 @@ public:
     return variablesMap["localDBCreate"].as<std::string>();
   }
 
+  static inline bool isUnpackerConfigFileSet(const po::variables_map& variablesMap) {
+    return variablesMap.count("unpackerConfigFile") > 0;
+  }
+  static inline std::string getUnpackerConfigFile(const po::variables_map& variablesMap) {
+    return variablesMap["unpackerConfigFile"].as<std::string>();
+  }
+
+  static inline bool isUnpackerCalibFileSet(const po::variables_map& variablesMap) {
+    return variablesMap.count("unpackerCalibFile") > 0;
+  }
+  static inline std::string getUnpackerCalibFile(const po::variables_map& variablesMap) {
+    return variablesMap["unpackerCalibFile"].as<std::string>();
+  }
+  
 protected:
   po::options_description fOptionsDescriptions;
 

--- a/JPetCmdParser/JPetCmdParserTest.cpp
+++ b/JPetCmdParser/JPetCmdParserTest.cpp
@@ -131,12 +131,14 @@ BOOST_AUTO_TEST_CASE(getOptionsDescriptionTest)
   //cout << rangeOptionDescription.format_name() << endl;
   BOOST_REQUIRE(std::string(rangeOptionDescription.format_name()) == "-r [ --range ]");
 
-  auto paramOptionDescription = optionDescription.find("param", true);
-  //cout << paramOptionDescription.description() << endl;
-  BOOST_REQUIRE(std::string(paramOptionDescription.description()) == "xml file with TRB settings used by the unpacker program.");
-  //cout << paramOptionDescription.format_name() << endl;
-  BOOST_REQUIRE(std::string(paramOptionDescription.format_name()) == "-p [ --param ]");
+  auto unpackerConfigOptionDescription = optionDescription.find("unpackerConfigFile", true);
+  BOOST_REQUIRE(std::string(unpackerConfigOptionDescription.description()) == "xml file with TRB settings used by the unpacker program.");
+  BOOST_REQUIRE(std::string(unpackerConfigOptionDescription.format_name()) == "-p [ --unpackerConfigFile ]");
 
+  auto unpackerCalibOptionDescription = optionDescription.find("unpackerCalibFile", true);
+  BOOST_REQUIRE(std::string(unpackerCalibOptionDescription.description()) == "ROOT file with TRB calibration used by the unpacker program.");
+  BOOST_REQUIRE(std::string(unpackerCalibOptionDescription.format_name()) == "-c [ --unpackerCalibFile ]");
+  
   auto runIdOptionDescription = optionDescription.find("runId", true);
   //cout << runIdOptionDescription.description() << endl;
   BOOST_REQUIRE(std::string(runIdOptionDescription.description()) == "Run id.");
@@ -216,7 +218,8 @@ BOOST_AUTO_TEST_CASE(generateOptionsTest)
   ("file,f", po::value<std::vector<std::string>>(), "File(s) to open")
   ("type,t", po::value<std::string>(), "type of file: hld, zip, root or scope")
   ("range,r", po::value<std::vector<int>>(), "Range of events to process.")
-  ("param,p", po::value<std::string>(), "File with TRB numbers.")
+  ("unpackerConfigFile,p", po::value<std::string>(), "xml file with TRB settings used by the unpacker program.")
+  ("unpackerCalibFile,c", po::value<std::string>(), "ROOT file with TRB calibration used by the unpacker program.")
   ("runId,i", po::value<int>(), "Run id.")
   ("progressBar,b", po::bool_switch()->default_value(false), "Progress bar.")
   ("localDB,l", po::value<std::string>(), "The file to use as the parameter database.")
@@ -247,9 +250,10 @@ BOOST_AUTO_TEST_CASE(generateOptionsTest)
   BOOST_REQUIRE(firstOption.getLocalDBCreate() == std::string("output.json"));
 }
 
+
 BOOST_AUTO_TEST_CASE(parseAndGenerateOptionsTest)
 {
-  auto commandLine = "main.x -f unitTestData/JPetCmdParserTest/data.hld -t hld -r 2 4 -p data.hld -i 231 -L output.json";
+  auto commandLine = "main.x -f unitTestData/JPetCmdParserTest/data.hld -t hld -r 2 4 -p unitTestData/JPetCmdParserTest/data.hld -c unitTestData/JPetUnpackerTest/calib.root -i 231 -L output.json";
   auto args_char = createArgs(commandLine);
   auto argc = args_char.size();
   auto argv = args_char.data();
@@ -262,6 +266,8 @@ BOOST_AUTO_TEST_CASE(parseAndGenerateOptionsTest)
 
   BOOST_REQUIRE(firstOption.areCorrect(firstOption.getOptions()));
   BOOST_REQUIRE(strcmp(firstOption.getInputFile(), "unitTestData/JPetCmdParserTest/data.hld") == 0);
+  BOOST_REQUIRE(strcmp(firstOption.getUnpackerConfigFile(), "unitTestData/JPetCmdParserTest/data.hld") == 0);
+  BOOST_REQUIRE(strcmp(firstOption.getUnpackerCalibFile(), "unitTestData/JPetUnpackerTest/calib.root") == 0);
   BOOST_REQUIRE(firstOption.getInputFileType() == JPetOptions::kHld);
   BOOST_REQUIRE(firstOption.getFirstEvent() == 2);
   BOOST_REQUIRE(firstOption.getLastEvent() == 4);
@@ -349,7 +355,8 @@ BOOST_AUTO_TEST_CASE(checkWrongOutputPath)
   ("file,f", po::value< std::vector<std::string> >()->required()->multitoken(), "File(s) to open.")
   ("outputPath,o", po::value<std::string>(), "Location to which the outputFiles will be saved.")
   ("range,r", po::value< std::vector<int> >()->multitoken()->default_value({ -1, -1}, ""), "Range of events to process e.g. -r 1 1000 .")
-  ("param,p", po::value<std::string>(), "xml file with TRB settings used by the unpacker program.")
+  ("unpackerConfigFile,p", po::value<std::string>(), "xml file with TRB settings used by the unpacker program.")
+  ("unpackerCalibFile,c", po::value<std::string>(), "ROOT file with TRB calibration used by the unpacker program.")
   ("runId,i", po::value<int>(), "Run id.")
   ("progressBar,b", po::bool_switch()->default_value(false), "Progress bar.")
   ("localDB,l", po::value<std::string>(), "The file to use as the parameter database.")

--- a/JPetOptions/JPetOptions.cpp
+++ b/JPetOptions/JPetOptions.cpp
@@ -27,7 +27,9 @@ JPetOptions::Options JPetOptions::kDefaultOptions = {
   {"firstEvent", "-1"},
   {"lastEvent", "-1"},
   {"progressBar", "false"},
-  {"runId", "-1"}
+  {"runId", "-1"},
+  {"unpackerConfigFile", "conf_trb3.xml"},
+  {"unpackerCalibFile", ""}
 };
 
 JPetOptions::JPetOptions()

--- a/JPetOptions/JPetOptions.h
+++ b/JPetOptions/JPetOptions.h
@@ -85,6 +85,14 @@ public:
     return result;
   }
 
+  inline const char* getUnpackerConfigFile() const {
+    return fOptions.at("unpackerConfigFile").c_str();
+  }
+
+  inline const char* getUnpackerCalibFile() const {
+    return fOptions.at("unpackerCalibFile").c_str();
+  }
+  
   FileType getInputFileType() const;
   FileType getOutputFileType() const;
 

--- a/JPetOptions/JPetOptionsTest.cpp
+++ b/JPetOptions/JPetOptionsTest.cpp
@@ -25,7 +25,9 @@ BOOST_AUTO_TEST_CASE(petOptionsDefaultConstrutorTest)
         {"firstEvent", "-1"},
         {"lastEvent", "-1"},
         {"progressBar", "false"},
-        {"runId", "-1"}
+        {"runId", "-1"},
+	{"unpackerConfigFile", "conf_trb3.xml"},
+	{"unpackerCalibFile", ""}
     };
 
     JPetOptions petOptions;
@@ -45,7 +47,9 @@ BOOST_AUTO_TEST_CASE(petOptionsBasicTest)
         {"runId", "2001, A Space Odyssey"},
         {"progressBar", "true"},
         {"inputFileType", "root"},
-        {"outputFileType", "scope"}
+        {"outputFileType", "scope"},
+	{"unpackerConfigFile", "conf_trb3.xml"},
+	{"unpackerCalibFile", ""}
     };
 
     JPetOptions petOptions(options);
@@ -79,7 +83,9 @@ BOOST_AUTO_TEST_CASE(getTotalEventsTest)
         {"runId", "2001, A Space Odyssey"},
         {"progressBar", "true"},
         {"inputFileType", "root"},
-        {"outputFileType", "scope"}
+        {"outputFileType", "scope"},
+        {"unpackerConfigFile", "conf_trb3.xml"},
+	{"unpackerCalibFile", ""}
     };
 
     BOOST_REQUIRE_EQUAL(JPetOptions(options).getTotalEvents(), -1);

--- a/JPetTaskChainExecutor/JPetTaskChainExecutorUtils.cpp
+++ b/JPetTaskChainExecutor/JPetTaskChainExecutorUtils.cpp
@@ -37,13 +37,16 @@ bool JPetTaskChainExecutorUtils::process(const JPetOptions& options, JPetParamMa
   }
   auto inputFile = options.getInputFile();
   auto inputFileType = options.getInputFileType();
+  auto unpackerConfigFile = options.getUnpackerConfigFile();
+  auto unpackerCalibFile = options.getUnpackerCalibFile();
+
   if (inputFileType == JPetOptions::kScope) {
     if (!createScopeTaskAndAddToTaskList(options, paramMgr, tasks)) {
       ERROR("Scope task not added correctly!!!");
       return false;
     }
   } else if (inputFileType == JPetOptions::kHld) {
-    unpackFile(inputFile, options.getTotalEvents());
+    unpackFile(inputFile, options.getTotalEvents(), unpackerConfigFile, unpackerCalibFile);
   }
   /// Assumption that if the file is zipped than it is in the hld format
   /// and we will also unpack if from hld  after unzipping.
@@ -55,7 +58,7 @@ bool JPetTaskChainExecutorUtils::process(const JPetOptions& options, JPetParamMa
     } else {
       INFO( std::string("Unpacking") );
       auto unzippedFilename = JPetCommonTools::stripFileNameSuffix(std::string(inputFile)).c_str();
-      unpackFile(unzippedFilename, options.getTotalEvents());
+      unpackFile(unzippedFilename, options.getTotalEvents(), unpackerConfigFile, unpackerCalibFile);
     }
   }
 
@@ -79,14 +82,14 @@ bool JPetTaskChainExecutorUtils::createScopeTaskAndAddToTaskList(const JPetOptio
   return true;
 }
 
-void JPetTaskChainExecutorUtils::unpackFile(const char* filename, long long nevents)
+void JPetTaskChainExecutorUtils::unpackFile(const char* filename, long long nevents, const char * configfile = "", const char * calibfile = "")
 {
   JPetUnpacker unpacker;
   if (nevents > 0) {
-    unpacker.setParams(filename, nevents);
+    unpacker.setParams(filename, nevents, configfile, calibfile);
     WARNING(std::string("Even though the range of events was set, only the first ") + JPetCommonTools::intToString(nevents) + std::string(" will be unpacked by the unpacker. \n The unpacker always starts from the beginning of the file."));
   } else {
-    unpacker.setParams(filename);
+    unpacker.setParams(filename, 100000000, configfile, calibfile);
   }
   unpacker.exec();
 }

--- a/JPetTaskChainExecutor/JPetTaskChainExecutorUtils.h
+++ b/JPetTaskChainExecutor/JPetTaskChainExecutorUtils.h
@@ -33,7 +33,7 @@ public:
   /// process() method depends on the options can: 1.saves paramBank locally in ASCII format , 2. generate and add ScopeLoader
   /// 3. unpack the hld file.
   bool process(const JPetOptions& options, JPetParamManager* fParamManager, std::list<JPetTaskRunnerInterface*>& tasks);
-  void unpackFile(const char* filename, long long nevents);
+  void unpackFile(const char* filename, long long nevents, const char * configfile, const char * calibfile);
   bool createScopeTaskAndAddToTaskList(const JPetOptions& options, JPetParamManager* paramMgr, std::list<JPetTaskRunnerInterface*>& tasks);
   static JPetParamManager* generateParamManager(const  JPetOptions& options);
   /// system(...) is returning integer, 0 when everything went smoothly and error code when not.

--- a/JPetUnpacker/JPetUnpacker.cpp
+++ b/JPetUnpacker/JPetUnpacker.cpp
@@ -61,6 +61,11 @@ bool JPetUnpacker::exec()
     ERROR("The config file doesnt exist");
     return false;
   }
+  if (getCalibFile()!="" && !boost::filesystem::exists(getCalibFile())) 
+  {
+    ERROR("The provided calib file doesnt exist");
+    return false;
+  }
   if(getEventsToProcess() <= 0)
   {
     ERROR("No events to process");

--- a/JPetUnpacker/JPetUnpacker.cpp
+++ b/JPetUnpacker/JPetUnpacker.cpp
@@ -25,7 +25,8 @@ JPetUnpacker::JPetUnpacker():
 fUnpacker(0),
 fEventsToProcess(0),
 fHldFile(""),
-fCfgFile("")
+fCfgFile(""),
+fCalibFile("")
 {
   /**/
 }
@@ -40,10 +41,11 @@ JPetUnpacker::~JPetUnpacker()
 }
 
 
-void JPetUnpacker::setParams(const std::string& hldFile,  int numOfEvents, const std::string& cfgFile)
+void JPetUnpacker::setParams(const std::string& hldFile,  int numOfEvents, const std::string& cfgFile, const std::string& calibFile)
 {
   fHldFile = hldFile;
   fCfgFile = cfgFile;
+  fCalibFile = calibFile;
   fEventsToProcess = numOfEvents;
 }
 
@@ -72,7 +74,7 @@ bool JPetUnpacker::exec()
   fUnpacker = new Unpacker2();
 
   int refChannelOffset = 65;
-  fUnpacker->UnpackSingleStep(fHldFile.c_str(), fCfgFile.c_str(), fEventsToProcess, refChannelOffset, "");
+  fUnpacker->UnpackSingleStep(fHldFile.c_str(), fCfgFile.c_str(), fEventsToProcess, refChannelOffset, fCalibFile.c_str());
   
   return true;
 }

--- a/JPetUnpacker/JPetUnpacker.h
+++ b/JPetUnpacker/JPetUnpacker.h
@@ -34,15 +34,20 @@ class JPetUnpacker: public TObject
   inline int getEventsToProcess() const { return fEventsToProcess; }
   inline std::string getHldFile() const { return fHldFile; }
   inline std::string getCfgFile() const { return fCfgFile; }
-  void setParams(const std::string& hldFile, int numOfEvents = 100000000, const std::string& cfgFile = "conf_trb3.xml");
+  inline std::string getCalibFile() const { return fCalibFile; }
+  void setParams(const std::string& hldFile,
+                 int numOfEvents = 100000000,
+                 const std::string& cfgFile = "conf_trb3.xml",
+                 const std::string& calibFile = "");
 
-  ClassDef(JPetUnpacker, 1);
+  ClassDef(JPetUnpacker, 2);
 
  private:
   Unpacker2* fUnpacker;  
   int fEventsToProcess;
   std::string fHldFile;
   std::string fCfgFile;
+  std::string fCalibFile;
 };
 
 #endif

--- a/JPetUnpacker/JPetUnpackerTest.cpp
+++ b/JPetUnpacker/JPetUnpackerTest.cpp
@@ -35,27 +35,30 @@ BOOST_AUTO_TEST_CASE( my_test )
   BOOST_REQUIRE(unpack.getEventsToProcess() == 0);
   BOOST_REQUIRE(unpack.getHldFile() == "");
   BOOST_REQUIRE(unpack.getCfgFile() == "");
+  BOOST_REQUIRE(unpack.getCalibFile() == "");
   BOOST_REQUIRE(!unpack.exec());
 }
 
 BOOST_AUTO_TEST_CASE( my_test2 )
 {
   JPetUnpacker unpack;
-  unpack.setParams("test.hld", 10, "conf_test.xml");
+  unpack.setParams("test.hld", 10, "conf_test.xml", "calib.root");
   BOOST_REQUIRE(unpack.getEventsToProcess() == 10);
   BOOST_REQUIRE(unpack.getHldFile() == "test.hld");
   BOOST_REQUIRE(unpack.getCfgFile() == "conf_test.xml");
+  BOOST_REQUIRE(unpack.getCalibFile() == "calib.root");
   BOOST_REQUIRE(!unpack.exec());
 }
 
 BOOST_FIXTURE_TEST_CASE( my_test3, Fixture )
 {
   JPetUnpacker unpack;
-  unpack.setParams("unitTestData/JPetUnpackerTest/xx14099113231.hld", 10, "unitTestData/JPetUnpackerTest/conf_trb3.xml");
+  unpack.setParams("unitTestData/JPetUnpackerTest/xx14099113231.hld", 10, "unitTestData/JPetUnpackerTest/conf_trb3.xml", "unitTestData/JPetUnpackerTest/calib.root");
   BOOST_REQUIRE(unpack.exec());
   BOOST_REQUIRE(unpack.getEventsToProcess() == 10);
   BOOST_REQUIRE(unpack.getHldFile() == "unitTestData/JPetUnpackerTest/xx14099113231.hld");
   BOOST_REQUIRE(unpack.getCfgFile() == "unitTestData/JPetUnpackerTest/conf_trb3.xml");
+  BOOST_REQUIRE(unpack.getCalibFile() == "unitTestData/JPetUnpackerTest/calib.root");
   BOOST_REQUIRE(unpack.exec());
 }
 
@@ -65,6 +68,10 @@ BOOST_FIXTURE_TEST_CASE( my_test4, Fixture )
   unpack.setParams("unitTestData/JPetUnpackerTest/xx14099113231.hld", 10, "unitTestData/JPetUnpackerTest/conf_trb3.xml");
   BOOST_REQUIRE(unpack.exec());
   unpack.setParams("unitTestData/JPetUnpackerTest/xx14099113231.hld", 10, "unitTestData/JPetUnpackerTest/conf_trb.xml");
+  BOOST_REQUIRE(!unpack.exec());
+  unpack.setParams("unitTestData/JPetUnpackerTest/xx14099113231.hld", 10, "unitTestData/JPetUnpackerTest/conf_trb3.xml", "unitTestData/JPetUnpackerTest/calib.root");
+  BOOST_REQUIRE(unpack.exec());
+  unpack.setParams("unitTestData/JPetUnpackerTest/xx14099113231.hld", 10, "unitTestData/JPetUnpackerTest/conf_trb3.xml", "unitTestData/JPetUnpackerTest/calib2.root");
   BOOST_REQUIRE(!unpack.exec());
 }
 


### PR DESCRIPTION
- config file name (XML)
- TRB calibration file name (TOT offsets in a ROOT file)

Note that these changes required adding a new file to unitTestData at the servers:
framework/unitTestData/JPetUnpackerTest/calib.root
I have added this file at Sphinx but it should also be added at Koza (where I have no access).
