### PR TITLE
Change name of test file used for develop version

### DIFF
--- a/JPetReader/JPetReaderTest.cpp
+++ b/JPetReader/JPetReaderTest.cpp
@@ -71,7 +71,7 @@ BOOST_AUTO_TEST_CASE (bad_file)
 
 BOOST_AUTO_TEST_CASE (good_file_with_constructor)
 {
-  JPetReader reader("unitTestData/JPetReaderTest/timewindows.root");
+  JPetReader reader("unitTestData/JPetReaderTest/timewindows_v2.root");
   BOOST_REQUIRE(reader.isOpen());
   BOOST_REQUIRE(std::string(reader.getCurrentEvent().GetName())==std::string("JPetTimeWindow"));
   BOOST_REQUIRE(reader.nextEvent());
@@ -83,9 +83,10 @@ BOOST_AUTO_TEST_CASE (good_file_with_constructor)
   BOOST_REQUIRE_EQUAL(reader.getNbOfAllEvents(), 10);
   BOOST_REQUIRE(reader.getHeaderClone());
 }
+
 BOOST_AUTO_TEST_CASE (good_file_getObject)
 {
-  JPetReader reader("unitTestData/JPetReaderTest/timewindows.root");
+  JPetReader reader("unitTestData/JPetReaderTest/timewindows_v2.root");
   BOOST_REQUIRE(!reader.getObjectFromFile("nonExistentObj"));
   BOOST_REQUIRE(reader.getObjectFromFile("tree"));
 }
@@ -93,7 +94,7 @@ BOOST_AUTO_TEST_CASE (good_file_getObject)
 BOOST_AUTO_TEST_CASE (good_file_openFileAndLoadData)
 {
   JPetReader reader;
-  BOOST_REQUIRE(reader.openFileAndLoadData("unitTestData/JPetReaderTest/timewindows.root","tree"));
+  BOOST_REQUIRE(reader.openFileAndLoadData("unitTestData/JPetReaderTest/timewindows_v2.root","tree"));
   BOOST_REQUIRE(reader.isOpen());
   BOOST_REQUIRE(std::string(reader.getCurrentEvent().GetName())==std::string("JPetTimeWindow"));
   BOOST_REQUIRE(reader.firstEvent());
@@ -110,7 +111,7 @@ BOOST_AUTO_TEST_CASE (good_file_openFileAndLoadData)
 BOOST_AUTO_TEST_CASE (good_file_closeFile)
 {
   JPetReader reader;
-  BOOST_REQUIRE(reader.openFileAndLoadData("unitTestData/JPetReaderTest/timewindows.root","tree"));
+  BOOST_REQUIRE(reader.openFileAndLoadData("unitTestData/JPetReaderTest/timewindows_v2.root","tree"));
   BOOST_REQUIRE(reader.isOpen());
   reader.closeFile();
   BOOST_REQUIRE(!reader.isOpen());


### PR DESCRIPTION
This PR only changes the name of a data file referenced by the JPetReader UT so that a new file can be used for tests without breaking tests for the master branch which still need the old file.