### PR TITLE
Remove all warnings 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ find_package(Boost 1.50.0 REQUIRED COMPONENTS
   unit_test_framework
   )
 
-include_directories(${Boost_INCLUDE_DIRS})
+include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 add_definitions(${Boost_DEFINITIONS})
 
 get_directory_property(has_parent PARENT_DIRECTORY)

--- a/JPetBarrelSlot/JPetBarrelSlotTest.cpp
+++ b/JPetBarrelSlot/JPetBarrelSlotTest.cpp
@@ -197,7 +197,7 @@ BOOST_AUTO_TEST_CASE( no_barrelSlots )
   JPetLayerFactory layerFactory(paramGetter, 0, frameFactory);
   JPetBarrelSlotFactory factory(paramGetter, 0, layerFactory);
   auto& barrelSlots = factory.getBarrelSlots();
-  BOOST_REQUIRE_EQUAL(barrelSlots.size(), 0);
+  BOOST_REQUIRE_EQUAL(barrelSlots.size(), 0u);
 }
 
 BOOST_AUTO_TEST_CASE( single_object )
@@ -206,7 +206,7 @@ BOOST_AUTO_TEST_CASE( single_object )
   JPetLayerFactory layerFactory(paramGetter, 1, frameFactory);
   JPetBarrelSlotFactory factory(paramGetter, 1, layerFactory);
   auto& barrelSlots = factory.getBarrelSlots();
-  BOOST_REQUIRE_EQUAL(barrelSlots.size(), 1);
+  BOOST_REQUIRE_EQUAL(barrelSlots.size(), 1u);
   auto barrelSlot = barrelSlots[1];
   BOOST_REQUIRE_EQUAL(barrelSlot->getID(), 1);
   BOOST_REQUIRE(barrelSlot->isActive());
@@ -223,7 +223,7 @@ BOOST_AUTO_TEST_CASE( two_objects )
   JPetLayerFactory layerFactory(paramGetter, 2, frameFactory);
   JPetBarrelSlotFactory factory(paramGetter, 2, layerFactory);
   auto& barrelSlots = factory.getBarrelSlots();
-  BOOST_REQUIRE_EQUAL(barrelSlots.size(), 2);
+  BOOST_REQUIRE_EQUAL(barrelSlots.size(), 2u);
   auto barrelSlot = barrelSlots[1];
   BOOST_REQUIRE_EQUAL(barrelSlot->getID(), 1);
   BOOST_REQUIRE(barrelSlot->isActive());

--- a/JPetCmdParser/JPetCmdParserTest.cpp
+++ b/JPetCmdParser/JPetCmdParserTest.cpp
@@ -50,7 +50,7 @@ BOOST_AUTO_TEST_CASE( parsing_1 )
 
   JPetCmdParser parser;
   auto options = parser.parseAndGenerateOptions(argc, const_cast<const char**>(argv));
-  BOOST_REQUIRE_EQUAL(options.size(), 1);
+  BOOST_REQUIRE_EQUAL(options.size(), 1u);
   auto option = options.at(0);
   BOOST_REQUIRE(std::string(option.getInputFile()) == "unitTestData/JPetCmdParserTest/testfile.hld");
   BOOST_REQUIRE_EQUAL(option.getFirstEvent(), -1);
@@ -71,7 +71,7 @@ BOOST_AUTO_TEST_CASE( parsing_2 )
 
   JPetCmdParser parser;
   auto options = parser.parseAndGenerateOptions(argc, const_cast<const char**>(argv));
-  BOOST_REQUIRE_EQUAL(options.size(), 1);
+  BOOST_REQUIRE_EQUAL(options.size(), 1u);
   auto option = options.at(0);
   BOOST_REQUIRE_EQUAL(std::string(option.getInputFile()), "unitTestData/JPetCmdParserTest/testfile_config1_6");
   BOOST_REQUIRE_EQUAL(std::string(option.getScopeConfigFile()), "unitTestData/JPetCmdParserTest/testfile.json");
@@ -93,7 +93,7 @@ BOOST_AUTO_TEST_CASE( parsing_zip_file )
 
   JPetCmdParser parser;
   auto options = parser.parseAndGenerateOptions(argc, const_cast<const char**>(argv));
-  BOOST_REQUIRE_EQUAL(options.size(), 1);
+  BOOST_REQUIRE_EQUAL(options.size(), 1u);
   auto option = options.at(0);
   BOOST_REQUIRE(std::string(option.getInputFile()) == "unitTestData/JPetCommonToolsTest/goodZip.gz");
   BOOST_REQUIRE_EQUAL(option.getInputFileType(), JPetOptions::kZip);
@@ -174,7 +174,7 @@ BOOST_AUTO_TEST_CASE(runIdTest)
   BOOST_REQUIRE(cmdParser.getRunNumber(variablesMap) == 231);
 
   auto runId = variablesMap["runId"].as<int>();
-  BOOST_REQUIRE(variablesMap.size() == 1);
+  BOOST_REQUIRE(variablesMap.size() == 1u);
   BOOST_REQUIRE(variablesMap.count("runId") == 1);
   BOOST_REQUIRE(runId == 231);
 }
@@ -261,7 +261,7 @@ BOOST_AUTO_TEST_CASE(parseAndGenerateOptionsTest)
   JPetCmdParser parser;
   std::vector<JPetOptions> options = parser.parseAndGenerateOptions(argc, const_cast<const char**>(argv));
 
-  BOOST_REQUIRE_EQUAL(options.size(), 1);
+  BOOST_REQUIRE_EQUAL(options.size(), 1u);
   JPetOptions firstOption = options.front();
 
   BOOST_REQUIRE(firstOption.areCorrect(firstOption.getOptions()));
@@ -288,7 +288,7 @@ BOOST_AUTO_TEST_CASE(parseAndGenerateOptionsDefaultValuesTest)
   JPetCmdParser parser;
   std::vector<JPetOptions> options = parser.parseAndGenerateOptions(argc, const_cast<const char**>(argv));
 
-  BOOST_REQUIRE_EQUAL(options.size(), 1);
+  BOOST_REQUIRE_EQUAL(options.size(), 1u);
   JPetOptions firstOption = options.front();
 
   BOOST_REQUIRE(firstOption.areCorrect(firstOption.getOptions()));
@@ -380,7 +380,7 @@ BOOST_AUTO_TEST_CASE(checkOptionsWithAddedFromJson)
   auto options = parser.parseAndGenerateOptions(argc, const_cast<const char**>(argv));
   auto option = options.at(0);
   auto allOptions = option.getOptions();
-  BOOST_REQUIRE_EQUAL(allOptions.count("myOption"), 1);
+  BOOST_REQUIRE_EQUAL(allOptions.count("myOption"), 1u);
   BOOST_REQUIRE_EQUAL(allOptions.at("myOption"), "great");
   BOOST_REQUIRE(allOptions.count("myAnotherOption"));
   BOOST_REQUIRE_EQUAL(allOptions.at("myAnotherOption"), "wat");

--- a/JPetDBParamGetter/JPetDBParamGetterTest.cpp
+++ b/JPetDBParamGetter/JPetDBParamGetterTest.cpp
@@ -21,7 +21,7 @@ BOOST_AUTO_TEST_CASE(basicDataTest)
   int run  = 1;
   ParamObjectsDescriptions descriptions = paramGetter.getAllBasicData(ParamObjectType::kLayer, run);
 
-  BOOST_REQUIRE_EQUAL(descriptions.size(), 1);
+  BOOST_REQUIRE_EQUAL(descriptions.size(), 1u);
 
   ParamObjectDescription & description = descriptions[1];
   BOOST_REQUIRE_EQUAL(description["id"], "1");
@@ -37,7 +37,7 @@ BOOST_AUTO_TEST_CASE(relationalDataTest)
   int run  = 1;
   ParamRelationalData relations = paramGetter.getAllRelationalData(ParamObjectType::kLayer, ParamObjectType::kFrame, run);
 
-  BOOST_REQUIRE_EQUAL(relations.size(), 1);
+  BOOST_REQUIRE_EQUAL(relations.size(), 1u);
   BOOST_REQUIRE_EQUAL(relations[1], 1);
 }
 
@@ -48,7 +48,7 @@ BOOST_AUTO_TEST_CASE(tombRelationalDataTest)
   int run  = 1;
   ParamRelationalData relations = paramGetter.getAllRelationalData(ParamObjectType::kTOMBChannel, ParamObjectType::kTRB, run);
 
-  BOOST_REQUIRE_EQUAL(relations.size(), 4);
+  BOOST_REQUIRE_EQUAL(relations.size(), 4u);
   BOOST_REQUIRE_EQUAL(relations[111], 1);
   BOOST_REQUIRE_EQUAL(relations[112], 1);
   BOOST_REQUIRE_EQUAL(relations[113], 1);

--- a/JPetEvent/JPetEventTest.cpp
+++ b/JPetEvent/JPetEventTest.cpp
@@ -25,7 +25,7 @@ BOOST_AUTO_TEST_CASE(constructor)
   JPetEvent event({firstHit, secondHit}, JPetEventType::kUnknown);
 
   BOOST_REQUIRE(!event.getHits().empty());
-  BOOST_REQUIRE_EQUAL(event.getHits().size(), 2);
+  BOOST_REQUIRE_EQUAL(event.getHits().size(), 2u);
 }
 
 BOOST_AUTO_TEST_CASE(constructor_orderedHits)
@@ -98,9 +98,9 @@ BOOST_AUTO_TEST_CASE(addHit)
   JPetHit thirdHit;
   event.setHits( {firstHit, secondHit});
   BOOST_REQUIRE(!event.getHits().empty());
-  BOOST_REQUIRE_EQUAL(event.getHits().size(), 2);
+  BOOST_REQUIRE_EQUAL(event.getHits().size(), 2u);
   event.addHit(thirdHit);
-  BOOST_REQUIRE_EQUAL(event.getHits().size(), 3);
+  BOOST_REQUIRE_EQUAL(event.getHits().size(), 3u);
 }
 
 BOOST_AUTO_TEST_CASE(eventTypes)

--- a/JPetFEB/JPetFEBTest.cpp
+++ b/JPetFEB/JPetFEBTest.cpp
@@ -154,7 +154,7 @@ BOOST_AUTO_TEST_CASE( no_febs )
   JPetTRBFactory trbFactory(paramGetter, 0);
   JPetFEBFactory factory(paramGetter, 0, trbFactory);
   auto & febs = factory.getFEBs();
-  BOOST_REQUIRE_EQUAL(febs.size(), 0);
+  BOOST_REQUIRE_EQUAL(febs.size(), 0u);
 }
 
 BOOST_AUTO_TEST_CASE( single_object )
@@ -162,7 +162,7 @@ BOOST_AUTO_TEST_CASE( single_object )
   JPetTRBFactory trbFactory(paramGetter, 1);
   JPetFEBFactory factory(paramGetter, 1, trbFactory);
   auto & febs = factory.getFEBs();
-  BOOST_REQUIRE_EQUAL(febs.size(), 1);
+  BOOST_REQUIRE_EQUAL(febs.size(), 1u);
   auto feb = febs[1];
   BOOST_REQUIRE_EQUAL(feb->getID(), 1);
   BOOST_REQUIRE(feb->isActive());
@@ -181,7 +181,7 @@ BOOST_AUTO_TEST_CASE( two_objects )
   JPetTRBFactory trbFactory(paramGetter, 2);
   JPetFEBFactory factory(paramGetter, 2, trbFactory);
   auto & febs = factory.getFEBs();
-  BOOST_REQUIRE_EQUAL(febs.size(), 2);
+  BOOST_REQUIRE_EQUAL(febs.size(), 2u);
   auto feb = febs[1];
   BOOST_REQUIRE_EQUAL(feb->getID(), 1);
   BOOST_REQUIRE(feb->isActive());

--- a/JPetFrame/JPetFrameTest.cpp
+++ b/JPetFrame/JPetFrameTest.cpp
@@ -126,14 +126,14 @@ BOOST_AUTO_TEST_CASE( no_frames )
 {
   JPetFrameFactory factory(paramGetter, 0);
   auto & frames = factory.getFrames();
-  BOOST_REQUIRE_EQUAL(frames.size(), 0);
+  BOOST_REQUIRE_EQUAL(frames.size(), 0u);
 }
 
 BOOST_AUTO_TEST_CASE( single_object )
 {
   JPetFrameFactory factory(paramGetter, 1);
   auto & frames = factory.getFrames();
-  BOOST_REQUIRE_EQUAL(frames.size(), 1);
+  BOOST_REQUIRE_EQUAL(frames.size(), 1u);
   auto frame = frames[1];
   BOOST_REQUIRE_EQUAL(frame->getID(), 1);
   BOOST_REQUIRE(frame->getIsActive());
@@ -147,7 +147,7 @@ BOOST_AUTO_TEST_CASE( two_objects )
 {
   JPetFrameFactory factory(paramGetter, 2);
   auto & frames = factory.getFrames();
-  BOOST_REQUIRE_EQUAL(frames.size(), 2);
+  BOOST_REQUIRE_EQUAL(frames.size(), 2u);
   auto frame = frames[1];
   BOOST_REQUIRE_EQUAL(frame->getID(), 1);
   BOOST_REQUIRE(frame->getIsActive());

--- a/JPetGeomMapping/JPetGeomMappingTest.cpp
+++ b/JPetGeomMapping/JPetGeomMappingTest.cpp
@@ -23,22 +23,22 @@ BOOST_FIXTURE_TEST_CASE(mappingFirst, myFixture)
 {
   auto bank = fparamManagerInstance.getParamBank();
   auto mapping  = JPetGeomMapping(bank);
-  BOOST_REQUIRE_EQUAL(mapping.getLayersCount(), 3);
-  BOOST_REQUIRE_EQUAL(mapping.getLayersCount(), 3);
+  BOOST_REQUIRE_EQUAL(mapping.getLayersCount(), 3u);
+  BOOST_REQUIRE_EQUAL(mapping.getLayersCount(), 3u); // is checking same thing 2 times was intended?
   JPetLayer layerOK(1, true, "Layer01", 42.5);
   JPetLayer layerWrong(2, true, "Layer02", 50);
 
-  BOOST_REQUIRE_EQUAL(mapping.getLayerNumber(layerOK), 1);
+  BOOST_REQUIRE_EQUAL(mapping.getLayerNumber(layerOK), 1u);
   BOOST_REQUIRE_EQUAL(mapping.getLayerNumber(layerWrong), JPetGeomMapping::kBadLayerNumber);
 
   BOOST_REQUIRE_EQUAL(mapping.getSlotsCount(0), JPetGeomMapping::kBadSlotNumber);
-  BOOST_REQUIRE_EQUAL(mapping.getSlotsCount(1), 2);
-  BOOST_REQUIRE_EQUAL(mapping.getSlotsCount(2), 1);
+  BOOST_REQUIRE_EQUAL(mapping.getSlotsCount(1), 2u);
+  BOOST_REQUIRE_EQUAL(mapping.getSlotsCount(2), 1u);
 
 
   auto sizes = mapping.getLayersSizes();
   BOOST_REQUIRE(!sizes.empty());
-  BOOST_REQUIRE_EQUAL(sizes.size(), 3);
+  BOOST_REQUIRE_EQUAL(sizes.size(), 3u);
 }
 
 BOOST_FIXTURE_TEST_CASE(getSlotNumber, myFixture)
@@ -53,8 +53,8 @@ BOOST_FIXTURE_TEST_CASE(getSlotNumber, myFixture)
   slotOK2.setLayer(layerOK);
   JPetBarrelSlot slotWrong(3, true, "C2AA", 5, 9);
 
-  BOOST_REQUIRE_EQUAL(mapping.getSlotNumber(slotOK1), 1);
-  BOOST_REQUIRE_EQUAL(mapping.getSlotNumber(slotOK2), 2);
+  BOOST_REQUIRE_EQUAL(mapping.getSlotNumber(slotOK1), 1u);
+  BOOST_REQUIRE_EQUAL(mapping.getSlotNumber(slotOK2), 2u);
   BOOST_REQUIRE_EQUAL(mapping.getSlotNumber(slotWrong), JPetGeomMapping::kBadSlotNumber);
 
 
@@ -78,7 +78,7 @@ BOOST_FIXTURE_TEST_CASE(minimalBank, myFixture)
   auto slot = 1;
   auto side = JPetPM::SideB;
   auto thresholdNumber  = 1;
-  BOOST_REQUIRE_EQUAL(mapping.count(std::make_tuple(layer, slot, side, thresholdNumber)), 1);
+  BOOST_REQUIRE_EQUAL(mapping.count(std::make_tuple(layer, slot, side, thresholdNumber)), 1u);
   auto result_tomb = mapping.at(std::make_tuple(layer, slot, side, thresholdNumber));
   BOOST_REQUIRE_EQUAL(result_tomb, 1);
   layer = 1;
@@ -149,7 +149,7 @@ BOOST_AUTO_TEST_CASE(TestOfLargeBarrelJson)
   auto tombMap = mapper.getTOMBMapping();
   BOOST_REQUIRE(!tombMap.empty());
   // (96 +48 + 48 scints) x 2 pm x4 thr = 1536
-  BOOST_REQUIRE_EQUAL(tombMap.size(), 1536);
+  BOOST_REQUIRE_EQUAL(tombMap.size(), 1536u);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/JPetLargeBarrelExtensions/PetDictTest.cpp
+++ b/JPetLargeBarrelExtensions/PetDictTest.cpp
@@ -24,7 +24,7 @@ BOOST_AUTO_TEST_SUITE(JPetMapTesting)
 
 BOOST_AUTO_TEST_CASE(empty){
     JPetMap<size_t> map({});
-    BOOST_REQUIRE_EQUAL(0,map.layersCount());
+    BOOST_REQUIRE_EQUAL(0u,map.layersCount());
     BOOST_CHECK_THROW(map.layerSize(0),Exception<JPetMap<size_t>>);
     BOOST_CHECK_THROW(map.layerSize(1),Exception<JPetMap<size_t>>);
     BOOST_CHECK_THROW(map.layerSize(2),Exception<JPetMap<size_t>>);
@@ -33,35 +33,35 @@ BOOST_AUTO_TEST_CASE(sizes){
     {
 	JPetMap<size_t> map({2});
 	BOOST_CHECK_THROW(map.layerSize(0),Exception<JPetMap<size_t>>);
-	BOOST_REQUIRE_EQUAL(2,map.layerSize(1));
+	BOOST_REQUIRE_EQUAL(2u,map.layerSize(1));
 	BOOST_CHECK_THROW(map.layerSize(2),Exception<JPetMap<size_t>>);
     }{
 	JPetMap<size_t> map({2,3});
 	BOOST_CHECK_THROW(map.layerSize(0),Exception<JPetMap<size_t>>);
 	BOOST_CHECK_THROW(map.operator[]({.layer=0,.slot=0}),Exception<JPetMap<size_t>>);
 	BOOST_CHECK_THROW(map.operator[]({.layer=0,.slot=1}),Exception<JPetMap<size_t>>);
-	BOOST_REQUIRE_EQUAL(2,map.layerSize(1));
+	BOOST_REQUIRE_EQUAL(2u,map.layerSize(1));
 	BOOST_CHECK_THROW(map.operator[]({.layer=1,.slot=0}),Exception<JPetMap<size_t>>);
 	BOOST_CHECK_NO_THROW(map.operator[]({.layer=1,.slot=1}));
 	BOOST_CHECK_NO_THROW(map.operator[]({.layer=1,.slot=2}));
 	BOOST_CHECK_THROW(map.operator[]({.layer=1,.slot=3}),Exception<JPetMap<size_t>>);
-	BOOST_REQUIRE_EQUAL(3,map.layerSize(2));
+	BOOST_REQUIRE_EQUAL(3u,map.layerSize(2));
 	BOOST_CHECK_THROW(map.layerSize(3),Exception<JPetMap<size_t>>);
     }{
 	JPetMap<size_t> map({2,3,8});
 	BOOST_CHECK_THROW(map.layerSize(0),Exception<JPetMap<size_t>>);
-	BOOST_REQUIRE_EQUAL(2,map.layerSize(1));
-	BOOST_REQUIRE_EQUAL(3,map.layerSize(2));
-	BOOST_REQUIRE_EQUAL(8,map.layerSize(3));
+	BOOST_REQUIRE_EQUAL(2u,map.layerSize(1));
+	BOOST_REQUIRE_EQUAL(3u,map.layerSize(2));
+	BOOST_REQUIRE_EQUAL(8u,map.layerSize(3));
 	BOOST_CHECK_THROW(map.layerSize(4),Exception<JPetMap<size_t>>);
     }
 }
 BOOST_AUTO_TEST_CASE(Positioning){
     JPetMap<size_t> map({2,3,8});
     const auto initpos=map.positionOfGlobalNumber(0);
-    BOOST_REQUIRE_EQUAL(initpos.layer,1);
-    BOOST_REQUIRE_EQUAL(initpos.slot,1);
-    BOOST_REQUIRE_EQUAL(0,map.globalSlotNumber(initpos));
+    BOOST_REQUIRE_EQUAL(initpos.layer,1u);
+    BOOST_REQUIRE_EQUAL(initpos.slot,1u);
+    BOOST_REQUIRE_EQUAL(0u,map.globalSlotNumber(initpos));
     for(size_t cur=1;cur<map.size();cur++){
 	const size_t prev=cur-1;
 	const auto prevpos=map.positionOfGlobalNumber(prev);
@@ -71,7 +71,7 @@ BOOST_AUTO_TEST_CASE(Positioning){
 	    BOOST_REQUIRE_EQUAL(prevpos.slot+1,curpos.slot);
 	}else{
 	    if((prevpos.layer+1)==curpos.layer){
-		BOOST_REQUIRE_EQUAL(1,curpos.slot);
+		BOOST_REQUIRE_EQUAL(1u,curpos.slot);
 		BOOST_REQUIRE_EQUAL(map.layerSize(prevpos.layer),prevpos.slot);
 	    }else BOOST_REQUIRE(false);
 	}

--- a/JPetLayer/JPetLayerTest.cpp
+++ b/JPetLayer/JPetLayerTest.cpp
@@ -163,7 +163,7 @@ BOOST_AUTO_TEST_CASE( no_layers )
   JPetFrameFactory frameFactory(paramGetter, 0);
   JPetLayerFactory factory(paramGetter, 0, frameFactory);
   auto& layers = factory.getLayers();
-  BOOST_REQUIRE_EQUAL(layers.size(), 0);
+  BOOST_REQUIRE_EQUAL(layers.size(), 0u);
 }
 
 BOOST_AUTO_TEST_CASE( single_object )
@@ -171,7 +171,7 @@ BOOST_AUTO_TEST_CASE( single_object )
   JPetFrameFactory frameFactory(paramGetter, 1);
   JPetLayerFactory factory(paramGetter, 1, frameFactory);
   auto& layers = factory.getLayers();
-  BOOST_REQUIRE_EQUAL(layers.size(), 1);
+  BOOST_REQUIRE_EQUAL(layers.size(), 1u);
   auto layer = layers[1];
   BOOST_REQUIRE_EQUAL(layer->getID(), 1);
   BOOST_REQUIRE(layer->getIsActive());
@@ -186,7 +186,7 @@ BOOST_AUTO_TEST_CASE( two_objects )
   JPetFrameFactory frameFactory(paramGetter, 2);
   JPetLayerFactory factory(paramGetter, 2, frameFactory);
   auto& layers = factory.getLayers();
-  BOOST_REQUIRE_EQUAL(layers.size(), 2);
+  BOOST_REQUIRE_EQUAL(layers.size(), 2u);
   auto layer = layers[1];
   BOOST_REQUIRE_EQUAL(layer->getID(), 1);
   BOOST_REQUIRE(layer->getIsActive());

--- a/JPetManager/JPetManagerTest.cpp
+++ b/JPetManager/JPetManagerTest.cpp
@@ -31,7 +31,7 @@ BOOST_AUTO_TEST_CASE( manager_getOptions )
 {
   JPetManager& manager = JPetManager::getManager();
   auto options = manager.getOptions();
-  BOOST_REQUIRE_EQUAL(options.size(), 0);
+  BOOST_REQUIRE_EQUAL(options.size(), 0u);
 }
 
 BOOST_AUTO_TEST_CASE( emptyRun )
@@ -39,7 +39,7 @@ BOOST_AUTO_TEST_CASE( emptyRun )
   JPetManager& manager = JPetManager::getManager();
   BOOST_REQUIRE(manager.run());
   auto options = manager.getOptions();
-  BOOST_REQUIRE_EQUAL(options.size(), 0);
+  BOOST_REQUIRE_EQUAL(options.size(), 0u);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/JPetOptions/JPetOptionsToolsTest.cpp
+++ b/JPetOptions/JPetOptionsToolsTest.cpp
@@ -24,7 +24,7 @@ BOOST_AUTO_TEST_CASE(createOptionsFromConfigFile)
   auto inFile = "unitTestData/JPetOptionsToolsTest/inputTestCfg.json";
   std::map<std::string, std::string> options = jpet_options_tools::createOptionsFromConfigFile(inFile);
   std::map<std::string, std::string> expected = {{"myOption", "great"}, {"myAnotherOption", "wat"}, {"boolOption", "true"}, {"NumberOption", "12.2"}};
-  BOOST_REQUIRE_EQUAL(options.size(), 4);
+  BOOST_REQUIRE_EQUAL(options.size(), 4u);
 
   std::vector<std::string> keys_expected;
   std::vector<std::string> values_expected;
@@ -95,7 +95,7 @@ BOOST_AUTO_TEST_CASE( createOptionsFromConfigFileThatHasWrongFormat )
 {
   auto inFile = "unitTestData/JPetOptionsToolsTest/wrongInputFile.json";
   auto options = jpet_options_tools::createOptionsFromConfigFile(inFile);
-  BOOST_REQUIRE_EQUAL(options.size(),  0);
+  BOOST_REQUIRE_EQUAL(options.size(),  0u);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/JPetPM/JPetPMTest.cpp
+++ b/JPetPM/JPetPMTest.cpp
@@ -255,7 +255,7 @@ BOOST_AUTO_TEST_CASE( no_pms )
   JPetScinFactory scinFactory(paramGetter, 0, barrelSlotFactory);
   JPetPMFactory factory(paramGetter, 0, febFactory, scinFactory, barrelSlotFactory);
   auto & pms = factory.getPMs();
-  BOOST_REQUIRE_EQUAL(pms.size(), 0);
+  BOOST_REQUIRE_EQUAL(pms.size(), 0u);
 }
 
 BOOST_AUTO_TEST_CASE( single_object )
@@ -268,7 +268,7 @@ BOOST_AUTO_TEST_CASE( single_object )
   JPetScinFactory scinFactory(paramGetter, 1, barrelSlotFactory);
   JPetPMFactory factory(paramGetter, 1, febFactory, scinFactory, barrelSlotFactory);
   auto & pms = factory.getPMs();
-  BOOST_REQUIRE_EQUAL(pms.size(), 1);
+  BOOST_REQUIRE_EQUAL(pms.size(), 1u);
   auto pm = pms[1];
   BOOST_REQUIRE_EQUAL(pm->getID(), 1);
   BOOST_REQUIRE_EQUAL(pm->getSide(), JPetPM::SideB);
@@ -288,7 +288,7 @@ BOOST_AUTO_TEST_CASE( two_objects )
   JPetScinFactory scinFactory(paramGetter, 2, barrelSlotFactory);
   JPetPMFactory factory(paramGetter, 2, febFactory, scinFactory, barrelSlotFactory);
   auto & pms = factory.getPMs();
-  BOOST_REQUIRE_EQUAL(pms.size(), 2);
+  BOOST_REQUIRE_EQUAL(pms.size(), 2u);
   auto pm = pms[1];
   BOOST_REQUIRE_EQUAL(pm->getID(), 1);
   BOOST_REQUIRE_EQUAL(pm->getSide(), JPetPM::SideB);

--- a/JPetPMCalib/JPetPMCalibTest.cpp
+++ b/JPetPMCalib/JPetPMCalibTest.cpp
@@ -128,14 +128,14 @@ BOOST_AUTO_TEST_CASE( no_pmCalibs )
 {
   JPetPMCalibFactory factory(paramGetter, 0);
   auto& pmCalibs = factory.getPMCalibs();
-  BOOST_REQUIRE_EQUAL(pmCalibs.size(), 0);
+  BOOST_REQUIRE_EQUAL(pmCalibs.size(), 0u);
 }
 
 BOOST_AUTO_TEST_CASE( single_object )
 {
   JPetPMCalibFactory factory(paramGetter, 1);
   auto& pmCalibs = factory.getPMCalibs();
-  BOOST_REQUIRE_EQUAL(pmCalibs.size(), 1);
+  BOOST_REQUIRE_EQUAL(pmCalibs.size(), 1u);
   auto pmCalib = pmCalibs[1];
   BOOST_REQUIRE_EQUAL(pmCalib->getID(), 1);
   BOOST_REQUIRE_EQUAL(pmCalib->GetNamePM(), "PMCalib");
@@ -152,7 +152,7 @@ BOOST_AUTO_TEST_CASE( two_objects )
 {
   JPetPMCalibFactory factory(paramGetter, 2);
   auto& pmCalibs = factory.getPMCalibs();
-  BOOST_REQUIRE_EQUAL(pmCalibs.size(), 2);
+  BOOST_REQUIRE_EQUAL(pmCalibs.size(), 2u);
   auto pmCalib = pmCalibs[1];
   BOOST_REQUIRE_EQUAL(pmCalib->getID(), 1);
   BOOST_REQUIRE_EQUAL(pmCalib->GetNamePM(), "PMCalib");

--- a/JPetParamGetterAscii/JPetParamGetterAsciiTest.cpp
+++ b/JPetParamGetterAscii/JPetParamGetterAsciiTest.cpp
@@ -14,20 +14,20 @@ BOOST_AUTO_TEST_SUITE(FirstSuite)
 BOOST_AUTO_TEST_CASE( noExisting_file_read )
 {
   JPetParamGetterAscii getter(dataDir + "noExisting.json");
-  BOOST_REQUIRE_EQUAL(getter.getAllBasicData(ParamObjectType::kPM, 1).size(), 0);
+  BOOST_REQUIRE_EQUAL(getter.getAllBasicData(ParamObjectType::kPM, 1).size(), 0u);
 }
 
 BOOST_AUTO_TEST_CASE( empty_file_read )
 {
   JPetParamGetterAscii getter(dataDir + "empty.json");
-  BOOST_REQUIRE_EQUAL(getter.getAllBasicData(ParamObjectType::kPM, 1).size(), 0);
+  BOOST_REQUIRE_EQUAL(getter.getAllBasicData(ParamObjectType::kPM, 1).size(), 0u);
 }
 
 BOOST_AUTO_TEST_CASE( minimal_basic_data_read )
 {
   JPetParamGetterAscii getter(dataDir + "DB1.json");
   ParamObjectsDescriptions descriptions = getter.getAllBasicData(ParamObjectType::kPM, 1);
-  BOOST_REQUIRE_EQUAL(descriptions.size(), 1);
+  BOOST_REQUIRE_EQUAL(descriptions.size(), 1u);
   ParamObjectDescription& description = descriptions[1];
 
   BOOST_REQUIRE_EQUAL(description["id"], "1");
@@ -38,7 +38,7 @@ BOOST_AUTO_TEST_CASE( minimal_relational_data_read )
 {
   JPetParamGetterAscii getter(dataDir + "DB1.json");
   ParamRelationalData relations = getter.getAllRelationalData(ParamObjectType::kPM, ParamObjectType::kBarrelSlot, 1);
-  BOOST_REQUIRE_EQUAL(relations.size(), 1);
+  BOOST_REQUIRE_EQUAL(relations.size(), 1u);
 
   BOOST_REQUIRE_EQUAL(relations[1], 1);
 }

--- a/JPetParamManager/JPetParamManagerTest.cpp
+++ b/JPetParamManager/JPetParamManagerTest.cpp
@@ -131,7 +131,7 @@ BOOST_AUTO_TEST_CASE(getParametersFromScopeConfigFile)
   const JPetParamBank& bank = paramManagerInstance.getParamBank();
   BOOST_REQUIRE(!bank.isDummy());
   auto bslots = bank.getBarrelSlots();
-  BOOST_REQUIRE_EQUAL(bslots.size(), 2);
+  BOOST_REQUIRE_EQUAL(bslots.size(), 2u);
   for(const BSlot& BSlotConf: config.fBSlots) {
     BOOST_REQUIRE(bslots.at(BSlotConf.fId));
     BOOST_REQUIRE_EQUAL(bslots.at(BSlotConf.fId)->getID(), BSlotConf.fId);
@@ -141,13 +141,13 @@ BOOST_AUTO_TEST_CASE(getParametersFromScopeConfigFile)
     BOOST_REQUIRE_EQUAL(bslots.at(BSlotConf.fId)->getTheta(), BSlotConf.fTheta);
   }
   auto pms = bank.getPMs();
-  BOOST_REQUIRE_EQUAL(pms.size(), 4);
+  BOOST_REQUIRE_EQUAL(pms.size(), 4u);
   for(const PM& PMConf: config.fPMs) {
     BOOST_REQUIRE(pms.at(PMConf.fId));
     BOOST_REQUIRE_EQUAL(pms.at(PMConf.fId)->getID(), PMConf.fId);
   }
   auto scintillators = bank.getScintillators();
-  BOOST_REQUIRE_EQUAL(scintillators.size(), 2);
+  BOOST_REQUIRE_EQUAL(scintillators.size(), 2u);
   for(const Scin& ScinConf: config.fScins) {
     BOOST_REQUIRE(scintillators.at(ScinConf.fId));
     BOOST_REQUIRE_EQUAL(scintillators.at(ScinConf.fId)->getID(), ScinConf.fId);
@@ -192,7 +192,7 @@ BOOST_AUTO_TEST_CASE(getParametersFromScopeConfigFileTwice)
   const JPetParamBank& bank = paramManagerInstance.getParamBank();
   BOOST_REQUIRE(!bank.isDummy());
   auto bslots = bank.getBarrelSlots();
-  BOOST_REQUIRE_EQUAL(bslots.size(), 2);
+  BOOST_REQUIRE_EQUAL(bslots.size(), 2u);
   for(const BSlot& BSlotConf: config.fBSlots) {
     BOOST_REQUIRE(bslots.at(BSlotConf.fId));
     BOOST_REQUIRE_EQUAL(bslots.at(BSlotConf.fId)->getID(), BSlotConf.fId);
@@ -202,14 +202,14 @@ BOOST_AUTO_TEST_CASE(getParametersFromScopeConfigFileTwice)
     BOOST_REQUIRE_EQUAL(bslots.at(BSlotConf.fId)->getTheta(), BSlotConf.fTheta);
   }
   auto pms = bank.getPMs();
-  BOOST_REQUIRE_EQUAL(pms.size(), 4);
+  BOOST_REQUIRE_EQUAL(pms.size(), 4u);
   for(const PM& PMConf: config.fPMs) {
     BOOST_REQUIRE(pms.at(PMConf.fId));
     BOOST_REQUIRE_EQUAL(pms.at(PMConf.fId)->getID(), PMConf.fId);
   }
 
   auto scintillators = bank.getScintillators();
-  BOOST_REQUIRE_EQUAL(scintillators.size(), 2);
+  BOOST_REQUIRE_EQUAL(scintillators.size(), 2u);
   for(const Scin& ScinConf: config.fScins) {
     BOOST_REQUIRE(scintillators.at(ScinConf.fId));
     BOOST_REQUIRE_EQUAL(scintillators.at(ScinConf.fId)->getID(), ScinConf.fId);

--- a/JPetPhysSignal/JPetPhysSignalTest.cpp
+++ b/JPetPhysSignal/JPetPhysSignalTest.cpp
@@ -65,7 +65,7 @@ BOOST_AUTO_TEST_CASE( AllSignalsTest2 ) {
   JPetPhysSignal & phys = (JPetPhysSignal&) reader.getCurrentEvent();
   BOOST_CHECK_CLOSE(phys.getTime(), 42.42f, epsilon);
 
-  BOOST_CHECK_EQUAL(phys.getRecoSignal().getShape().size(), 502);
+  BOOST_CHECK_EQUAL(phys.getRecoSignal().getShape().size(), 502u);
   BOOST_CHECK_CLOSE(phys.getRecoSignal().getShape().front().time, 501.f,
                     epsilon);
   BOOST_CHECK_CLOSE(phys.getRecoSignal().getShape().back().amplitude, 0.43f,

--- a/JPetRawSignal/JPetRawSignalTest.cpp
+++ b/JPetRawSignal/JPetRawSignalTest.cpp
@@ -69,7 +69,7 @@ BOOST_AUTO_TEST_CASE(GetVectorOfPointsTest) {
 
   BOOST_REQUIRE_EQUAL(
       signal.getPoints(JPetSigCh::Leading, JPetRawSignal::ByThrValue).size(),
-      0);
+      0u);
 
 }
 
@@ -189,21 +189,21 @@ BOOST_AUTO_TEST_CASE(GetMapOfTOTsVsThrNumOrValueTest) {
   std::map<int, double> map;
   map = signal.getTOTsVsThresholdNumber();
 
-  BOOST_REQUIRE_EQUAL( map.size(), 2 );
+  BOOST_REQUIRE_EQUAL( map.size(), 2u );
   BOOST_REQUIRE_EQUAL( map[1], sigch1t.getValue() - sigch1l.getValue() );
   BOOST_REQUIRE_EQUAL( map[4], sigch3t.getValue() - sigch3l.getValue() );
-  BOOST_REQUIRE_EQUAL( map.count(2), 0 ); 
-  BOOST_REQUIRE_EQUAL( map.count(3), 0 ); 
+  BOOST_REQUIRE_EQUAL( map.count(2), 0u ); 
+  BOOST_REQUIRE_EQUAL( map.count(3), 0u ); 
   BOOST_CHECK_THROW( map.at(2), std::out_of_range);
   
   std::map<int, double> map2;
   map2 = signal.getTOTsVsThresholdValue();
 
-  BOOST_REQUIRE_EQUAL( map2.size(), 2 );
+  BOOST_REQUIRE_EQUAL( map2.size(), 2u );
   BOOST_REQUIRE_EQUAL( map2[100.f], sigch3t.getValue() - sigch1l.getValue() );
   BOOST_REQUIRE_EQUAL( map2[400.f], sigch1t.getValue() - sigch3l.getValue() );
-  BOOST_REQUIRE_EQUAL( map2.count(50.f), 0 ); 
-  BOOST_REQUIRE_EQUAL( map2.count(200.f), 0 ); 
+  BOOST_REQUIRE_EQUAL( map2.count(50.f), 0u ); 
+  BOOST_REQUIRE_EQUAL( map2.count(200.f), 0u ); 
 
 }
 

--- a/JPetRecoSignal/JPetRecoSignalTest.cpp
+++ b/JPetRecoSignal/JPetRecoSignalTest.cpp
@@ -14,7 +14,7 @@ BOOST_AUTO_TEST_CASE( ConstructorTest ) {
   BOOST_CHECK_CLOSE(signal.getOffset(), 0.f, epsilon);
   BOOST_CHECK_CLOSE(signal.getCharge(), 0.f, epsilon);
 
-  BOOST_CHECK_EQUAL(signal.getShape().size(), 0);
+  BOOST_CHECK_EQUAL(signal.getShape().size(), 0u);
 }
 
 BOOST_AUTO_TEST_CASE( ScalarFieldsTest ) {
@@ -39,7 +39,7 @@ BOOST_AUTO_TEST_CASE( SignalShapePointsTest ) {
   }
 
   const std::vector<shapePoint> & vec = signal.getShape();
-  BOOST_CHECK_EQUAL(vec.size(), 502);
+  BOOST_CHECK_EQUAL(vec.size(), 502u);
 
   BOOST_CHECK_CLOSE(vec.front().time, 501.f, epsilon);
   BOOST_CHECK_CLOSE(vec.front().amplitude, 501.43f, epsilon);

--- a/JPetScin/JPetScinTest.cpp
+++ b/JPetScin/JPetScinTest.cpp
@@ -212,7 +212,7 @@ BOOST_AUTO_TEST_CASE( no_scins )
   JPetBarrelSlotFactory barrelSlotFactory(paramGetter, 0, layerFactory);
   JPetScinFactory factory(paramGetter, 0, barrelSlotFactory);
   auto & scins = factory.getScins();
-  BOOST_REQUIRE_EQUAL(scins.size(), 0);
+  BOOST_REQUIRE_EQUAL(scins.size(), 0u);
 }
 
 BOOST_AUTO_TEST_CASE( single_object )
@@ -222,7 +222,7 @@ BOOST_AUTO_TEST_CASE( single_object )
   JPetBarrelSlotFactory barrelSlotFactory(paramGetter, 1, layerFactory);
   JPetScinFactory factory(paramGetter, 1, barrelSlotFactory);
   auto & scins = factory.getScins();
-  BOOST_REQUIRE_EQUAL(scins.size(), 1);
+  BOOST_REQUIRE_EQUAL(scins.size(), 1u);
   auto scin = scins[1];
   BOOST_REQUIRE_EQUAL(scin->getID(), 1);
   BOOST_REQUIRE_CLOSE(scin->getAttenLen(), 10.34, epsilon);
@@ -240,7 +240,7 @@ BOOST_AUTO_TEST_CASE( two_objects )
   JPetBarrelSlotFactory barrelSlotFactory(paramGetter, 2, layerFactory);
   JPetScinFactory factory(paramGetter, 2, barrelSlotFactory);
   auto & scins = factory.getScins();
-  BOOST_REQUIRE_EQUAL(scins.size(), 2);
+  BOOST_REQUIRE_EQUAL(scins.size(), 2u);
   auto scin = scins[1];
   BOOST_REQUIRE_EQUAL(scin->getID(), 1);
   BOOST_REQUIRE_CLOSE(scin->getAttenLen(), 10.34, epsilon);

--- a/JPetScopeConfigParser/JPetScopeConfigParserTest.cpp
+++ b/JPetScopeConfigParser/JPetScopeConfigParserTest.cpp
@@ -140,7 +140,7 @@ BOOST_AUTO_TEST_CASE(getElementsWithExistingDirs)
   std::vector<std::pair<std::string, std::string> >  dirsAndFakeFiles = { std::make_pair("./", "file1"), std::make_pair("fake/directory", "file2")};
   JPetScopeConfigParser parser;
   auto result = parser.getElementsWithExistingDirs(dirsAndFakeFiles );
-  BOOST_REQUIRE_EQUAL(result.size(), 1);
+  BOOST_REQUIRE_EQUAL(result.size(), 1u);
   BOOST_REQUIRE_EQUAL(result.at(0).first, "./");
   BOOST_REQUIRE_EQUAL(result.at(0).second, "file1");
   BOOST_REQUIRE(parser.getElementsWithExistingDirs({}).empty());

--- a/JPetScopeTask/JPetScopeTaskTest.cpp
+++ b/JPetScopeTask/JPetScopeTaskTest.cpp
@@ -52,14 +52,14 @@ BOOST_AUTO_TEST_CASE(getFilesInTimeWindowOrder)
   JPetScopeTask testTask("testScopeTask", "It is a test scope task");
   BOOST_REQUIRE(testTask.getFilesInTimeWindowOrder({}).empty());
   auto result = testTask.getFilesInTimeWindowOrder({std::make_pair("C1_0003.txt", 5)});
-  BOOST_REQUIRE_EQUAL(result.size(), 1);
+  BOOST_REQUIRE_EQUAL(result.size(), 1u);
   BOOST_REQUIRE_EQUAL(result.find("C1_0003.txt")->second, 5);
   std::map<std::string, int> inputMap = {std::make_pair("C1_0003.txt", 1), 
                                           std::make_pair("C1_0001.txt", 7),
                                           std::make_pair("C2_0003.txt", 5)
                                         };
   auto result2 = testTask.getFilesInTimeWindowOrder(inputMap);
-  BOOST_REQUIRE_EQUAL(result2.size(), 3);
+  BOOST_REQUIRE_EQUAL(result2.size(), 3u);
   std::set<std::string> expectedFiles = { "C1_0003.txt", "C2_0003.txt"};
   std::set<int> expectedIds = {1, 5};
   std::set<int> obtainedIds;

--- a/JPetTOMBChannel/JPetTOMBChannelTest.cpp
+++ b/JPetTOMBChannel/JPetTOMBChannelTest.cpp
@@ -243,7 +243,7 @@ BOOST_AUTO_TEST_CASE( no_tombChannels )
   JPetPMFactory pmFactory(paramGetter, 0, febFactory, scinFactory, barrelSlotFactory);
   JPetTOMBChannelFactory factory(paramGetter, 0, febFactory, trbFactory, pmFactory);
   auto & tombChannels = factory.getTOMBChannels();
-  BOOST_REQUIRE_EQUAL(tombChannels.size(), 0);
+  BOOST_REQUIRE_EQUAL(tombChannels.size(), 0u);
 }
 
 BOOST_AUTO_TEST_CASE( single_object )
@@ -257,11 +257,11 @@ BOOST_AUTO_TEST_CASE( single_object )
   JPetPMFactory pmFactory(paramGetter, 1, febFactory, scinFactory, barrelSlotFactory);
   JPetTOMBChannelFactory factory(paramGetter, 1, febFactory, trbFactory, pmFactory);
   auto & tombChannels = factory.getTOMBChannels();
-  BOOST_REQUIRE_EQUAL(tombChannels.size(), 1);
+  BOOST_REQUIRE_EQUAL(tombChannels.size(), 1u);
   auto tombChannel = tombChannels[1];
   BOOST_REQUIRE_EQUAL(tombChannel->getChannel(), 1);
-  BOOST_REQUIRE_EQUAL(tombChannel->getLocalChannelNumber(), 2);
-  BOOST_REQUIRE_EQUAL(tombChannel->getFEBInputNumber(), 3);
+  BOOST_REQUIRE_EQUAL(tombChannel->getLocalChannelNumber(), 2u);
+  BOOST_REQUIRE_EQUAL(tombChannel->getFEBInputNumber(), 3u);
   BOOST_REQUIRE_CLOSE(tombChannel->getThreshold(), 4, epsilon);
 
   BOOST_REQUIRE_EQUAL(tombChannel->getFEB().getID(), febFactory.getFEBs().at(1)->getID());
@@ -280,11 +280,11 @@ BOOST_AUTO_TEST_CASE( two_objects )
   JPetPMFactory pmFactory(paramGetter, 2, febFactory, scinFactory, barrelSlotFactory);
   JPetTOMBChannelFactory factory(paramGetter, 2, febFactory, trbFactory, pmFactory);
   auto & tombChannels = factory.getTOMBChannels();
-  BOOST_REQUIRE_EQUAL(tombChannels.size(), 2);
+  BOOST_REQUIRE_EQUAL(tombChannels.size(), 2u);
   auto tombChannel = tombChannels[1];
   BOOST_REQUIRE_EQUAL(tombChannel->getChannel(), 1);
-  BOOST_REQUIRE_EQUAL(tombChannel->getLocalChannelNumber(), 2);
-  BOOST_REQUIRE_EQUAL(tombChannel->getFEBInputNumber(), 3);
+  BOOST_REQUIRE_EQUAL(tombChannel->getLocalChannelNumber(), 2u);
+  BOOST_REQUIRE_EQUAL(tombChannel->getFEBInputNumber(), 3u);
   BOOST_REQUIRE_CLOSE(tombChannel->getThreshold(), 4, epsilon);
 
   BOOST_REQUIRE_EQUAL(tombChannel->getFEB().getID(), febFactory.getFEBs().at(1)->getID());
@@ -293,8 +293,8 @@ BOOST_AUTO_TEST_CASE( two_objects )
 
   tombChannel = tombChannels[5];
   BOOST_REQUIRE_EQUAL(tombChannel->getChannel(), 5);
-  BOOST_REQUIRE_EQUAL(tombChannel->getLocalChannelNumber(), 3);
-  BOOST_REQUIRE_EQUAL(tombChannel->getFEBInputNumber(), 4);
+  BOOST_REQUIRE_EQUAL(tombChannel->getLocalChannelNumber(), 3u);
+  BOOST_REQUIRE_EQUAL(tombChannel->getFEBInputNumber(), 4u);
   BOOST_REQUIRE_CLOSE(tombChannel->getThreshold(), 5, epsilon);
 
   BOOST_REQUIRE_EQUAL(tombChannel->getFEB().getID(), febFactory.getFEBs().at(1)->getID());

--- a/JPetTRB/JPetTRBTest.cpp
+++ b/JPetTRB/JPetTRBTest.cpp
@@ -104,14 +104,14 @@ BOOST_AUTO_TEST_CASE( no_trbs )
 {
   JPetTRBFactory factory(paramGetter, 0);
   auto & trbs = factory.getTRBs();
-  BOOST_REQUIRE_EQUAL(trbs.size(), 0);
+  BOOST_REQUIRE_EQUAL(trbs.size(), 0u);
 }
 
 BOOST_AUTO_TEST_CASE( single_object )
 {
   JPetTRBFactory factory(paramGetter, 1);
   auto & trbs = factory.getTRBs();
-  BOOST_REQUIRE_EQUAL(trbs.size(), 1);
+  BOOST_REQUIRE_EQUAL(trbs.size(), 1u);
   auto trb = trbs[1];
   BOOST_REQUIRE_EQUAL(trb->getID(), 1);
   BOOST_REQUIRE_EQUAL(trb->getType(), 1);
@@ -122,7 +122,7 @@ BOOST_AUTO_TEST_CASE( two_objects )
 {
   JPetTRBFactory factory(paramGetter, 2);
   auto & trbs = factory.getTRBs();
-  BOOST_REQUIRE_EQUAL(trbs.size(), 2);
+  BOOST_REQUIRE_EQUAL(trbs.size(), 2u);
   auto trb = trbs[1];
   BOOST_REQUIRE_EQUAL(trb->getID(), 1);
   BOOST_REQUIRE_EQUAL(trb->getType(), 1);


### PR DESCRIPTION
Remove unsigned/signed int compare warnings, suppress boost's warnings by include boost with SYSTEM option: https://cmake.org/cmake/help/v3.0/command/include_directories.html
Now I don't have any warnings while compiling from scratch. 