### PR TITLE
Remove const if not necessary

### DIFF
--- a/JPetGeomMapping/JPetGeomMapping.cpp
+++ b/JPetGeomMapping/JPetGeomMapping.cpp
@@ -71,12 +71,12 @@ JPetGeomMapping::JPetGeomMapping(const JPetParamBank& paramBank)
 
 JPetGeomMapping::~JPetGeomMapping() {}
 
-const size_t JPetGeomMapping::getLayersCount() const
+size_t JPetGeomMapping::getLayersCount() const
 {
   return fRadiusToLayer.size();
 }
 
-const size_t JPetGeomMapping::getLayerNumber(const JPetLayer& layer) const
+size_t JPetGeomMapping::getLayerNumber(const JPetLayer& layer) const
 {
   auto radius = layer.getRadius();
   if (fRadiusToLayer.find(radius) != fRadiusToLayer.end()) {
@@ -87,7 +87,7 @@ const size_t JPetGeomMapping::getLayerNumber(const JPetLayer& layer) const
   }
 }
 
-const size_t JPetGeomMapping::getSlotsCount(const JPetLayer& layer) const
+size_t JPetGeomMapping::getSlotsCount(const JPetLayer& layer) const
 {
   auto layerNr = getLayerNumber(layer);
   if (fNumberOfSlotsInLayer.size() > layerNr) {
@@ -98,7 +98,7 @@ const size_t JPetGeomMapping::getSlotsCount(const JPetLayer& layer) const
   }
 }
 
-const size_t JPetGeomMapping::getSlotsCount(const size_t layerNr) const
+size_t JPetGeomMapping::getSlotsCount(const size_t layerNr) const
 {
   if ((fNumberOfSlotsInLayer.size() >= layerNr) && (layerNr > 0)) {
     return fNumberOfSlotsInLayer.at(layerNr - 1);
@@ -108,7 +108,7 @@ const size_t JPetGeomMapping::getSlotsCount(const size_t layerNr) const
   }
 }
 
-const size_t JPetGeomMapping::getSlotNumber(const JPetBarrelSlot& slot) const
+size_t JPetGeomMapping::getSlotNumber(const JPetBarrelSlot& slot) const
 {
   auto layerNr = getLayerNumber(slot.getLayer());
   auto theta = slot.getTheta();
@@ -124,7 +124,7 @@ const size_t JPetGeomMapping::getSlotNumber(const JPetBarrelSlot& slot) const
   return fThetaToSlot.at(index).at(theta);
 }
 
-const size_t JPetGeomMapping::getGlobalSlotNumber(const JPetBarrelSlot& slot) const
+size_t JPetGeomMapping::getGlobalSlotNumber(const JPetBarrelSlot& slot) const
 {
   auto layerNr = getLayerNumber(slot.getLayer());
   auto index = layerNr - 1;
@@ -155,7 +155,7 @@ const vector< size_t > JPetGeomMapping::getLayersSizes() const
   return res;
 }
 
-const size_t JPetGeomMapping::calcDeltaID(const JPetBarrelSlot& slot1, const JPetBarrelSlot& slot2) const
+size_t JPetGeomMapping::calcDeltaID(const JPetBarrelSlot& slot1, const JPetBarrelSlot& slot2) const
 {
   if (slot1.getLayer().getID() == slot2.getLayer().getID()) {
     int delta_ID = abs(getSlotNumber(slot1) - getSlotNumber(slot2));
@@ -168,7 +168,7 @@ const size_t JPetGeomMapping::calcDeltaID(const JPetBarrelSlot& slot1, const JPe
   return -1;
 }
 
-const size_t JPetGeomMapping::calcGlobalPMTNumber(const JPetPM& pmt) const
+size_t JPetGeomMapping::calcGlobalPMTNumber(const JPetPM& pmt) const
 {
   return -1;
   const size_t number_of_sides = 2;
@@ -232,7 +232,7 @@ std::map<std::tuple<int, int, JPetPM::Side, int>, int> JPetGeomMapping::getTOMBM
   return fTOMBs;
 }
 
-const int JPetGeomMapping::getTOMB(int LayerNr, int barrel_slot_nr, const JPetPM::Side& side, int threshold) const
+int JPetGeomMapping::getTOMB(int LayerNr, int barrel_slot_nr, const JPetPM::Side& side, int threshold) const
 {
   auto key = std::make_tuple(LayerNr, barrel_slot_nr, side, threshold);
   if (fTOMBs.find(key) == fTOMBs.end()) {

--- a/JPetGeomMapping/JPetGeomMapping.h
+++ b/JPetGeomMapping/JPetGeomMapping.h
@@ -34,15 +34,15 @@ public:
 
   explicit JPetGeomMapping(const JPetParamBank& paramBank);
   virtual ~JPetGeomMapping();
-  virtual const size_t getLayersCount()const override;
-  virtual const size_t getLayerNumber(const JPetLayer& layer)const override;
-  virtual const size_t getSlotsCount(const JPetLayer& layer)const override;
-  virtual const size_t getSlotsCount(const size_t layer)const override;
-  virtual const size_t getSlotNumber(const JPetBarrelSlot& slot) const override; /// Slot number within a given layer !!!
+  virtual size_t getLayersCount()const override;
+  virtual size_t getLayerNumber(const JPetLayer& layer)const override;
+  virtual size_t getSlotsCount(const JPetLayer& layer)const override;
+  virtual size_t getSlotsCount(const size_t layer)const override;
+  virtual size_t getSlotNumber(const JPetBarrelSlot& slot) const override; /// Slot number within a given layer !!!
   virtual const StripPos getStripPos(const JPetBarrelSlot& slot) const override;
   virtual const std::vector<size_t> getLayersSizes() const override;
-  const size_t calcDeltaID(const JPetBarrelSlot& slot1, const JPetBarrelSlot& slot2) const;
-  const size_t calcGlobalPMTNumber(const JPetPM& pmt) const;
+  size_t calcDeltaID(const JPetBarrelSlot& slot1, const JPetBarrelSlot& slot2) const;
+  size_t calcGlobalPMTNumber(const JPetPM& pmt) const;
 
   /// Function returns a map which reflects the relation:
   /// layer id, barrel slot id, photomultiplier side, threshold -->  TOMB channel number.
@@ -52,8 +52,8 @@ public:
   /// The map is created based on the JPetParamBank content.
   /// If any of param objects needed to create the map is not set in JPetParamBank, the empty map will be returned.
   std::map<std::tuple<int, int, JPetPM::Side, int>, int> getTOMBMapping() const;
-  const int getTOMB(int LayerNr, int slotNr, const JPetPM::Side& side, int threshold) const;
-  const size_t getGlobalSlotNumber(const JPetBarrelSlot& slot) const ; /// Slot number calculated for all layers e.g, 1-48 for layer 1 and 49-... for layers 2 and so on
+  int getTOMB(int LayerNr, int slotNr, const JPetPM::Side& side, int threshold) const;
+  size_t getGlobalSlotNumber(const JPetBarrelSlot& slot) const ; /// Slot number calculated for all layers e.g, 1-48 for layer 1 and 49-... for layers 2 and so on
 
 private:
   std::map<std::tuple<int, int, JPetPM::Side, int>, int> getTOMBMap(const JPetParamBank& bank) const;

--- a/JPetGeomMappingInterface/JPetGeomMappingInterface.h
+++ b/JPetGeomMappingInterface/JPetGeomMappingInterface.h
@@ -28,11 +28,11 @@ struct StripPos {
 class JPetGeomMappingInterface
 {
 public:
-  virtual const size_t getLayersCount() const = 0;
-  virtual const size_t getLayerNumber(const JPetLayer& layer) const = 0;
-  virtual const size_t getSlotsCount(const JPetLayer& layer) const = 0;
-  virtual const size_t getSlotsCount(const size_t layer) const = 0;
-  virtual const size_t getSlotNumber(const JPetBarrelSlot& slot) const = 0;
+  virtual size_t getLayersCount() const = 0;
+  virtual size_t getLayerNumber(const JPetLayer& layer) const = 0;
+  virtual size_t getSlotsCount(const JPetLayer& layer) const = 0;
+  virtual size_t getSlotsCount(const size_t layer) const = 0;
+  virtual size_t getSlotNumber(const JPetBarrelSlot& slot) const = 0;
   virtual const StripPos getStripPos(const JPetBarrelSlot& slot) const = 0;
   virtual const std::vector<size_t> getLayersSizes() const = 0 ;
 };

--- a/JPetLOR/JPetLOR.cpp
+++ b/JPetLOR/JPetLOR.cpp
@@ -44,10 +44,10 @@ JPetLOR::JPetLOR(float Time, float QualityOfTime, JPetHit& firstHit,
 
 JPetLOR::~JPetLOR(){}
 
-const float JPetLOR::getTime() const {
+float JPetLOR::getTime() const {
 	return fTime;
 }
-const float JPetLOR::getQualityOfTime() const{
+float JPetLOR::getQualityOfTime() const{
 	return fQualityOfTime;
 }
 void JPetLOR::setTime(const float time){
@@ -82,13 +82,13 @@ void JPetLOR::setTimeDiff(const float td) {
 void JPetLOR::setQualityOfTimeDiff(const float qtd) {
 	fQualityOfTime = qtd;
 }
-const float JPetLOR::getTimeDiff() const {
+float JPetLOR::getTimeDiff() const {
 	return fTimeDiff;
 }
-const float JPetLOR::getQualityOfTimeDiff() const{
+float JPetLOR::getQualityOfTimeDiff() const{
 	return fQualityOfTimeDiff;
 }
-const bool JPetLOR::isHitSet(const unsigned int index){
+bool JPetLOR::isHitSet(const unsigned int index){
 	switch(index){
 		case 0:
 			return fIsHitSet[0];
@@ -99,7 +99,7 @@ const bool JPetLOR::isHitSet(const unsigned int index){
 	};
 }
 
-const bool JPetLOR::isFromSameBarrelSlot() const {  
+bool JPetLOR::isFromSameBarrelSlot() const {  
 	if(fIsHitSet[0]&&fIsHitSet[1] ){// do not claim inconsistency if signals are not set yet
 		const int slot_a = getFirstHit().getBarrelSlot().getID();
 		const int slot_b = getSecondHit().getBarrelSlot().getID();

--- a/JPetLOR/JPetLOR.h
+++ b/JPetLOR/JPetLOR.h
@@ -39,8 +39,8 @@ public:
   virtual ~JPetLOR();
 
 public:
-	const float getTime() const;
-	const float getQualityOfTime() const;
+	float getTime() const;
+	float getQualityOfTime() const;
 	void setTime(const float time);
 	void setQualityOfTime(const float qualityOfTime);
 	const JPetHit& getFirstHit() const;
@@ -69,9 +69,9 @@ public:
 
   void setTimeDiff(const float td);
   void setQualityOfTimeDiff(const float qtd);
-  const float getTimeDiff() const;
-  const float getQualityOfTimeDiff() const;
-  const bool isHitSet(const unsigned int index);
+  float getTimeDiff() const;
+  float getQualityOfTimeDiff() const;
+  bool isHitSet(const unsigned int index);
   
 ClassDef(JPetLOR,1);
 
@@ -90,7 +90,7 @@ ClassDef(JPetLOR,1);
  *
  *  @return true if both signals are consistently from the same barrel slot.
  */
-const bool isFromSameBarrelSlot() const; 
+bool isFromSameBarrelSlot() const; 
 private:
 
   float fTime; ///< reconstructed absolute time of the event wrt to beginning of the run [ps]

--- a/JPetLargeBarrelExtensions/BarrelExtensions.cpp
+++ b/JPetLargeBarrelExtensions/BarrelExtensions.cpp
@@ -58,26 +58,26 @@ LargeBarrelMapping::LargeBarrelMapping(const JPetParamBank& paramBank)
     sort( thetas.begin(), thetas.end(), less<double>() );
 }
 LargeBarrelMapping::~LargeBarrelMapping() {}
-const size_t LargeBarrelMapping::getLayersCount() const
+size_t LargeBarrelMapping::getLayersCount() const
 {
   return fRadii.size();
 }
-const size_t LargeBarrelMapping::getLayerNumber(const JPetLayer& layer) const
+size_t LargeBarrelMapping::getLayerNumber(const JPetLayer& layer) const
 {
   size_t res = 0;
   while (layer.getRadius() != fRadii[res])
     res++;
   return res + 1;
 }
-const size_t LargeBarrelMapping::getSlotsCount(const size_t layer) const
+size_t LargeBarrelMapping::getSlotsCount(const size_t layer) const
 {
   return fTheta[layer - 1].size();
 }
-const size_t LargeBarrelMapping::getSlotsCount(const JPetLayer& layer) const
+size_t LargeBarrelMapping::getSlotsCount(const JPetLayer& layer) const
 {
   return fTheta[getLayerNumber(layer) - 1].size();
 }
-const size_t LargeBarrelMapping::getSlotNumber(const JPetBarrelSlot& slot) const
+size_t LargeBarrelMapping::getSlotNumber(const JPetBarrelSlot& slot) const
 {
   const auto& theta = fTheta[getLayerNumber(slot.getLayer()) - 1];
   size_t res = 0;
@@ -85,7 +85,7 @@ const size_t LargeBarrelMapping::getSlotNumber(const JPetBarrelSlot& slot) const
     res++;
   return res + 1;
 }
-const size_t LargeBarrelMapping::calcDeltaID(const JPetBarrelSlot& slot1, const JPetBarrelSlot& slot2) const
+size_t LargeBarrelMapping::calcDeltaID(const JPetBarrelSlot& slot1, const JPetBarrelSlot& slot2) const
 {
   if (slot1.getLayer().getID() == slot2.getLayer().getID()) {
     auto delta_ID = size_t(abs(int(getSlotNumber(slot1)) - int(getSlotNumber(slot2))));
@@ -96,7 +96,7 @@ const size_t LargeBarrelMapping::calcDeltaID(const JPetBarrelSlot& slot1, const 
   }
   throw Exception<LargeBarrelMapping>("attempt to calc deltaID for strips from different layers");
 }
-const size_t LargeBarrelMapping::calcGlobalPMTNumber(const JPetPM& pmt) const
+size_t LargeBarrelMapping::calcGlobalPMTNumber(const JPetPM& pmt) const
 {
   const size_t number_of_sides = 2;
   const auto layer_number = getLayerNumber(pmt.getBarrelSlot().getLayer());

--- a/JPetLargeBarrelExtensions/BarrelExtensions.h
+++ b/JPetLargeBarrelExtensions/BarrelExtensions.h
@@ -15,6 +15,7 @@
 
 #ifndef _LARGE_BARREL_EXTENSIONS_
 #define _LARGE_BARREL_EXTENSIONS_
+
 #include <map>
 #include <vector>
 #include <string>
@@ -35,13 +36,13 @@ class LargeBarrelMapping: public JPetGeomMappingInterface
 public:
   LargeBarrelMapping(const JPetParamBank& paramBank);
   virtual ~LargeBarrelMapping();
-  virtual const size_t getLayersCount()const override;
-  virtual const size_t getLayerNumber(const JPetLayer& layer)const override;
-  virtual const size_t getSlotsCount(const JPetLayer& layer)const override;
-  virtual const size_t getSlotsCount(const size_t layer)const override;
-  virtual const size_t getSlotNumber(const JPetBarrelSlot& slot) const override;
-  const size_t calcDeltaID(const JPetBarrelSlot& slot1, const JPetBarrelSlot& slot2) const;
-  const size_t calcGlobalPMTNumber(const JPetPM& pmt) const;
+  virtual size_t getLayersCount()const override;
+  virtual size_t getLayerNumber(const JPetLayer& layer)const override;
+  virtual size_t getSlotsCount(const JPetLayer& layer)const override;
+  virtual size_t getSlotsCount(const size_t layer)const override;
+  virtual size_t getSlotNumber(const JPetBarrelSlot& slot) const override;
+  size_t calcDeltaID(const JPetBarrelSlot& slot1, const JPetBarrelSlot& slot2) const;
+  size_t calcGlobalPMTNumber(const JPetPM& pmt) const;
   const StripPos getStripPos(const JPetBarrelSlot& slot) const;
   const std::vector<size_t> getLayersSizes()const;
 private:

--- a/JPetParamBank/JPetParamBank.cpp
+++ b/JPetParamBank/JPetParamBank.cpp
@@ -19,7 +19,7 @@ ClassImp (JPetParamBank);
 
 JPetParamBank::JPetParamBank():fDummy(false){}
 JPetParamBank::JPetParamBank(const bool d):fDummy(d){}
-const bool JPetParamBank::isDummy()const{return fDummy;}
+bool JPetParamBank::isDummy()const{return fDummy;}
 JPetParamBank::JPetParamBank(const JPetParamBank& paramBank):fDummy(false){
   copyMapValues(fScintillators, paramBank.fScintillators);
   copyMapValues(fPMs, paramBank.fPMs);

--- a/JPetParamBank/JPetParamBank.h
+++ b/JPetParamBank/JPetParamBank.h
@@ -40,7 +40,7 @@ public:
   void clear();
 
   JPetParamBank(const bool dummy);
-  const bool isDummy()const;
+  bool isDummy() const;
 
   int getSize(ParamObjectType type) const;
 


### PR DESCRIPTION
Remove const if it was not necessary to remove warning: type qualifiers ignored on function return type [-Wignored-qualifiers]

See: http://stackoverflow.com/questions/1607188/why-is-a-type-qualifier-on-a-return-type-meaningless