### PR TITLE
Change int to long long in nthEvent of JPetReader

### DIFF
--- a/JPetCmdParser/JPetCmdParserTest.cpp
+++ b/JPetCmdParser/JPetCmdParserTest.cpp
@@ -95,7 +95,7 @@ BOOST_AUTO_TEST_CASE( parsing_zip_file )
   auto options = parser.parseAndGenerateOptions(argc, const_cast<const char**>(argv));
   BOOST_REQUIRE_EQUAL(options.size(), 1);
   auto option = options.at(0);
-  BOOST_REQUIRE(std::string(option.getInputFile()) == "unitTestData/JPetCommonToolsTest/goodZip.gz");
+  BOOST_REQUIRE_EQUAL(std::string(option.getInputFile()), "unitTestData/JPetCommonToolsTest/goodZip.gz");
   BOOST_REQUIRE_EQUAL(option.getInputFileType(), JPetOptions::kZip);
 }
 

--- a/JPetCmdParser/JPetCmdParserTest.cpp
+++ b/JPetCmdParser/JPetCmdParserTest.cpp
@@ -95,7 +95,7 @@ BOOST_AUTO_TEST_CASE( parsing_zip_file )
   auto options = parser.parseAndGenerateOptions(argc, const_cast<const char**>(argv));
   BOOST_REQUIRE_EQUAL(options.size(), 1);
   auto option = options.at(0);
-  BOOST_REQUIRE_EQUAL(std::string(option.getInputFile()), "unitTestData/JPetCommonToolsTest/goodZip.gz");
+  BOOST_REQUIRE(std::string(option.getInputFile()) == "unitTestData/JPetCommonToolsTest/goodZip.gz");
   BOOST_REQUIRE_EQUAL(option.getInputFileType(), JPetOptions::kZip);
 }
 

--- a/JPetReader/JPetReader.cpp
+++ b/JPetReader/JPetReader.cpp
@@ -78,7 +78,7 @@ bool JPetReader::lastEvent()
   return loadCurrentEvent();
 }
 
-bool JPetReader::nthEvent(int n)
+bool JPetReader::nthEvent(long long n)
 {
   fCurrentEventNumber = n;
   return loadCurrentEvent();

--- a/JPetReader/JPetReader.h
+++ b/JPetReader/JPetReader.h
@@ -55,7 +55,7 @@ public:
   virtual bool nextEvent();
   virtual bool firstEvent();
   virtual bool lastEvent();
-  virtual bool nthEvent(int n);
+  virtual bool nthEvent(long long n);
   virtual long long getCurrentEventNumber() const {
     return fCurrentEventNumber;
   }

--- a/JPetReaderInterface/JPetReaderInterface.h
+++ b/JPetReaderInterface/JPetReaderInterface.h
@@ -26,7 +26,7 @@ class JPetReaderInterface {
   virtual bool nextEvent()=0;
   virtual bool firstEvent()=0;
   virtual bool lastEvent()=0;
-  virtual bool nthEvent(int n)=0;
+  virtual bool nthEvent(long long int n)=0;
   virtual long long getCurrentEventNumber() const =0;
   virtual long long getNbOfAllEvents() const =0; 
   virtual TObject* getObjectFromFile(const char* name)=0;


### PR DESCRIPTION
fCurrentEventNumber is long long variable, also GetEntry of TTree taking Long64_t variable, I think function nthEvent should also take long long variable instead of int.