### PR TITLE
Change data classes' base from TNamed to TObject

### DIFF
--- a/JPetBaseSignal/JPetBaseSignal.cpp
+++ b/JPetBaseSignal/JPetBaseSignal.cpp
@@ -18,7 +18,7 @@
 ClassImp(JPetBaseSignal);
 
 JPetBaseSignal::JPetBaseSignal() :
-    TNamed("JPetBaseSignal", "Base Signal structure"), fPM(0), fBarrelSlot(0),
+    TObject(), fPM(0), fBarrelSlot(0),
     fTimeWindowIndex(0) {
 }
 JPetBaseSignal::JPetBaseSignal(bool isNull):

--- a/JPetBaseSignal/JPetBaseSignal.cpp
+++ b/JPetBaseSignal/JPetBaseSignal.cpp
@@ -23,9 +23,7 @@ JPetBaseSignal::JPetBaseSignal() :
 }
 JPetBaseSignal::JPetBaseSignal(bool isNull):
   fIsNullObject(isNull)
-{
-	SetNameTitle("JPetBaseSignal", "Base Signal structure");
-}
+{}
 
 bool JPetBaseSignal::isNullObject() const
 {

--- a/JPetBaseSignal/JPetBaseSignal.h
+++ b/JPetBaseSignal/JPetBaseSignal.h
@@ -19,13 +19,13 @@
 #include "../JPetSigCh/JPetSigCh.h"
 #include "../JPetPM/JPetPM.h"
 #include "../JPetBarrelSlot/JPetBarrelSlot.h"
-#include <TNamed.h>
+#include <TObject.h>
 #include <TRef.h>
 
 /**
  * @brief Base class for all signal data classes
  */
-class JPetBaseSignal: public TNamed
+class JPetBaseSignal: public TObject
 {
 public:
 
@@ -89,7 +89,7 @@ bool fIsNullObject = false;
 bool fIsNullObject;
 #endif
 
-ClassDef(JPetBaseSignal, 1)
-  ;
+ClassDef(JPetBaseSignal, 2);
+
 };
 #endif /*  !JPETBASESIGNAL_H */

--- a/JPetEvent/JPetEvent.cpp
+++ b/JPetEvent/JPetEvent.cpp
@@ -18,13 +18,13 @@
 
 ClassImp(JPetEvent);
 
-JPetEvent::JPetEvent(): TNamed("JPetEvent", "event structure")
+JPetEvent::JPetEvent(): TObject()
 {
   /**/
 }
 
 JPetEvent::JPetEvent(const std::vector<JPetHit>& hits, JPetEventType eventType, bool orderedByTime):
-  TNamed("JPetEvent", "event structure"),
+  TObject(),
   fType(eventType)
 {
   setHits(hits, orderedByTime);

--- a/JPetEvent/JPetEvent.h
+++ b/JPetEvent/JPetEvent.h
@@ -18,7 +18,7 @@
 #define JPETEVENT_H
 
 #include "../JPetHit/JPetHit.h"
-#include <TNamed.h>
+#include <TObject.h>
 #include <vector>
 #include "../JPetEventType/JPetEventType.h"
 
@@ -36,7 +36,7 @@
  * This means, that at given moment we don't know to which type it belongs.
  */
 
-class JPetEvent : public TNamed
+class JPetEvent : public TObject
 {
 
 public:
@@ -65,6 +65,6 @@ protected:
   JPetEventType fType;
 #endif
 
-  ClassDef(JPetEvent, 2);
+  ClassDef(JPetEvent, 3);
 };
 #endif /*  !JPETEVENT_H */

--- a/JPetHit/JPetHit.cpp
+++ b/JPetHit/JPetHit.cpp
@@ -21,13 +21,13 @@
 ClassImp(JPetHit);
 
 JPetHit::JPetHit() :
-  TNamed("JPetHit", "Hit Structure")
+  TObject()
 {
 }
 
 JPetHit::JPetHit(float e, float qe, float t, float qt, TVector3& pos, JPetPhysSignal& siga, JPetPhysSignal& sigb,
-                 JPetBarrelSlot& bslot, JPetScin& scin): 
-  TNamed("JPetHit", "Hit Structure") , fEnergy(e), fQualityOfEnergy(qe), fTime(t),
+                 JPetBarrelSlot& bslot, JPetScin& scin) :
+  TObject() , fEnergy(e), fQualityOfEnergy(qe), fTime(t),
   fQualityOfTime(qt), fPos(pos), fSignalA(siga), fSignalB(sigb), fBarrelSlot(&bslot), fScintillator(&scin)
 {
   fIsSignalAset = true ;

--- a/JPetHit/JPetHit.h
+++ b/JPetHit/JPetHit.h
@@ -21,7 +21,7 @@
 #include "../JPetPhysSignal/JPetPhysSignal.h"
 #include "../JPetTimeWindow/JPetTimeWindow.h"
 
-#include "TNamed.h"
+#include "TObject.h"
 #include "TVector3.h"
 #include <TRef.h>
 
@@ -38,7 +38,7 @@ class JPetTimeWindow;
  *
  * It contains two objects of type JPetPhysSignal (from "Side A" and "Side B" of the Barrel) which represent signals at two ends of a scintillator strip, from which the hit was reconstructed.
  */
-class JPetHit : public TNamed
+class JPetHit : public TObject
 {
 
 public:
@@ -134,7 +134,7 @@ private:
   TRef fBarrelSlot = NULL; ///< BarrelSlot in which the hit was recorded
   TRef fScintillator = NULL; ///< Scintillator strip which was hit
 
-  ClassDef(JPetHit, 3);
+  ClassDef(JPetHit, 4);
 };
 
 #endif

--- a/JPetLOR/JPetLOR.cpp
+++ b/JPetLOR/JPetLOR.cpp
@@ -18,7 +18,7 @@
 ClassImp(JPetLOR);
 
 JPetLOR::JPetLOR() :
-    TNamed("JPetLOR", "Event Structure"), 
+    TObject(),
     fTime(0.0f), 
     fQualityOfTime(0.0f),
     fTimeDiff(0.0f), 
@@ -30,7 +30,7 @@ JPetLOR::JPetLOR() :
 
 JPetLOR::JPetLOR(float Time, float QualityOfTime, JPetHit& firstHit,
                  JPetHit& secondHit) :
-    TNamed("JPetLOR", "Event Structure"), 
+    TObject(), 
     fTime(Time),
     fQualityOfTime(QualityOfTime),
     fTimeDiff(0.0f),

--- a/JPetLOR/JPetLOR.h
+++ b/JPetLOR/JPetLOR.h
@@ -30,7 +30,7 @@ class JPetHit;
  * An event consists of two hits (JPetHit objects) in two barel slots, referred to as "first" and "second" according to their chronological order in a time slot.
  * The user is responsible for setting the first and second hit in the appropriate order
  */
-class JPetLOR: public TNamed
+class JPetLOR: public TObject
 {
 public:
   JPetLOR();
@@ -73,7 +73,7 @@ public:
   float getQualityOfTimeDiff() const;
   bool isHitSet(const unsigned int index);
   
-ClassDef(JPetLOR,1);
+ClassDef(JPetLOR,2);
 
 /** @brief Checks whether both Hit objects set in this LOR object
  *  come from different barrel slots and are properly time-ordered

--- a/JPetPhysSignal/JPetPhysSignal.cpp
+++ b/JPetPhysSignal/JPetPhysSignal.cpp
@@ -32,9 +32,7 @@ JPetPhysSignal::~JPetPhysSignal()
 
 JPetPhysSignal::JPetPhysSignal(bool isNull):
   fIsNullObject(isNull)
-{
-	SetNameTitle("JPetPhysSignal", "Physical signal structure");
-}
+{}
 
 bool JPetPhysSignal::isNullObject() const
 {

--- a/JPetPhysSignal/JPetPhysSignal.cpp
+++ b/JPetPhysSignal/JPetPhysSignal.cpp
@@ -23,7 +23,6 @@ JPetPhysSignal::JPetPhysSignal() :
   fPhe(0),
   fQualityOfPhe(0)
 {
-  //  SetNameTitle("JPetPhysSignal", "Physical signal structure");
 }
 
 

--- a/JPetPhysSignal/JPetPhysSignal.cpp
+++ b/JPetPhysSignal/JPetPhysSignal.cpp
@@ -23,7 +23,7 @@ JPetPhysSignal::JPetPhysSignal() :
   fPhe(0),
   fQualityOfPhe(0)
 {
-  SetNameTitle("JPetPhysSignal", "Physical signal structure");
+  //  SetNameTitle("JPetPhysSignal", "Physical signal structure");
 }
 
 

--- a/JPetRawSignal/JPetRawSignal.cpp
+++ b/JPetRawSignal/JPetRawSignal.cpp
@@ -19,8 +19,6 @@ ClassImp(JPetRawSignal);
 
 JPetRawSignal::JPetRawSignal(const int points){
 
-  //  SetNameTitle("JPetRawSignal", "Raw signal (from Front-End electronics) structure");
-
   fLeadingPoints.reserve(points);
   fTrailingPoints.reserve(points);
 
@@ -44,8 +42,6 @@ void JPetRawSignal::addPoint(const JPetSigCh& sigch) {
     fTrailingPoints.push_back(sigch);
   } else if (sigch.getType() == JPetSigCh::Leading) {
     fLeadingPoints.push_back(sigch);
-  } else if (sigch.getType() == JPetSigCh::Charge) {
-    fTOTPoint = sigch;
   }
 }
 
@@ -74,8 +70,8 @@ std::map<int, double> JPetRawSignal::getTimesVsThresholdNumber(JPetSigCh::EdgeTy
   return thrToTime;
 }
 
-std::map<int, std::pair<float, float>> JPetRawSignal::getTimesVsThresholdValue(JPetSigCh::EdgeType edge) const {
-  std::map<int, std::pair<float, float>> thrToTime;
+std::map<int, std::pair<float, float> > JPetRawSignal::getTimesVsThresholdValue(JPetSigCh::EdgeType edge) const {
+  std::map<int, std::pair<float, float> > thrToTime;
 
   const std::vector<JPetSigCh> & vec = (edge==JPetSigCh::Trailing ? fTrailingPoints : fLeadingPoints);
 

--- a/JPetRawSignal/JPetRawSignal.cpp
+++ b/JPetRawSignal/JPetRawSignal.cpp
@@ -19,7 +19,7 @@ ClassImp(JPetRawSignal);
 
 JPetRawSignal::JPetRawSignal(const int points){
 
-  SetNameTitle("JPetRawSignal", "Raw signal (from Front-End electronics) structure");
+  //  SetNameTitle("JPetRawSignal", "Raw signal (from Front-End electronics) structure");
 
   fLeadingPoints.reserve(points);
   fTrailingPoints.reserve(points);

--- a/JPetRawSignal/JPetRawSignal.h
+++ b/JPetRawSignal/JPetRawSignal.h
@@ -103,7 +103,7 @@ private:
   std::vector<JPetSigCh> fLeadingPoints; ///< vector of JPetSigCh objects from leading edge of the signal
   std::vector<JPetSigCh> fTrailingPoints; ///< vector of JPetSigCh objects from trailing edge of the signal
 
-ClassDef(JPetRawSignal, 5)
+ClassDef(JPetRawSignal, 4)
   ;
 };
 #endif /*  !JPETRAWSIGNAL_H */

--- a/JPetRawSignal/JPetRawSignal.h
+++ b/JPetRawSignal/JPetRawSignal.h
@@ -61,8 +61,7 @@ public:
    *
    * The JPetSigCh object is automatically added to the array
    * of trailing-edge or leading-edge points depending
-   * on the type which was set in it. If its type is Charge,
-   * it will be set as the TOT point.
+   * on the type which was set in it. 
    */
   void addPoint(const JPetSigCh& sigch);
 
@@ -87,7 +86,7 @@ public:
   /**
    * @brief Get a map with (threshold value [mV], time [ps]) pairs.
    */
-  std::map<int, std::pair<float, float>> getTimesVsThresholdValue(JPetSigCh::EdgeType edge) const;
+  std::map<int, std::pair<float, float> > getTimesVsThresholdValue(JPetSigCh::EdgeType edge) const;
 
   /**
    * @brief Get a map with (threshold value [mV], TOT [ps]) pairs.
@@ -103,9 +102,8 @@ public:
 private:
   std::vector<JPetSigCh> fLeadingPoints; ///< vector of JPetSigCh objects from leading edge of the signal
   std::vector<JPetSigCh> fTrailingPoints; ///< vector of JPetSigCh objects from trailing edge of the signal
-  JPetSigCh fTOTPoint;
 
-ClassDef(JPetRawSignal, 3)
+ClassDef(JPetRawSignal, 5)
   ;
 };
 #endif /*  !JPETRAWSIGNAL_H */

--- a/JPetRecoSignal/JPetRecoSignal.cpp
+++ b/JPetRecoSignal/JPetRecoSignal.cpp
@@ -20,8 +20,6 @@ ClassImp(JPetRecoSignal);
 JPetRecoSignal::JPetRecoSignal(const int points) :
     fDelay(0), fAmplitude(0), fOffset(0), fCharge(0) {
 
-  //  SetNameTitle("JPetRecoSignal", "Working signal structure for reconstruction");
-
   if (points > 0) {
     fShape.reserve(points);
   }

--- a/JPetRecoSignal/JPetRecoSignal.cpp
+++ b/JPetRecoSignal/JPetRecoSignal.cpp
@@ -20,7 +20,7 @@ ClassImp(JPetRecoSignal);
 JPetRecoSignal::JPetRecoSignal(const int points) :
     fDelay(0), fAmplitude(0), fOffset(0), fCharge(0) {
 
-  SetNameTitle("JPetRecoSignal", "Working signal structure for reconstruction");
+  //  SetNameTitle("JPetRecoSignal", "Working signal structure for reconstruction");
 
   if (points > 0) {
     fShape.reserve(points);

--- a/JPetSigCh/JPetSigCh.cpp
+++ b/JPetSigCh/JPetSigCh.cpp
@@ -23,7 +23,7 @@ ClassImp(JPetSigCh);
 const float JPetSigCh::kUnset = std::numeric_limits<float>::infinity();
 
 void JPetSigCh::Init() {
-  SetNameTitle("JPetSigCh", "Signal Channel Structure");
+  //  SetNameTitle("JPetSigCh", "Signal Channel Structure");
   fValue = kUnset;
   fType = Leading;
   fThreshold = kUnset;

--- a/JPetSigCh/JPetSigCh.cpp
+++ b/JPetSigCh/JPetSigCh.cpp
@@ -40,20 +40,6 @@ JPetSigCh::JPetSigCh(EdgeType Edge, float EdgeTime) {
 
 }
 
-bool JPetSigCh::isCharge() const {
-  if (fType == Charge) {
-    return true;
-  }
-  return false;
-}
-
-bool JPetSigCh::isTime() const {
-  if (fType == Trailing || fType == Leading) {
-    return true;
-  }
-  return false;
-}
-
 bool JPetSigCh::compareByThresholdValue(const JPetSigCh& A,
                                         const JPetSigCh& B) {
   if (A.getThreshold() < B.getThreshold()) {

--- a/JPetSigCh/JPetSigCh.cpp
+++ b/JPetSigCh/JPetSigCh.cpp
@@ -23,7 +23,6 @@ ClassImp(JPetSigCh);
 const float JPetSigCh::kUnset = std::numeric_limits<float>::infinity();
 
 void JPetSigCh::Init() {
-  //  SetNameTitle("JPetSigCh", "Signal Channel Structure");
   fValue = kUnset;
   fType = Leading;
   fThreshold = kUnset;

--- a/JPetSigCh/JPetSigCh.h
+++ b/JPetSigCh/JPetSigCh.h
@@ -31,14 +31,15 @@
 /**
  * @brief Data class representing a SIGnal from a single tdc CHannel.
  *
- * Contains either time corresponding to a single threshold and slope type of a front-end board or charge from a single PM (if available in a given setup).
+ * Represents time of signal from one PMT crossing a certain voltage threshold
+ * at either leading or trailing edge of the signal.
  */
 class JPetSigCh: public TObject
 {
 public:
   enum EdgeType
   {
-    Trailing, Leading, Charge
+    Trailing, Leading
   };
   const static float kUnset;
 
@@ -50,9 +51,9 @@ public:
   }
 
   /**
-   * @brief Used to obtain the time or charge carried by the TDC signal.
+   * @brief Used to obtain the time value carried by the TDC signal.
    *
-   * @return either time with respect to beginning of the time window [ps] (TSlot) or charge (if getType()==Charge)
+   * @return time with respect to the end of the time window [ps] 
    */
   inline float getValue() const {
     return fValue;
@@ -61,7 +62,7 @@ public:
   /**
    * @brief Used to obtain the type of the signal information
    *
-   * Trailing edge, leading edge or charge (Charge)
+   * Time at either trailing edge or leading edge of the signal
    */
   inline EdgeType getType() const {
     return fType;
@@ -104,16 +105,6 @@ public:
     return getTOMBChannel().getChannel();
   }
   
-  /**
-   * Returns true if the value of the signal represents charge information (integral of the signal calculated by front-end board)
-   */
-  bool isCharge() const;
-
-  /**
-   * Returns true if the value of the signal represents time information from the TDC
-   */
-  bool isTime() const;
-
   inline void setPM(const JPetPM & pm) {
     fPM = const_cast<JPetPM*>(&pm);
   }
@@ -127,7 +118,7 @@ public:
     fTOMBChannel = const_cast<JPetTOMBChannel*>(&channel);
   }
 
-  // Set time wrt beginning of TSlot [ps] or charge
+  // Set time [ps]
   inline void setValue(float val) {
     fValue = val;
   }
@@ -190,8 +181,8 @@ public:
   ClassDef(JPetSigCh, 6);
   
 protected:
-  EdgeType fType; ///< type of the SigCh: Leading, Trailing (time) or Charge (charge)
-  float fValue; ///< main value of the SigCh; either time [ps] (if fType is kRiging or Leading) or charge (if fType is Charge)
+  EdgeType fType; ///< type of the SigCh: Leading or Trailing
+  float fValue; ///< value of time [ps] 
 
   unsigned int fThresholdNumber;
   float fThreshold; ///< value of threshold [mV]

--- a/JPetSigCh/JPetSigCh.h
+++ b/JPetSigCh/JPetSigCh.h
@@ -33,7 +33,7 @@
  *
  * Contains either time corresponding to a single threshold and slope type of a front-end board or charge from a single PM (if available in a given setup).
  */
-class JPetSigCh: public TNamed
+class JPetSigCh: public TObject
 {
 public:
   enum EdgeType
@@ -187,7 +187,7 @@ public:
   static bool compareByThresholdNumber(const JPetSigCh & A,
                                        const JPetSigCh & B);
   
-  ClassDef(JPetSigCh, 5);
+  ClassDef(JPetSigCh, 6);
   
 protected:
   EdgeType fType; ///< type of the SigCh: Leading, Trailing (time) or Charge (charge)

--- a/JPetSigCh/JPetSigChTest.cpp
+++ b/JPetSigCh/JPetSigChTest.cpp
@@ -10,8 +10,6 @@
 /// @todo update the method list - tests are outdated
 //  JPetSigCh() { init(); }
 //  JPetSigCh(EdgeType Edge, float EdgeTime);
-//  bool isCharge() const;
-//  bool isTime() const;
 //  inline float getValue() const { return fValue; }
 //  inline EdgeType getType() const { return fType; }
 //  inline JPetPM * getPM() const { return (JPetPM*) fPM.GetObject(); }
@@ -35,8 +33,6 @@ BOOST_AUTO_TEST_SUITE(FirstSuite)
 BOOST_AUTO_TEST_CASE( first )
 {
   JPetSigCh test;
-  BOOST_REQUIRE_EQUAL(test.isCharge(), 0);
-  BOOST_REQUIRE_EQUAL(test.isTime(), 1);
   BOOST_REQUIRE_EQUAL(test.getValue(), JPetSigCh::kUnset);
   BOOST_REQUIRE_EQUAL(test.getType(), JPetSigCh::Leading);
   BOOST_REQUIRE_EQUAL(test.getThreshold(), JPetSigCh::kUnset);
@@ -61,8 +57,6 @@ BOOST_AUTO_TEST_CASE( second )
   test.setType(JPetSigCh::Leading);
   test.setValue(time_test);
   
-  BOOST_REQUIRE_EQUAL(test.isTime(), 1);
-  BOOST_REQUIRE_EQUAL(test.isCharge(), 0);
   BOOST_REQUIRE_CLOSE(test.getValue(), time_test, epsilon);
   BOOST_REQUIRE_EQUAL(test.getType(), JPetSigCh::Leading);
   BOOST_REQUIRE_EQUAL(test.getChannel(), 12);

--- a/JPetTask/JPetTask.cpp
+++ b/JPetTask/JPetTask.cpp
@@ -40,7 +40,7 @@ void JPetTask::terminate()
 {
 }
 
-void JPetTask::setEvent(TNamed* ev)
+void JPetTask::setEvent(TObject* ev)
 {
   fEvent = ev;
 }

--- a/JPetTask/JPetTask.h
+++ b/JPetTask/JPetTask.h
@@ -35,11 +35,11 @@ public:
   virtual void setStatistics(JPetStatistics* statistics);
   virtual void setAuxilliaryData(JPetAuxilliaryData* auxData);
   virtual void setWriter(JPetWriter*) {};
-  virtual void setEvent(TNamed* ev);
+  virtual void setEvent(TObject* ev);
   const JPetParamBank& getParamBank();
   JPetStatistics& getStatistics();
   JPetAuxilliaryData& getAuxilliaryData();
-  virtual TNamed* getEvent() {
+  virtual TObject* getEvent() {
     return fEvent;
   }
 
@@ -52,7 +52,7 @@ public:
 
 protected:
   TNamed fName;
-  TNamed* fEvent;
+  TObject* fEvent;
   JPetParamManager* fParamManager;
   JPetStatistics* fStatistics;
   JPetAuxilliaryData* fAuxilliaryData;

--- a/JPetTaskChainExecutor/JPetTaskChainExecutorUtils.cpp
+++ b/JPetTaskChainExecutor/JPetTaskChainExecutorUtils.cpp
@@ -14,10 +14,13 @@
  */
 
 #include <cassert>
+#include <chrono>
 #include "./JPetTaskChainExecutorUtils.h"
 #include "../JPetTaskLoader/JPetTaskLoader.h"
 #include "../JPetParamGetterAscii/JPetParamGetterAscii.h"
 #include "../JPetParamGetterAscii/JPetParamSaverAscii.h"
+
+using namespace std::chrono;
 
 bool JPetTaskChainExecutorUtils::process(const JPetOptions& options, JPetParamManager* paramMgr, std::list<JPetTaskRunnerInterface*>& tasks)
 {
@@ -91,8 +94,14 @@ void JPetTaskChainExecutorUtils::unpackFile(const char* filename, long long neve
   } else {
     unpacker.setParams(filename, 100000000, configfile, calibfile);
   }
+  // measure unpacking time
+  high_resolution_clock::time_point tstart = high_resolution_clock::now();
   unpacker.exec();
+  high_resolution_clock::time_point tend = high_resolution_clock::now();
+  auto duration = duration_cast<seconds>(tend - tstart).count();
+  INFO(Form("Unpacking took %ld seconds.", duration));
 }
+
 
 JPetParamManager* JPetTaskChainExecutorUtils::generateParamManager(const JPetOptions& options)
 {

--- a/JPetTaskChainExecutor/JPetTaskChainExecutorUtils.cpp
+++ b/JPetTaskChainExecutor/JPetTaskChainExecutorUtils.cpp
@@ -14,13 +14,10 @@
  */
 
 #include <cassert>
-#include <chrono>
 #include "./JPetTaskChainExecutorUtils.h"
 #include "../JPetTaskLoader/JPetTaskLoader.h"
 #include "../JPetParamGetterAscii/JPetParamGetterAscii.h"
 #include "../JPetParamGetterAscii/JPetParamSaverAscii.h"
-
-using namespace std::chrono;
 
 bool JPetTaskChainExecutorUtils::process(const JPetOptions& options, JPetParamManager* paramMgr, std::list<JPetTaskRunnerInterface*>& tasks)
 {
@@ -94,14 +91,8 @@ void JPetTaskChainExecutorUtils::unpackFile(const char* filename, long long neve
   } else {
     unpacker.setParams(filename, 100000000, configfile, calibfile);
   }
-  // measure unpacking time
-  high_resolution_clock::time_point tstart = high_resolution_clock::now();
   unpacker.exec();
-  high_resolution_clock::time_point tend = high_resolution_clock::now();
-  auto duration = duration_cast<seconds>(tend - tstart).count();
-  INFO(Form("Unpacking took %ld seconds.", duration));
 }
-
 
 JPetParamManager* JPetTaskChainExecutorUtils::generateParamManager(const JPetOptions& options)
 {

--- a/JPetTaskIO/JPetTaskIO.cpp
+++ b/JPetTaskIO/JPetTaskIO.cpp
@@ -67,7 +67,7 @@ void JPetTaskIO::exec()
   for (auto i = firstEvent; i <= lastEvent; i++) {
 
     //(std::dynamic_pointer_cast<JPetTask>(fTask))->setEvent(&(static_cast<TNamed&>(fReader->getCurrentEvent())));
-    (dynamic_cast<JPetTask*>(fTask))->setEvent(&(static_cast<TNamed&>(fReader->getCurrentEvent())));
+    (dynamic_cast<JPetTask*>(fTask))->setEvent(&(static_cast<TObject&>(fReader->getCurrentEvent())));
     if (fOptions.isProgressBar()) {
       displayProgressBar(i, lastEvent);
     }

--- a/JPetTimeWindow/JPetTimeWindow.h
+++ b/JPetTimeWindow/JPetTimeWindow.h
@@ -30,7 +30,6 @@ class JPetTimeWindow: public TObject
 {
 public:
   JPetTimeWindow() {
-    //    SetName("JPetTimeWindow");
   }
 
   void addCh(JPetSigCh& new_ch);

--- a/JPetTimeWindow/JPetTimeWindow.h
+++ b/JPetTimeWindow/JPetTimeWindow.h
@@ -18,21 +18,19 @@
 
 #include <vector>
 #include <map>
-#include <TNamed.h>
+#include <TObject.h>
 #include "../JPetSigCh/JPetSigCh.h"
-#include <TClonesArray.h>
 
 /**
  * @brief Data class representing a time window of the TRB board.
  *
  * A single TSlot contains many SigCh objects representing TDC hits recorded during a time window of the TRB board.
  */
-class JPetTimeWindow: public TNamed
+class JPetTimeWindow: public TObject
 {
 public:
-/// @todo think about changing TClonesArray to something else ? what about cleaning
   JPetTimeWindow() {
-    SetName("JPetTimeWindow");
+    //    SetName("JPetTimeWindow");
   }
 
   void addCh(JPetSigCh& new_ch);
@@ -71,7 +69,7 @@ public:
     fIndex = index;
   }
 
-  ClassDef(JPetTimeWindow, 2);
+  ClassDef(JPetTimeWindow, 3);
 
 private:
   std::vector<JPetSigCh> fSigChannels;

--- a/JPetTimeWindow/JPetTimeWindowTest.cpp
+++ b/JPetTimeWindow/JPetTimeWindowTest.cpp
@@ -28,7 +28,7 @@ BOOST_AUTO_TEST_CASE( default_constructor )
 BOOST_AUTO_TEST_CASE( some_channels )
 {
   JPetTimeWindow test;
-  JPetSigCh ch_test(JPetSigCh::Trailing, 1.2), ch_test2(JPetSigCh::Leading, 1.5), ch_test3(JPetSigCh::Charge, 98);
+  JPetSigCh ch_test(JPetSigCh::Trailing, 1.2), ch_test2(JPetSigCh::Leading, 1.5), ch_test3(JPetSigCh::Leading, 98);
   test.addCh(ch_test);
   test.addCh(ch_test2);
   test.addCh(ch_test3);


### PR DESCRIPTION
additionally, removed obsolete "charge" option from JPetSigCh.

Note: unit test of JPetReader requires update of a data file "timewindows.root" at Sphinx. I have temporarily substituted this file and UTs at Travis pass correctly (UTs also pass locally on my machine).
Now the file is back to the old version at Sphinx. I will update it permanently if we decide to merge this PR.