### PR TITLE
TimeWindow-based processing scheme

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,10 +107,13 @@ set(CMAKE_INSTALL_RPATH_USE_LINK_PATH ON)
 # add Unpacker subdirectory
 add_subdirectory(Unpacker2/Unpacker2)
 
-file(GLOB HEADERS JPet*/*.h tools/JPet*/*.h modules/JPet*/*.h)
-file(GLOB SOURCES JPet*/*.cpp tools/JPet*/*.cpp modules/JPet*/*.cpp)
+file(GLOB HEADERS JPet*/*.h tools/JPet*/*.h # modules/JPet*/*.h
+  )
+file(GLOB SOURCES JPet*/*.cpp tools/JPet*/*.cpp # modules/JPet*/*.cpp
+  )
 file(GLOB UNIT_TEST_SOURCES JPet*/*Test.cpp)
-file(GLOB MODULES_UNIT_TEST_SOURCES modules/JPet*/*Test.cpp)
+file(GLOB MODULES_UNIT_TEST_SOURCES # modules/JPet*/*Test.cpp
+  )
 list(APPEND UNIT_TEST_SOURCES ${MODULES_UNIT_TEST_SOURCES})
 list(REMOVE_ITEM SOURCES ${UNIT_TEST_SOURCES})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,13 +107,10 @@ set(CMAKE_INSTALL_RPATH_USE_LINK_PATH ON)
 # add Unpacker subdirectory
 add_subdirectory(Unpacker2/Unpacker2)
 
-file(GLOB HEADERS JPet*/*.h tools/JPet*/*.h # modules/JPet*/*.h
-  )
-file(GLOB SOURCES JPet*/*.cpp tools/JPet*/*.cpp # modules/JPet*/*.cpp
-  )
+file(GLOB HEADERS JPet*/*.h tools/JPet*/*.h)
+file(GLOB SOURCES JPet*/*.cpp tools/JPet*/*.cpp)
 file(GLOB UNIT_TEST_SOURCES JPet*/*Test.cpp)
-file(GLOB MODULES_UNIT_TEST_SOURCES # modules/JPet*/*Test.cpp
-  )
+file(GLOB MODULES_UNIT_TEST_SOURCES)
 list(APPEND UNIT_TEST_SOURCES ${MODULES_UNIT_TEST_SOURCES})
 list(REMOVE_ITEM SOURCES ${UNIT_TEST_SOURCES})
 

--- a/JPetBaseSignal/JPetBaseSignal.cpp
+++ b/JPetBaseSignal/JPetBaseSignal.cpp
@@ -18,8 +18,7 @@
 ClassImp(JPetBaseSignal);
 
 JPetBaseSignal::JPetBaseSignal() :
-    TObject(), fPM(0), fBarrelSlot(0),
-    fTimeWindowIndex(0) {
+  TObject(), fPM(0), fBarrelSlot(0) {
 }
 JPetBaseSignal::JPetBaseSignal(bool isNull):
   fIsNullObject(isNull)

--- a/JPetBaseSignal/JPetBaseSignal.cpp
+++ b/JPetBaseSignal/JPetBaseSignal.cpp
@@ -28,10 +28,19 @@ bool JPetBaseSignal::isNullObject() const
 {
    return fIsNullObject;
 }
+
 JPetBaseSignal& JPetBaseSignal::getDummyResult()
 {
    static JPetBaseSignal DummyResult(true);
    return DummyResult;
 }
+
 JPetBaseSignal::~JPetBaseSignal() {
+}
+
+void JPetBaseSignal::Clear(Option_t *){
+
+  fPM = NULL;
+  fBarrelSlot = NULL;
+
 }

--- a/JPetBaseSignal/JPetBaseSignal.h
+++ b/JPetBaseSignal/JPetBaseSignal.h
@@ -32,23 +32,9 @@ public:
   JPetBaseSignal();
   virtual ~JPetBaseSignal();
   explicit JPetBaseSignal(bool isNull);
-  /**
-   * @brief Set number of the Time Slot this signal belongs to.
-   *
-   * Should be set to the value returned by JPetTimeWindow::getIndex() for the respective Time Window
-   */
+
   bool isNullObject() const;
   static  JPetBaseSignal& getDummyResult();
-  inline void setTimeWindowIndex(unsigned int index) {
-    fTimeWindowIndex = index;
-  }
-
-  /**
-   * @brief Get the number of the Time Window this signal belongs to.
-   */
-  inline unsigned int getTimeWindowIndex() const {
-    return fTimeWindowIndex;
-  }
 
   inline void setPM(const JPetPM & pm) {
     fPM = const_cast<JPetPM*>(&pm);
@@ -78,8 +64,6 @@ private:
   // references to parametric objects
   TRef fPM; ///< Photomultiplier which recorded this signal
   TRef fBarrelSlot; ///< BarrelSlot containing the PM which recorded this signal
-
-  unsigned int fTimeWindowIndex; // index of original TSlot
 
 protected:
 

--- a/JPetBaseSignal/JPetBaseSignal.h
+++ b/JPetBaseSignal/JPetBaseSignal.h
@@ -60,6 +60,8 @@ public:
     return (JPetBarrelSlot&) *fBarrelSlot.GetObject();
   }
 
+  void Clear(Option_t * opt = "");
+  
 private:
   // references to parametric objects
   TRef fPM; ///< Photomultiplier which recorded this signal

--- a/JPetEvent/JPetEvent.cpp
+++ b/JPetEvent/JPetEvent.cpp
@@ -77,3 +77,8 @@ void JPetEvent::addEventType(JPetEventType type)
     fType = static_cast<JPetEventType>(fType | type); /// adding flag to the existing one
   }
 }
+
+void JPetEvent::Clear(Option_t *){
+  fType = kUnknown;
+  fHits.clear();
+}

--- a/JPetEvent/JPetEvent.h
+++ b/JPetEvent/JPetEvent.h
@@ -57,6 +57,8 @@ public:
   bool isTypeOf(JPetEventType type) const; /// check if the event is of a given type. Event can belong to more than one category e.g. k2Gamma|kScattered.
   bool isOnlyTypeOf(JPetEventType type) const;/// check if the event is of only given type e.g. isOnlyTypeOf(k2Gamma) will return false if the type is k2Gamma|kScattered.
 
+  void Clear(Option_t * opt = "");
+  
 protected:
   std::vector<JPetHit> fHits;
 #ifndef __CINT__

--- a/JPetHit/JPetHit.cpp
+++ b/JPetHit/JPetHit.cpp
@@ -227,7 +227,7 @@ bool JPetHit::checkConsistency() const
   return true;
 }
 
-void JPetHit::setSignals(JPetPhysSignal& p_sigA, JPetPhysSignal& p_sigB)
+void JPetHit::setSignals(const JPetPhysSignal& p_sigA, const JPetPhysSignal& p_sigB)
 {
   fSignalA = p_sigA;
   fIsSignalAset = true;
@@ -237,7 +237,7 @@ void JPetHit::setSignals(JPetPhysSignal& p_sigA, JPetPhysSignal& p_sigB)
     return;
 }
 
-void JPetHit::setSignalA(JPetPhysSignal& p_sig)
+void JPetHit::setSignalA(const JPetPhysSignal& p_sig)
 {
   fSignalA = p_sig;
   fIsSignalAset = true;
@@ -245,7 +245,7 @@ void JPetHit::setSignalA(JPetPhysSignal& p_sig)
     return;
 }
 
-void JPetHit::setSignalB(JPetPhysSignal& p_sig)
+void JPetHit::setSignalB(const JPetPhysSignal& p_sig)
 {
   fSignalB = p_sig;
   fIsSignalBset = true;

--- a/JPetHit/JPetHit.cpp
+++ b/JPetHit/JPetHit.cpp
@@ -218,12 +218,6 @@ bool JPetHit::checkConsistency() const
     return false;
   }
 
-  if ( getSignalA().getTimeWindowIndex() != getSignalB().getTimeWindowIndex() ) {
-    ERROR( Form("Signals added to Hit come from different time windows: %d and %d." ,
-                getSignalA().getTimeWindowIndex(), getSignalB().getTimeWindowIndex()) );
-    return false;
-  }
-
   return true;
 }
 
@@ -253,7 +247,4 @@ void JPetHit::setSignalB(const JPetPhysSignal& p_sig)
     return;
 }
 
-unsigned int JPetHit::getTimeWindowIndex() const
-{
-  return getSignalA().getTimeWindowIndex();
-}
+

--- a/JPetHit/JPetHit.cpp
+++ b/JPetHit/JPetHit.cpp
@@ -247,4 +247,19 @@ void JPetHit::setSignalB(const JPetPhysSignal& p_sig)
     return;
 }
 
-
+void JPetHit::Clear(Option_t *){
+  fEnergy = 0.0f;
+  fQualityOfEnergy = 0.0f;
+  fTime = 0.0f;
+  fQualityOfTime = 0.0f;
+  fTimeDiff = 0.0f;
+  fQualityOfTimeDiff = 0.0f;
+  fPos = TVector3();
+  fSignalA = JPetPhysSignal();
+  fSignalB = JPetPhysSignal();
+  fIsSignalAset = false;
+  fIsSignalBset = false;
+  
+  fBarrelSlot = NULL;
+  fScintillator = NULL;
+}

--- a/JPetHit/JPetHit.h
+++ b/JPetHit/JPetHit.h
@@ -114,6 +114,9 @@ public:
    */
   bool checkConsistency() const;
 
+  void Clear(Option_t * opt  = "");
+  
+  
 private:
   float fEnergy = 0.0f; ///< reconstructed energy of the hit [keV]
   float fQualityOfEnergy = 0.0f;

--- a/JPetHit/JPetHit.h
+++ b/JPetHit/JPetHit.h
@@ -90,9 +90,9 @@ public:
   void setBarrelSlot( JPetBarrelSlot& bs) ;
   void setScintillator(JPetScin& sc) ;
 
-  void setSignals(JPetPhysSignal& p_sigA, JPetPhysSignal& p_sigB);
-  void setSignalA(JPetPhysSignal& p_sig);
-  void setSignalB(JPetPhysSignal& p_sig);
+  void setSignals(const JPetPhysSignal& p_sigA, const JPetPhysSignal& p_sigB);
+  void setSignalA(const JPetPhysSignal& p_sig);
+  void setSignalB(const JPetPhysSignal& p_sig);
   unsigned int getTimeWindowIndex()const;
   
   /** @brief Checks whether information contained in both Signal objects

--- a/JPetHit/JPetHit.h
+++ b/JPetHit/JPetHit.h
@@ -19,7 +19,6 @@
 #include "../JPetBarrelSlot/JPetBarrelSlot.h"
 #include "../JPetScin/JPetScin.h"
 #include "../JPetPhysSignal/JPetPhysSignal.h"
-#include "../JPetTimeWindow/JPetTimeWindow.h"
 
 #include "TObject.h"
 #include "TVector3.h"
@@ -31,7 +30,6 @@
 class JPetBarrelSlot;
 class JPetScin;
 class JPetPhysSignal;
-class JPetTimeWindow;
 
 /**
  * @brief Data class representing a reconstructed hit of a photon in the scintillator strip.
@@ -93,7 +91,6 @@ public:
   void setSignals(const JPetPhysSignal& p_sigA, const JPetPhysSignal& p_sigB);
   void setSignalA(const JPetPhysSignal& p_sig);
   void setSignalB(const JPetPhysSignal& p_sig);
-  unsigned int getTimeWindowIndex()const;
   
   /** @brief Checks whether information contained in both Signal objects
    *  set in this Hit object is consistent and logs an error message if

--- a/JPetLOR/JPetLOR.cpp
+++ b/JPetLOR/JPetLOR.cpp
@@ -115,3 +115,12 @@ bool JPetLOR::isFromSameBarrelSlot() const {
 	}
 	return true;
 }
+
+void JPetLOR::Clear(Option_t *){
+  fTime = 0.0f;
+  fQualityOfTime = 0.0f;
+  fTimeDiff = 0.0f;
+  fQualityOfTimeDiff = 0.0f;
+  fIsHitSet[0] = false;
+  fIsHitSet[1] = false;  
+}

--- a/JPetLOR/JPetLOR.h
+++ b/JPetLOR/JPetLOR.h
@@ -91,6 +91,9 @@ ClassDef(JPetLOR,2);
  *  @return true if both signals are consistently from the same barrel slot.
  */
 bool isFromSameBarrelSlot() const; 
+
+  void Clear(Option_t * opt = "");
+
 private:
 
   float fTime; ///< reconstructed absolute time of the event wrt to beginning of the run [ps]

--- a/JPetLargeBarrelExtensions/BarrelExtensions.cpp
+++ b/JPetLargeBarrelExtensions/BarrelExtensions.cpp
@@ -116,10 +116,7 @@ void LargeBarrelTask::init(const JPetTaskInterface::Options&)
 {
   fBarrelMap = make_shared<LargeBarrelMapping>(getParamBank());
 }
-void LargeBarrelTask::setWriter(JPetWriter* writer)
-{
-  fWriter = writer;
-}
+
 JPetWriter& LargeBarrelTask::writter() const
 {
   //ToDo: provide control

--- a/JPetLargeBarrelExtensions/BarrelExtensions.h
+++ b/JPetLargeBarrelExtensions/BarrelExtensions.h
@@ -57,7 +57,6 @@ protected:
 public:
   virtual ~LargeBarrelTask();
   virtual void init(const JPetTaskInterface::Options& opts)override;
-  virtual void setWriter(JPetWriter* writer)override;
 protected:
   JPetWriter& writter()const;
   const std::shared_ptr<LargeBarrelMapping>map()const;

--- a/JPetPM/JPetPMFactory.cpp
+++ b/JPetPM/JPetPMFactory.cpp
@@ -57,7 +57,12 @@ JPetPM* JPetPMFactory::build(ParamObjectDescription data)
   try {
     int id = boost::lexical_cast<int>(data.at("id"));
     JPetPM::Side side = boost::lexical_cast<bool>(data.at("is_right_side")) ? JPetPM::Side::SideB : JPetPM::Side::SideA;
-    std::string description = boost::lexical_cast<std::string>(data.at("description"));
+    std::string description;
+    try{
+      description = boost::lexical_cast<std::string>(data.at("description"));
+    } catch (const std::exception& e) {
+      description = "";
+    }
     JPetPM* result = new JPetPM(id, description);
     result->setSide(side);
     return result;

--- a/JPetParamAndDataFactory/JPetParamAndDataFactory.cpp
+++ b/JPetParamAndDataFactory/JPetParamAndDataFactory.cpp
@@ -69,8 +69,7 @@ JPetBarrelSlot makeBarrelSlot(JPetLayer& p_layer, int id, bool isActive, const s
 JPetTimeWindow makeTimeWindow(const std::vector<JPetSigCh>& vec)
 {
   JPetTimeWindow timeWindowObject;
-  for(auto sigch: vec)
-  {
+  for (auto sigch : vec) {
     timeWindowObject.add<JPetSigCh>(sigch);
   }
   return timeWindowObject;
@@ -85,7 +84,7 @@ JPetPM makePM(JPetPM::Side side, int id, int set, int opt, std::pair<float, floa
   return pmObject;
 }
 
-JPetBaseSignal makeBaseSignal(JPetPM & pm, JPetBarrelSlot & bs)
+JPetBaseSignal makeBaseSignal(JPetPM& pm, JPetBarrelSlot& bs)
 {
   JPetBaseSignal baseSignalObject;
   baseSignalObject.setPM(pm);

--- a/JPetParamAndDataFactory/JPetParamAndDataFactory.cpp
+++ b/JPetParamAndDataFactory/JPetParamAndDataFactory.cpp
@@ -66,13 +66,13 @@ JPetBarrelSlot makeBarrelSlot(JPetLayer& p_layer, int id, bool isActive, const s
   return barrelSlotObject;
 }
 
-JPetTimeWindow makeTimeWindow(const std::vector<JPetSigCh>& vec, unsigned int window_id)
+JPetTimeWindow makeTimeWindow(const std::vector<JPetSigCh>& vec)
 {
   JPetTimeWindow timeWindowObject;
-  for (auto sigch : vec) {
-    timeWindowObject.addCh(sigch);
+  for(auto sigch: vec)
+  {
+    timeWindowObject.add<JPetSigCh>(sigch);
   }
-  timeWindowObject.setIndex(window_id);
   return timeWindowObject;
 }
 

--- a/JPetParamAndDataFactory/JPetParamAndDataFactory.cpp
+++ b/JPetParamAndDataFactory/JPetParamAndDataFactory.cpp
@@ -85,10 +85,9 @@ JPetPM makePM(JPetPM::Side side, int id, int set, int opt, std::pair<float, floa
   return pmObject;
 }
 
-JPetBaseSignal makeBaseSignal(unsigned int index, JPetPM& pm, JPetBarrelSlot& bs)
+JPetBaseSignal makeBaseSignal(JPetPM & pm, JPetBarrelSlot & bs)
 {
   JPetBaseSignal baseSignalObject;
-  baseSignalObject.setTimeWindowIndex(index);
   baseSignalObject.setPM(pm);
   baseSignalObject.setBarrelSlot(bs);
   return baseSignalObject;

--- a/JPetParamAndDataFactory/JPetParamAndDataFactory.h
+++ b/JPetParamAndDataFactory/JPetParamAndDataFactory.h
@@ -45,9 +45,11 @@ JPetLayer makeLayer(int id, bool isActive, const std::string& name, float radius
 JPetHit makeHit(float e, float qe, float t, float qt, TVector3& pos, JPetPhysSignal& siga, JPetPhysSignal& sigb, JPetBarrelSlot& bslot, JPetScin& scin, float qtd, float td);
 JPetSigCh makeSigCh(JPetPM& pm, JPetTRB& trb, JPetFEB& feb, JPetTOMBChannel& channel, float val, JPetSigCh::EdgeType type, float thr, Int_t daqch, unsigned int threshold_number);
 JPetBarrelSlot makeBarrelSlot(JPetLayer& p_layer, int id, bool isActive, const std::string& name, float theta, int inFrameID);
-JPetTimeWindow makeTimeWindow(const std::vector<JPetSigCh>& vec, unsigned int window_id);
-JPetPM makePM(JPetPM::Side side, int id, int set, int opt, std::pair<float, float>& gain, std::string description, JPetFEB& p_FEB, JPetScin& p_scin, JPetBarrelSlot& p_barrelSlot);
-JPetBaseSignal makeBaseSignal(unsigned int index, JPetPM& pm, JPetBarrelSlot& bs);
+JPetTimeWindow makeTimeWindow(const std::vector<JPetSigCh>& vec); 
+JPetPM makePM(JPetPM::Side side, int id, int set, int opt, std::pair<float, float>& gain, JPetFEB& p_FEB, JPetScin& p_scin, JPetBarrelSlot& p_barrelSlot); 
+JPetSigCh makeSigCh(JPetPM & pm, JPetTRB & trb, JPetFEB & feb, JPetTOMBChannel & channel, float val, JPetSigCh::EdgeType type, float thr, Int_t daqch, unsigned int threshold_number); 
+JPetBarrelSlot makeBarrelSlot(JPetLayer& p_layer, int id, bool isActive, const std::string& name, float theta, int inFrameID); 
+JPetBaseSignal makeBaseSignal(unsigned int index, JPetPM & pm, JPetBarrelSlot & bs);
 JPetPhysSignal makePhysSignal(float time, float qualityOfTime, double phe, double qualityOfPhe, JPetRecoSignal& recoSignal);
 JPetRawSignal makeRawSignal(const std::vector<JPetSigCh>& vec);
 JPetTOMBChannel makeTOMBChannel(int p_channel, JPetFEB& p_FEB, JPetTRB& p_TRB, JPetPM& p_PM, float p_threshold, unsigned int lcn, unsigned int fin);

--- a/JPetParamAndDataFactory/JPetParamAndDataFactory.h
+++ b/JPetParamAndDataFactory/JPetParamAndDataFactory.h
@@ -45,10 +45,10 @@ JPetLayer makeLayer(int id, bool isActive, const std::string& name, float radius
 JPetHit makeHit(float e, float qe, float t, float qt, TVector3& pos, JPetPhysSignal& siga, JPetPhysSignal& sigb, JPetBarrelSlot& bslot, JPetScin& scin, float qtd, float td);
 JPetSigCh makeSigCh(JPetPM& pm, JPetTRB& trb, JPetFEB& feb, JPetTOMBChannel& channel, float val, JPetSigCh::EdgeType type, float thr, Int_t daqch, unsigned int threshold_number);
 JPetBarrelSlot makeBarrelSlot(JPetLayer& p_layer, int id, bool isActive, const std::string& name, float theta, int inFrameID);
-JPetTimeWindow makeTimeWindow(const std::vector<JPetSigCh>& vec); 
-JPetPM makePM(JPetPM::Side side, int id, int set, int opt, std::pair<float, float>& gain, JPetFEB& p_FEB, JPetScin& p_scin, JPetBarrelSlot& p_barrelSlot); 
-JPetBarrelSlot makeBarrelSlot(JPetLayer& p_layer, int id, bool isActive, const std::string& name, float theta, int inFrameID); 
-JPetBaseSignal makeBaseSignal(JPetPM & pm, JPetBarrelSlot & bs);
+JPetTimeWindow makeTimeWindow(const std::vector<JPetSigCh>& vec);
+JPetPM makePM(JPetPM::Side side, int id, int set, int opt, std::pair<float, float>& gain, JPetFEB& p_FEB, JPetScin& p_scin, JPetBarrelSlot& p_barrelSlot);
+JPetBarrelSlot makeBarrelSlot(JPetLayer& p_layer, int id, bool isActive, const std::string& name, float theta, int inFrameID);
+JPetBaseSignal makeBaseSignal(JPetPM& pm, JPetBarrelSlot& bs);
 JPetPhysSignal makePhysSignal(float time, float qualityOfTime, double phe, double qualityOfPhe, JPetRecoSignal& recoSignal);
 JPetRawSignal makeRawSignal(const std::vector<JPetSigCh>& vec);
 JPetTOMBChannel makeTOMBChannel(int p_channel, JPetFEB& p_FEB, JPetTRB& p_TRB, JPetPM& p_PM, float p_threshold, unsigned int lcn, unsigned int fin);

--- a/JPetParamAndDataFactory/JPetParamAndDataFactory.h
+++ b/JPetParamAndDataFactory/JPetParamAndDataFactory.h
@@ -49,7 +49,7 @@ JPetTimeWindow makeTimeWindow(const std::vector<JPetSigCh>& vec);
 JPetPM makePM(JPetPM::Side side, int id, int set, int opt, std::pair<float, float>& gain, JPetFEB& p_FEB, JPetScin& p_scin, JPetBarrelSlot& p_barrelSlot); 
 JPetSigCh makeSigCh(JPetPM & pm, JPetTRB & trb, JPetFEB & feb, JPetTOMBChannel & channel, float val, JPetSigCh::EdgeType type, float thr, Int_t daqch, unsigned int threshold_number); 
 JPetBarrelSlot makeBarrelSlot(JPetLayer& p_layer, int id, bool isActive, const std::string& name, float theta, int inFrameID); 
-JPetBaseSignal makeBaseSignal(unsigned int index, JPetPM & pm, JPetBarrelSlot & bs);
+JPetBaseSignal makeBaseSignal(JPetPM & pm, JPetBarrelSlot & bs);
 JPetPhysSignal makePhysSignal(float time, float qualityOfTime, double phe, double qualityOfPhe, JPetRecoSignal& recoSignal);
 JPetRawSignal makeRawSignal(const std::vector<JPetSigCh>& vec);
 JPetTOMBChannel makeTOMBChannel(int p_channel, JPetFEB& p_FEB, JPetTRB& p_TRB, JPetPM& p_PM, float p_threshold, unsigned int lcn, unsigned int fin);

--- a/JPetParamAndDataFactory/JPetParamAndDataFactory.h
+++ b/JPetParamAndDataFactory/JPetParamAndDataFactory.h
@@ -47,7 +47,6 @@ JPetSigCh makeSigCh(JPetPM& pm, JPetTRB& trb, JPetFEB& feb, JPetTOMBChannel& cha
 JPetBarrelSlot makeBarrelSlot(JPetLayer& p_layer, int id, bool isActive, const std::string& name, float theta, int inFrameID);
 JPetTimeWindow makeTimeWindow(const std::vector<JPetSigCh>& vec); 
 JPetPM makePM(JPetPM::Side side, int id, int set, int opt, std::pair<float, float>& gain, JPetFEB& p_FEB, JPetScin& p_scin, JPetBarrelSlot& p_barrelSlot); 
-JPetSigCh makeSigCh(JPetPM & pm, JPetTRB & trb, JPetFEB & feb, JPetTOMBChannel & channel, float val, JPetSigCh::EdgeType type, float thr, Int_t daqch, unsigned int threshold_number); 
 JPetBarrelSlot makeBarrelSlot(JPetLayer& p_layer, int id, bool isActive, const std::string& name, float theta, int inFrameID); 
 JPetBaseSignal makeBaseSignal(JPetPM & pm, JPetBarrelSlot & bs);
 JPetPhysSignal makePhysSignal(float time, float qualityOfTime, double phe, double qualityOfPhe, JPetRecoSignal& recoSignal);

--- a/JPetParamAndDataFactory/JPetParamAndDataFactoryTest.cpp
+++ b/JPetParamAndDataFactory/JPetParamAndDataFactoryTest.cpp
@@ -152,14 +152,16 @@ BOOST_AUTO_TEST_CASE( barrelSlot )
   BOOST_REQUIRE_EQUAL(barrelSlot.getLayer().getRadius(), p_layer.getRadius());
 }
 
+/*
 BOOST_AUTO_TEST_CASE( timeWindow )
 {
   JPetSigCh::EdgeType type = JPetSigCh::Trailing;
-  std::vector<JPetSigCh> vec = {JPetSigCh(type, 1), JPetSigCh(type, 1)};
-  JPetTimeWindow timeWindow = param_and_data_factory::makeTimeWindow(vec, 1);
-  BOOST_REQUIRE_EQUAL(timeWindow.getNumberOfSigCh(), 2);
-  BOOST_REQUIRE_EQUAL(timeWindow.getIndex(), 1);
+  std::vector<JPetSigCh> vec ={JPetSigCh(type, 1), JPetSigCh(type, 1)};
+  JPetTimeWindow timeWindow = param_and_data_factory::makeTimeWindow(vec);
+  BOOST_REQUIRE_EQUAL(timeWindow.getNumberOfEvents(), 2);
+
 }
+*/
 
 BOOST_AUTO_TEST_CASE( pm )
 {

--- a/JPetParamAndDataFactory/JPetParamAndDataFactoryTest.cpp
+++ b/JPetParamAndDataFactory/JPetParamAndDataFactoryTest.cpp
@@ -199,8 +199,7 @@ BOOST_AUTO_TEST_CASE( baseSignal )
   pm.setHVopt(2);
   pm.setHVset(3);
   JPetBarrelSlot p_barrelSlot(1, true, "name", 2, 3);
-  JPetBaseSignal bs = param_and_data_factory::makeBaseSignal(1, pm, p_barrelSlot);
-  BOOST_REQUIRE_EQUAL(bs.getTimeWindowIndex(), 1 );
+  JPetBaseSignal bs = param_and_data_factory::makeBaseSignal(pm, p_barrelSlot);
 
   BOOST_REQUIRE_EQUAL(bs.getPM().getHVopt(), pm.getHVopt() );
   BOOST_REQUIRE_EQUAL(bs.getPM().getHVset(), pm.getHVset() );

--- a/JPetPhysSignal/JPetPhysSignal.cpp
+++ b/JPetPhysSignal/JPetPhysSignal.cpp
@@ -41,5 +41,12 @@ void JPetPhysSignal::setRecoSignal(const JPetRecoSignal& recoSignal){
    fRecoSignal = recoSignal;
    setPM( recoSignal.getPM() );
    setBarrelSlot( recoSignal.getBarrelSlot() );
-   setTimeWindowIndex( recoSignal.getTimeWindowIndex() );
+}
+
+void JPetPhysSignal::Clear(Option_t *){
+  fTime = 0.;
+  fQualityOfTime = 0.;
+  fPhe = 0.; 
+  fQualityOfPhe = 0.;
+  fRecoSignal = JPetRecoSignal();
 }

--- a/JPetPhysSignal/JPetPhysSignal.h
+++ b/JPetPhysSignal/JPetPhysSignal.h
@@ -85,6 +85,8 @@ public:
 
   void setRecoSignal(const JPetRecoSignal& recoSignal);
 
+  void Clear(Option_t * opt = "");
+  
 private:
   double fTime; ///< one time reconstructed for the whole signal [ps]
   double fQualityOfTime; ///< quantitative measure of the time reconstruction quality (scale is yet to be decided)

--- a/JPetRawSignal/JPetRawSignal.cpp
+++ b/JPetRawSignal/JPetRawSignal.cpp
@@ -110,3 +110,7 @@ std::map<int, double> JPetRawSignal::getTOTsVsThresholdValue() const {
   return thrToTOT;
 }
 
+void JPetRawSignal::Clear(Option_t *){
+  fLeadingPoints.clear();
+  fTrailingPoints.clear();
+}

--- a/JPetRawSignal/JPetRawSignal.h
+++ b/JPetRawSignal/JPetRawSignal.h
@@ -98,12 +98,13 @@ public:
    */
   std::map<int, double> getTOTsVsThresholdNumber() const;
 
+  void Clear(Option_t * opt = "");
   
 private:
   std::vector<JPetSigCh> fLeadingPoints; ///< vector of JPetSigCh objects from leading edge of the signal
   std::vector<JPetSigCh> fTrailingPoints; ///< vector of JPetSigCh objects from trailing edge of the signal
 
-ClassDef(JPetRawSignal, 4)
+  ClassDef(JPetRawSignal, 4)
   ;
 };
 #endif /*  !JPETRAWSIGNAL_H */

--- a/JPetRawSignal/JPetRawSignalTest.cpp
+++ b/JPetRawSignal/JPetRawSignalTest.cpp
@@ -127,12 +127,6 @@ BOOST_AUTO_TEST_CASE(GetMapOfTimesVsThrValueTest) {
   BOOST_REQUIRE_EQUAL(map[4].second, sigch3.getValue());
 }
 
-BOOST_AUTO_TEST_CASE(SetAndGetTSlotIndexTest) {
-  JPetRawSignal signal;
-  signal.setTimeWindowIndex(8);
-  BOOST_CHECK(signal.getTimeWindowIndex() == 8);
-}
-
 BOOST_AUTO_TEST_CASE(SetAndGetTRefPMObjectTest) {
   JPetRawSignal signal;
   JPetPM PM;

--- a/JPetRecoSignal/JPetRecoSignal.cpp
+++ b/JPetRecoSignal/JPetRecoSignal.cpp
@@ -59,5 +59,28 @@ void JPetRecoSignal::setRawSignal(const JPetRawSignal& rawSignal){
    fRawSignal = rawSignal;
    setPM( rawSignal.getPM() );
    setBarrelSlot( rawSignal.getBarrelSlot() );
-   setTimeWindowIndex( rawSignal.getTimeWindowIndex() );
 }
+
+void JPetRecoSignal::Clear(Option_t *){
+  fShape.clear();
+  fDelay = 0.;
+  fAmplitude = 0.;
+  fOffset = 0.;
+  fCharge = 0.;
+
+  fRawSignal = JPetRawSignal();
+
+  fRecoTimesAtThreshold.clear();
+}
+
+
+
+
+
+
+
+
+
+
+
+

--- a/JPetRecoSignal/JPetRecoSignal.h
+++ b/JPetRecoSignal/JPetRecoSignal.h
@@ -216,6 +216,8 @@ public:
     return const_cast<std::map<float, float> & > (fRecoTimesAtThreshold)[threshold];
   }
 
+  void Clear(Option_t * opt = "");
+  
 private:
 
   static bool compareShapePointsTime(const shapePoint & A,

--- a/JPetScopeTask/JPetScopeTask.cpp
+++ b/JPetScopeTask/JPetScopeTask.cpp
@@ -60,7 +60,6 @@ void JPetScopeTask::exec()
     for(const auto & file : inputFilesInTimeWindowOrder){
       DEBUG(std::string("file to open:")+file.first);
       JPetRecoSignal sig = RecoSignalUtils::generateSignal(file.first.c_str());
-      sig.setTimeWindowIndex(getTimeWindowIndex(file.first));
       DEBUG("before setPM");
       const JPetPM & pm = bank.getPM(file.second);
       const JPetBarrelSlot & bs = pm.getBarrelSlot();

--- a/JPetSigCh/JPetSigCh.cpp
+++ b/JPetSigCh/JPetSigCh.cpp
@@ -22,15 +22,21 @@ ClassImp(JPetSigCh);
 
 const float JPetSigCh::kUnset = std::numeric_limits<float>::infinity();
 
-void JPetSigCh::Init() {
+void JPetSigCh::init() {
   fValue = kUnset;
   fType = Leading;
   fThreshold = kUnset;
   fThresholdNumber = 0;
+  fDAQch = -1;
+
+  fPM = NULL;
+  fFEB = NULL;
+  fTRB = NULL;
+  fTOMBChannel = NULL;
 }
 
 JPetSigCh::JPetSigCh(EdgeType Edge, float EdgeTime) {
-  Init();
+  init();
   /// @todo: perform some sanity checks of the given values
   assert(EdgeTime > 0.);
 
@@ -53,4 +59,8 @@ bool JPetSigCh::compareByThresholdNumber(const JPetSigCh& A,
     return true;
   }
   return false;
+}
+
+void JPetSigCh::Clear(Option_t *){
+  init();
 }

--- a/JPetSigCh/JPetSigCh.h
+++ b/JPetSigCh/JPetSigCh.h
@@ -44,7 +44,7 @@ public:
   const static float kUnset;
 
   JPetSigCh() {
-    Init();
+    init();
   }
   JPetSigCh(EdgeType Edge, float EdgeTime);
   ~JPetSigCh() {
@@ -177,6 +177,8 @@ public:
    */
   static bool compareByThresholdNumber(const JPetSigCh & A,
                                        const JPetSigCh & B);
+
+  void Clear(Option_t * = "");
   
   ClassDef(JPetSigCh, 6);
   
@@ -193,7 +195,7 @@ protected:
   TRef fTRB;
   TRef fTOMBChannel;
   
-  void Init();
+  void init();
 };
 
 #endif

--- a/JPetSimplePhysSignalReco/JPetSimplePhysSignalReco.cpp
+++ b/JPetSimplePhysSignalReco/JPetSimplePhysSignalReco.cpp
@@ -35,11 +35,7 @@ JPetSimplePhysSignalReco::~JPetSimplePhysSignalReco()
 }
 
 void JPetSimplePhysSignalReco::exec()
-{
-  // Get a Reco Signal
-  //  auto currSignal = (JPetRecoSignal&) (*getEvent());
-  //  savePhysSignal(createPhysSignal(currSignal));
-}
+{}
 
 void JPetSimplePhysSignalReco::savePhysSignal(JPetPhysSignal sig)
 {

--- a/JPetSimplePhysSignalReco/JPetSimplePhysSignalReco.cpp
+++ b/JPetSimplePhysSignalReco/JPetSimplePhysSignalReco.cpp
@@ -37,8 +37,8 @@ JPetSimplePhysSignalReco::~JPetSimplePhysSignalReco()
 void JPetSimplePhysSignalReco::exec()
 {
   // Get a Reco Signal
-  auto currSignal = (JPetRecoSignal&) (*getEvent());
-  savePhysSignal(createPhysSignal(currSignal));
+  //  auto currSignal = (JPetRecoSignal&) (*getEvent());
+  //  savePhysSignal(createPhysSignal(currSignal));
 }
 
 void JPetSimplePhysSignalReco::savePhysSignal(JPetPhysSignal sig)

--- a/JPetSimplePhysSignalReco/JPetSimplePhysSignalReco.h
+++ b/JPetSimplePhysSignalReco/JPetSimplePhysSignalReco.h
@@ -30,7 +30,6 @@ public:
 
   virtual void exec();
   virtual void terminate();
-  virtual void setWriter(JPetWriter* writer) {fWriter =writer;}
   inline int getAlpha() const { return fAlpha; }
   inline float getThresholdSel() const { return fThresholdSel; }
   inline void setAlpha(int val) { fAlpha = val; }

--- a/JPetTask/JPetTask.cpp
+++ b/JPetTask/JPetTask.cpp
@@ -22,7 +22,8 @@ JPetTask::JPetTask(const char* name, const char* description):
   fEvent(0),
   fParamManager(0),
   fStatistics(0),
-  fAuxilliaryData(0)
+  fAuxilliaryData(0),
+  fOutputEvents(0)
 {
 }
 

--- a/JPetTask/JPetTask.h
+++ b/JPetTask/JPetTask.h
@@ -15,6 +15,7 @@
 
 #ifndef JPETTASK_H
 #define JPETTASK_H
+#include "../JPetTimeWindow/JPetTimeWindow.h"
 #include "../JPetTaskInterface/JPetTaskInterface.h"
 #include "../JPetParamBank/JPetParamBank.h"
 #include "../JPetStatistics/JPetStatistics.h"
@@ -50,11 +51,16 @@ public:
     return fName.GetTitle();
   }
 
+  virtual JPetTimeWindow * getOutputEvents(){
+    return fOutputEvents;
+  }
+  
 protected:
   TNamed fName;
   TObject* fEvent;
   JPetParamManager* fParamManager;
   JPetStatistics* fStatistics;
   JPetAuxilliaryData* fAuxilliaryData;
+  JPetTimeWindow * fOutputEvents;
 };
 #endif /*  !JPETTASK_H */

--- a/JPetTask/JPetTask.h
+++ b/JPetTask/JPetTask.h
@@ -35,7 +35,6 @@ public:
   virtual void setParamManager(JPetParamManager* paramManager) override;
   virtual void setStatistics(JPetStatistics* statistics);
   virtual void setAuxilliaryData(JPetAuxilliaryData* auxData);
-  virtual void setWriter(JPetWriter*) {};
   virtual void setEvent(TObject* ev);
   const JPetParamBank& getParamBank();
   JPetStatistics& getStatistics();

--- a/JPetTaskIO/JPetTaskIO.cpp
+++ b/JPetTaskIO/JPetTaskIO.cpp
@@ -177,9 +177,7 @@ void JPetTaskIO::createOutputObjects(const char* outputFilename)
   fWriter = new JPetWriter( outputFilename );
   assert(fWriter);
   if (fTask) {
-    //auto task = std::dynamic_pointer_cast<JPetTask>(fTask);
     auto task = dynamic_cast<JPetTask*>(fTask);
-    task->setWriter(fWriter);
     if (!fAuxilliaryData) {
       fAuxilliaryData = new JPetAuxilliaryData();
     }

--- a/JPetTaskIO/JPetTaskIO.cpp
+++ b/JPetTaskIO/JPetTaskIO.cpp
@@ -71,7 +71,9 @@ void JPetTaskIO::exec()
     if (fOptions.isProgressBar()) {
       displayProgressBar(i, lastEvent);
     }
+    (dynamic_cast<JPetTask*>(fTask))->getOutputEvents()->Clear();
     fTask->exec();
+    fWriter->write(*((dynamic_cast<JPetTask*>(fTask))->getOutputEvents()));
     fReader->nextEvent();
   }
   fTask->terminate();

--- a/JPetTimeWindow/JPetTimeWindow.cpp
+++ b/JPetTimeWindow/JPetTimeWindow.cpp
@@ -15,9 +15,4 @@
 
 #include "JPetTimeWindow.h"
 
-void JPetTimeWindow::addCh(JPetSigCh& new_ch)
-{
-  fSigChannels.push_back( JPetSigCh(new_ch) );
-}
-
 ClassImp(JPetTimeWindow);

--- a/JPetTimeWindow/JPetTimeWindow.h
+++ b/JPetTimeWindow/JPetTimeWindow.h
@@ -31,6 +31,11 @@ class JPetTimeWindow: public TObject
 {
 public:
 
+  JPetTimeWindow() : fEvents() {
+    SetName("JPetTimeWindow");
+    std::cout << "TW default contructor called" << "\n";
+  }
+  
   JPetTimeWindow(const char * event_type) : fEvents(event_type, 2000) {
     SetName("JPetTimeWindow");
     std::cout << "TW contructor called" << "\n";
@@ -43,7 +48,6 @@ public:
   template<typename T>
   void Add(T & evt){
     new (fEvents[fEventCount++]) T(evt);
-    fEventCount++;
   }
   
   inline size_t getNumberOfEvents() const {
@@ -64,6 +68,11 @@ public:
     fEventCount = 0;
   }
 
+  virtual void Clear() {
+    fEvents.Clear();
+    fEventCount = 0;
+  }
+  
   ClassDef(JPetTimeWindow, 3);
 
 private:

--- a/JPetTimeWindow/JPetTimeWindow.h
+++ b/JPetTimeWindow/JPetTimeWindow.h
@@ -46,7 +46,7 @@ public:
   }
   
   template<typename T>
-  void Add(T & evt){
+  void add(const T & evt){
     new (fEvents[fEventCount++]) T(evt);
   }
   

--- a/JPetTimeWindow/JPetTimeWindow.h
+++ b/JPetTimeWindow/JPetTimeWindow.h
@@ -39,7 +39,7 @@ public:
   
   template<typename T>
   void add(const T & evt){
-    new (fEvents[fEventCount++]) T(evt);
+    dynamic_cast<T&>(*(fEvents.ConstructedAt(fEventCount++))) = evt;
   }
   
   inline size_t getNumberOfEvents() const {
@@ -56,12 +56,12 @@ public:
   }
 
   virtual ~JPetTimeWindow() {
-    fEvents.Clear();
+    fEvents.Clear("C");
     fEventCount = 0;
   }
 
   virtual void Clear() {
-    fEvents.Clear();
+    fEvents.Clear("C");
     fEventCount = 0;
   }
   

--- a/JPetTimeWindow/JPetTimeWindow.h
+++ b/JPetTimeWindow/JPetTimeWindow.h
@@ -31,19 +31,11 @@ class JPetTimeWindow: public TObject
 {
 public:
 
-  JPetTimeWindow() : fEvents() {
-    SetName("JPetTimeWindow");
-    std::cout << "TW default contructor called" << "\n";
-  }
+  JPetTimeWindow() : fEvents()
+  {}
   
-  JPetTimeWindow(const char * event_type) : fEvents(event_type, 2000) {
-    SetName("JPetTimeWindow");
-    std::cout << "TW contructor called" << "\n";
-  }
-
-  JPetTimeWindow(const JPetTimeWindow &){
-    std::cout << "TW COPY contructor called" << "\n";
-  }
+  JPetTimeWindow(const char * event_type) : fEvents(event_type, 2000)
+  {}
   
   template<typename T>
   void add(const T & evt){

--- a/JPetTimeWindow/JPetTimeWindowTest.cpp
+++ b/JPetTimeWindow/JPetTimeWindowTest.cpp
@@ -3,16 +3,8 @@
 #include <boost/test/unit_test.hpp>
 
 #include "../JPetSigCh/JPetSigCh.h"
+#include "../JPetHit/JPetHit.h"
 #include "../JPetTimeWindow/JPetTimeWindow.h"
-
-
-
-
-/// @todo update methods tests are outdated
-//#include <TError.h> /// gErrorIgnoreLevel
-//  gErrorIgnoreLevel = 7000;
-
-
 
 
 BOOST_AUTO_TEST_SUITE(FirstSuite)
@@ -20,31 +12,37 @@ BOOST_AUTO_TEST_SUITE(FirstSuite)
 BOOST_AUTO_TEST_CASE( default_constructor )
 {
   JPetTimeWindow test;
-  BOOST_REQUIRE(test.getNumberOfSigCh() == 0);
-  BOOST_REQUIRE(test.getSigChVect().size() == 0);
+  BOOST_REQUIRE(test.getNumberOfEvents() == 0);
 
 }
 
 BOOST_AUTO_TEST_CASE( some_channels )
 {
-  JPetTimeWindow test;
+  JPetTimeWindow test("JPetSigCh");
   JPetSigCh ch_test(JPetSigCh::Trailing, 1.2), ch_test2(JPetSigCh::Leading, 1.5), ch_test3(JPetSigCh::Leading, 98);
-  test.addCh(ch_test);
-  test.addCh(ch_test2);
-  test.addCh(ch_test3);
+  test.add<JPetSigCh>(ch_test);
+  test.add<JPetSigCh>(ch_test2);
+  test.add<JPetSigCh>(ch_test3);
 
-  BOOST_REQUIRE(test.getNumberOfSigCh() == 3);
-  BOOST_REQUIRE(test.getSigChVect().size() == 3);
+  BOOST_REQUIRE_EQUAL(test.getNumberOfEvents(), 3);
   double epsilon = 0.001;
-  BOOST_REQUIRE_CLOSE(test[0].getValue(), 1.2, epsilon);
-  BOOST_REQUIRE_CLOSE(test[1].getValue(), 1.5, epsilon);
-  BOOST_REQUIRE_CLOSE(test[2].getValue(), 98, epsilon);
+  BOOST_REQUIRE_CLOSE((dynamic_cast<const JPetSigCh&>(test[0])).getValue(), 1.2, epsilon);
+  BOOST_REQUIRE_CLOSE(test.getEvent<JPetSigCh>(1).getValue(), 1.5, epsilon);
+  BOOST_REQUIRE_CLOSE(test.getEvent<JPetSigCh>(2).getValue(), 98, epsilon);
 
-  const std::vector<JPetSigCh> array = test.getSigChVect();
-  BOOST_REQUIRE_CLOSE((array.at(0)).getValue(), 1.2, epsilon);
-  BOOST_REQUIRE_CLOSE((array.at(1)).getValue(), 1.5, epsilon);
-  BOOST_REQUIRE_CLOSE((array.at(2)).getValue(), 98, epsilon);
+}
 
+BOOST_AUTO_TEST_CASE( clearing )
+{
+  JPetTimeWindow test("JPetHit");
+  JPetHit hit1;
+  JPetHit hit2;
+  test.add<JPetHit>(hit1);
+  test.add<JPetHit>(hit2);
+  BOOST_REQUIRE_EQUAL(test.getNumberOfEvents(), 2);
+
+  test.Clear();
+  BOOST_REQUIRE_EQUAL(test.getNumberOfEvents(), 0);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/JPetWriter/JPetWriterTest.cpp
+++ b/JPetWriter/JPetWriterTest.cpp
@@ -131,7 +131,7 @@ BOOST_AUTO_TEST_CASE( saving_different_objects2 )
   const auto kHugeNumberOfObjects = 10000;
   for (int i = 0; i < kHugeNumberOfObjects; i++) {
     if (i % 1000 == 0) std::cout << "*" << std::flush;
-    JPetTimeWindow testJPetTimeWindow;
+    JPetTimeWindow testJPetTimeWindow("JPetSigCh");
     writer.write(testJPetTimeWindow);
   }
   writer.closeFile();

--- a/version.h.in
+++ b/version.h.in
@@ -1,5 +1,5 @@
 /**
- *  @copyright Copyright 2016 The J-PET Framework Authors. All rights reserved.
+ *  @copyright Copyright 2017 The J-PET Framework Authors. All rights reserved.
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may find a copy of the License in the LICENCE file.


### PR DESCRIPTION
In this scheme:
 - all tasks read the relevant data objects in a TimeWindow container rather than one-by-one
 - tasks are independent of JPetWriter (as they were only from JPetReader before) - they only produce a TimeWindow, which is read out by higher0level classes like TaskIO
 - TimeWindow is implemented as a TClonerArray and using its optimizations
 - execution time of the LargeBarrelAnalysisExtended analysis chain is improved by more than 2x

To be merged only after PR #104 (I will try to keep this version rebased).

**NOTE:**
This changes break the interface for analysis modules and require all of the existing modules to be modified. A version of the examples which works with this Framework version is available here:
https://github.com/alekgajos/j-pet-framework-examples/tree/timeWindow

