### PR TITLE
JPetStatistics file storage change

### DIFF
--- a/JPetScopeLoader/JPetScopeLoader.cpp
+++ b/JPetScopeLoader/JPetScopeLoader.cpp
@@ -171,7 +171,7 @@ void JPetScopeLoader::terminate()
   assert(fHeader);
   assert(fStatistics);
   fWriter->writeHeader(fHeader);
-  fWriter->writeObject(fStatistics->getHistogramsTable(), "Stats");
+  fWriter->writeCollection(fStatistics->getStatsTable(), "Stats");
   //store the parametric objects in the ouptut ROOT file
   getParamManager().saveParametersToFile(fWriter);
   getParamManager().clearParameters();

--- a/JPetStatistics/JPetStatistics.cpp
+++ b/JPetStatistics/JPetStatistics.cpp
@@ -18,37 +18,35 @@
 ClassImp(JPetStatistics);
 
 JPetStatistics::~JPetStatistics(){
-  fHistos.Clear("nodelete");
-  fGraphs.Clear("nodelete");
-  fCanvas.Clear("nodelete");
+  fStats.Clear("nodelete");
 }
 
 void JPetStatistics::createHistogram(TObject * object){
-  fHistos.Add(object);
+  fStats.Add(object);
 }
 
 void JPetStatistics::createGraph(TObject * object){
-  fGraphs.Add(object);
+  fStats.Add(object);
 }
 
 void JPetStatistics::createCanvas(TObject * object){
-  fCanvas.Add(object);
+  fStats.Add(object);
 }
 
 TH1F & JPetStatistics::getHisto1D(const char * name){
-  return dynamic_cast<TH1F&>(*(fHistos.FindObject(name)));
+  return dynamic_cast<TH1F&>(*(fStats.FindObject(name)));
 }
 
 TH2F & JPetStatistics::getHisto2D(const char * name){
-  return dynamic_cast<TH2F&>(*(fHistos.FindObject(name)));
+  return dynamic_cast<TH2F&>(*(fStats.FindObject(name)));
 }
 
 TGraph & JPetStatistics::getGraph(const char * name){
-  return dynamic_cast<TGraph&>(*(fGraphs.FindObject(name)));
+  return dynamic_cast<TGraph&>(*(fStats.FindObject(name)));
 }
 
 TCanvas & JPetStatistics::getCanvas(const char * name){
-  return dynamic_cast<TCanvas&>(*(fCanvas.FindObject(name)));
+  return dynamic_cast<TCanvas&>(*(fStats.FindObject(name)));
 }
 
 void JPetStatistics::createCounter(const char * name){
@@ -60,6 +58,6 @@ double & JPetStatistics::getCounter(const char * name){
   return fCounters[name];
 }
 
-const THashTable * JPetStatistics::getHistogramsTable() const{
-  return &fHistos;
+const THashTable * JPetStatistics::getStatsTable() const{
+  return &fStats;
 }

--- a/JPetStatistics/JPetStatistics.h
+++ b/JPetStatistics/JPetStatistics.h
@@ -44,14 +44,12 @@ class JPetStatistics: public TObject{
   void createCounter(const char * name);
   double & getCounter(const char * name);
 
-  const THashTable * getHistogramsTable() const;
+  const THashTable * getStatsTable() const;
   
-  ClassDef(JPetStatistics,2); 
+  ClassDef(JPetStatistics,3); 
     
  protected:
-  THashTable fHistos;
-  THashTable fGraphs;
-  THashTable fCanvas;
+  THashTable fStats;
   std::map<TString, double> fCounters;
  
 };

--- a/JPetTaskIO/JPetTaskIO.cpp
+++ b/JPetTaskIO/JPetTaskIO.cpp
@@ -87,7 +87,7 @@ void JPetTaskIO::terminate()
 
   fWriter->writeHeader(fHeader);
 
-  fWriter->writeCollection(fStatistics->getHistogramsTable(), "Stats");
+  fWriter->writeCollection(fStatistics->getStatsTable(), "Stats");
   
   fWriter->writeObject(fAuxilliaryData, "Auxilliary Data");
 

--- a/JPetTaskIO/JPetTaskIO.cpp
+++ b/JPetTaskIO/JPetTaskIO.cpp
@@ -87,8 +87,8 @@ void JPetTaskIO::terminate()
 
   fWriter->writeHeader(fHeader);
 
-  fWriter->writeObject(fStatistics->getHistogramsTable(), "Stats");
-
+  fWriter->writeCollection(fStatistics->getHistogramsTable(), "Stats");
+  
   fWriter->writeObject(fAuxilliaryData, "Auxilliary Data");
 
   // store the parametric objects in the ouptut ROOT file

--- a/JPetWriter/JPetWriter.cpp
+++ b/JPetWriter/JPetWriter.cpp
@@ -63,3 +63,57 @@ void JPetWriter::writeHeader(TObject* header)
   fTree->GetUserInfo()->AddAt(header, JPetUserInfoStructure::kHeader);
 }
 
+void JPetWriter::writeCollection(const TCollection * col, const char* dirname, const char* subdirname){
+
+  TDirectory * current =  fFile->GetDirectory(dirname);
+
+  if(!current){
+    current = fFile->mkdir(dirname);
+  }
+
+  assert(current);
+  
+  // use a subdirectory if requested by user
+  if(!std::string(subdirname).empty()){
+    
+    if(current->GetDirectory(subdirname)){
+      current = current->GetDirectory(subdirname);
+    }else{
+      current = current->mkdir(subdirname);
+    }
+    
+  }  
+
+  assert(current);
+  
+  current->cd();
+
+  TIterator * it = col->MakeIterator();
+
+  TObject * obj;
+  while((obj = it->Next())){
+    obj->Write();
+  }
+
+  fFile->cd();
+
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/JPetWriter/JPetWriter.cpp
+++ b/JPetWriter/JPetWriter.cpp
@@ -18,8 +18,8 @@
 
 
 JPetWriter::JPetWriter(const char* p_fileName) :
-  fFileName(p_fileName),			// string z nazwą pliku
-  fFile(0),	// plik
+  fFileName(p_fileName),                        // string z nazwą pliku
+  fFile(0),     // plik
   fIsBranchCreated(false),
   fTree(0)
 {
@@ -63,6 +63,24 @@ void JPetWriter::writeHeader(TObject* header)
   fTree->GetUserInfo()->AddAt(header, JPetUserInfoStructure::kHeader);
 }
 
+
+/**
+ * @brief Write all TObjects from a given TCollection into a certain directory structure in the file
+ *
+ * @param col pointer to a TCollection-based container
+ * @param dirname name of a directory inside the output file to which the objects should be written
+ * @param subdirname optional name of a subdirectory inside dirname to which the objects should be written
+ * 
+ * This method whites all TObject-based objects contained in the TCollection-based container (see ROOT documentation)
+ * into a directory whose name is given by dirname inside the output file. If dirname does not exist
+ * in the output file, it will be created. Otherwise, contents of the col collection will be appended to an existing
+ * directory.
+ *
+ * If the optional subdirectory name is specified (subdirname parameter, defaults to empty string) then the 
+ * contents of the collection will be written to "dirname/subdirname". If the "subdirname" directory does not
+ * exist inside the "dirname" directory, it will be created.
+ *
+ */
 void JPetWriter::writeCollection(const TCollection * col, const char* dirname, const char* subdirname){
 
   TDirectory * current =  fFile->GetDirectory(dirname);
@@ -80,8 +98,7 @@ void JPetWriter::writeCollection(const TCollection * col, const char* dirname, c
       current = current->GetDirectory(subdirname);
     }else{
       current = current->mkdir(subdirname);
-    }
-    
+    }    
   }  
 
   assert(current);
@@ -96,24 +113,4 @@ void JPetWriter::writeCollection(const TCollection * col, const char* dirname, c
   }
 
   fFile->cd();
-
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/JPetWriter/JPetWriter.h
+++ b/JPetWriter/JPetWriter.h
@@ -69,6 +69,7 @@ public:
     return fFile->WriteTObject(obj, name);
   }
 
+  void writeCollection(const TCollection * hash, const char* dirname, const char* subdirname="");
 
 protected:
   std::string fFileName;

--- a/JPetWriter/JPetWriterTest.cpp
+++ b/JPetWriter/JPetWriterTest.cpp
@@ -57,7 +57,6 @@ BOOST_AUTO_TEST_CASE( my_test2 )
   BOOST_REQUIRE(std::string(objOut.GetTitle()) == "Title of this testObj");
 }
 
-
 /// a tree must have a name if not SetAutoSave makes it crash when when call Branch
 BOOST_AUTO_TEST_CASE( my_helperTest_for_test3 )
 {
@@ -115,6 +114,7 @@ BOOST_AUTO_TEST_CASE( saving_different_objects1 )
     JPetSigCh testJPetSigCh;
     writer.write(testJPetSigCh);
   }
+  writer.closeFile();
   BOOST_REQUIRE(boost::filesystem::exists(fileTest));
   JPetReader reader(fileTest);
   BOOST_REQUIRE_EQUAL(reader.getNbOfAllEvents(), kHugeNumberOfObjects);
@@ -133,6 +133,7 @@ BOOST_AUTO_TEST_CASE( saving_different_objects2 )
     JPetTimeWindow testJPetTimeWindow;
     writer.write(testJPetTimeWindow);
   }
+  writer.closeFile();
   BOOST_REQUIRE(boost::filesystem::exists(fileTest));
   JPetReader reader(fileTest);
   BOOST_REQUIRE_EQUAL(reader.getNbOfAllEvents(), kHugeNumberOfObjects);
@@ -152,6 +153,7 @@ BOOST_AUTO_TEST_CASE( saving_different_objects3 )
     JPetBaseSignal testJPetBaseSignal;
     writer.write(testJPetBaseSignal);
   }
+  writer.closeFile();
   BOOST_REQUIRE(boost::filesystem::exists(fileTest));
   JPetReader reader(fileTest);
   BOOST_REQUIRE_EQUAL(reader.getNbOfAllEvents(), kHugeNumberOfObjects);
@@ -170,6 +172,7 @@ BOOST_AUTO_TEST_CASE( saving_different_objects4 )
     JPetRawSignal testJPetRawSignal;
     writer.write(testJPetRawSignal);
   }
+  writer.closeFile();
   BOOST_REQUIRE(boost::filesystem::exists(fileTest));
   JPetReader reader(fileTest);
   BOOST_REQUIRE_EQUAL(reader.getNbOfAllEvents(), kHugeNumberOfObjects);
@@ -189,6 +192,7 @@ BOOST_AUTO_TEST_CASE( saving_different_objects5 )
     JPetRecoSignal testJPetRecoSignal;
     writer.write(testJPetRecoSignal);
   }
+  writer.closeFile();
   BOOST_REQUIRE(boost::filesystem::exists(fileTest));
   JPetReader reader(fileTest);
   BOOST_REQUIRE_EQUAL(reader.getNbOfAllEvents(), kHugeNumberOfObjects);
@@ -208,6 +212,7 @@ BOOST_AUTO_TEST_CASE( saving_different_objects6 )
     JPetPhysSignal testJPetPhysSignal;
     writer.write(testJPetPhysSignal);
   }
+  writer.closeFile();
   BOOST_REQUIRE(boost::filesystem::exists(fileTest));
   JPetReader reader(fileTest);
   BOOST_REQUIRE_EQUAL(reader.getNbOfAllEvents(), kHugeNumberOfObjects);
@@ -227,6 +232,7 @@ BOOST_AUTO_TEST_CASE( saving_different_objects7 )
     JPetHit testJPetHit;
     writer.write(testJPetHit);
   }
+  writer.closeFile();
   BOOST_REQUIRE(boost::filesystem::exists(fileTest));
   JPetReader reader(fileTest);
   BOOST_REQUIRE_EQUAL(reader.getNbOfAllEvents(), kHugeNumberOfObjects);
@@ -246,6 +252,7 @@ BOOST_AUTO_TEST_CASE( saving_different_objects8 )
     JPetLOR testJPetLOR;
     writer.write(testJPetLOR);
   }
+  writer.closeFile();
   BOOST_REQUIRE(boost::filesystem::exists(fileTest));
   JPetReader reader(fileTest);
   BOOST_REQUIRE_EQUAL(reader.getNbOfAllEvents(), kHugeNumberOfObjects);
@@ -253,6 +260,5 @@ BOOST_AUTO_TEST_CASE( saving_different_objects8 )
   if(boost::filesystem::exists(fileTest))
     boost::filesystem::remove(fileTest);
 } 
-
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
JPetStatistics is now written to the ROOT file as a TDirectory (optionally with an additional subdirectory) instead of THashTable. JPetWriter was extended with a method allowing to write the contents of any TCollection into a TDirectory in a TFile.

Now the histograms contained in ROOT files produced by the Framework can be correctly added with "hadd" from ROOT.

Moreover, the subdirectory option allows for writing contents of several JPetStatistics objects (e.g.) from different tasks into the same file, which can be used in a version without writing of intermediate files.