### PR TITLE
Fix JPetOptionsTools functions returning pointer to local variable

### DIFF
--- a/Core/JPetTaskIO/JPetTaskIO.cpp
+++ b/Core/JPetTaskIO/JPetTaskIO.cpp
@@ -222,15 +222,15 @@ void JPetTaskIO::setOptions(const JPetParams& opts)
 JPetParamManager& JPetTaskIO::getParamManager()
 {
   DEBUG("JPetTaskIO");
-   auto paramManager = fParams.getParamManager();
-   static JPetParamManager NullManager(true);
-   if (paramManager) {
-     DEBUG("JPetParamManger returning normal parammanager");
-     return *paramManager;
-   } else {
-     DEBUG("JPetParamManger returning NullManager ");
-     return NullManager;
- }
+  auto paramManager = fParams.getParamManager();
+  static JPetParamManager NullManager(true);
+  if (paramManager) {
+    DEBUG("JPetParamManger returning normal parammanager");
+    return *paramManager;
+  } else {
+    DEBUG("JPetParamManger returning NullManager ");
+    return NullManager;
+  }
 }
 
 bool JPetTaskIO::createInputObjects(const char* inputFilename)
@@ -247,7 +247,7 @@ bool JPetTaskIO::createInputObjects(const char* inputFilename)
       fHeader->setFrameworkRevision(FRAMEWORK_REVISION);
 
       // add general info to the Tree header
-      fHeader->setBaseFileName(getInputFile(options));
+      fHeader->setBaseFileName(getInputFile(options).c_str());
 
     } else {
       auto paramManager = fParams.getParamManager();

--- a/Options/JPetOptionsTools/JPetOptionsTools.cpp
+++ b/Options/JPetOptionsTools/JPetOptionsTools.cpp
@@ -119,29 +119,29 @@ std::vector<std::string> getInputFiles(const std::map<std::string, boost::any>& 
   return any_cast<std::vector<std::string>>(opts.at("file_std::vector<std::string>"));
 }
 
-const char* getInputFile(const std::map<std::string, boost::any>& opts)
+std::string getInputFile(const std::map<std::string, boost::any>& opts)
 {
-  return any_cast<std::string>(opts.at("inputFile_std::string")).c_str();
+  return any_cast<std::string>(opts.at("inputFile_std::string"));
 }
 
-const char* getScopeConfigFile(const std::map<std::string, boost::any>& opts)
+std::string getScopeConfigFile(const std::map<std::string, boost::any>& opts)
 {
-  return any_cast<std::string>(opts.at("scopeConfigFile_std::string")).c_str();
+  return any_cast<std::string>(opts.at("scopeConfigFile_std::string"));
 }
 
-const char* getScopeInputDirectory(const std::map<std::string, boost::any>& opts)
+std::string getScopeInputDirectory(const std::map<std::string, boost::any>& opts)
 {
-  return any_cast<std::string>(opts.at("scopeInputDirectory_std::string")).c_str();
+  return any_cast<std::string>(opts.at("scopeInputDirectory_std::string"));
 }
 
-const char* getOutputFile(const std::map<std::string, boost::any>& opts)
+std::string getOutputFile(const std::map<std::string, boost::any>& opts)
 {
-  return any_cast<std::string>(opts.at("outputFile_std::string")).c_str();
+  return any_cast<std::string>(opts.at("outputFile_std::string"));
 }
 
-const char* getOutputPath(const std::map<std::string, boost::any>& opts)
+std::string getOutputPath(const std::map<std::string, boost::any>& opts)
 {
-  return any_cast<std::string>(opts.at("outputPath_std::string")).c_str();
+  return any_cast<std::string>(opts.at("outputPath_std::string"));
 }
 
 long long getFirstEvent(const std::map<std::string, boost::any>& opts)
@@ -202,14 +202,14 @@ std::string getLocalDBCreate(const std::map<std::string, boost::any>& opts)
   return result;
 }
 
-const char* getUnpackerConfigFile(const std::map<std::string, boost::any>& opts)
+std::string getUnpackerConfigFile(const std::map<std::string, boost::any>& opts)
 {
-  return any_cast<std::string>(opts.at("unpackerConfigFile_std::string")).c_str();
+  return any_cast<std::string>(opts.at("unpackerConfigFile_std::string"));
 }
 
-const char* getUnpackerCalibFile(const std::map<std::string, boost::any>& opts)
+std::string getUnpackerCalibFile(const std::map<std::string, boost::any>& opts)
 {
-  return any_cast<std::string>(opts.at("unpackerCalibFile_std::string")).c_str();
+  return any_cast<std::string>(opts.at("unpackerCalibFile_std::string"));
 }
 
 std::string getConfigFileName(const std::map<std::string, boost::any>& optsMap)

--- a/Options/JPetOptionsTools/JPetOptionsTools.h
+++ b/Options/JPetOptionsTools/JPetOptionsTools.h
@@ -51,11 +51,11 @@ std::vector<std::string> getInputFiles(const OptsStrAny& opts);
 
 /// This function returns a valid result only if the inputFile option is given
 /// in the transformed form with _std::string suffix
-const char* getInputFile(const OptsStrAny& opts);
-const char* getScopeConfigFile(const OptsStrAny& opts);
-const char* getScopeInputDirectory(const OptsStrAny& opts);
-const char* getOutputFile(const OptsStrAny& opts);
-const char* getOutputPath(const OptsStrAny& opts);
+std::string getInputFile(const OptsStrAny& opts);
+std::string getScopeConfigFile(const OptsStrAny& opts);
+std::string getScopeInputDirectory(const OptsStrAny& opts);
+std::string getOutputFile(const OptsStrAny& opts);
+std::string getOutputPath(const OptsStrAny& opts);
 long long getFirstEvent(const OptsStrAny& opts);
 long long getLastEvent(const OptsStrAny& opts);
 
@@ -72,8 +72,8 @@ bool isLocalDB(const OptsStrAny& opts);
 std::string getLocalDB(const OptsStrAny& opts);
 bool isLocalDBCreate(const OptsStrAny& opts);
 std::string getLocalDBCreate(const OptsStrAny& opts);
-const char* getUnpackerConfigFile(const OptsStrAny& opts);
-const char* getUnpackerCalibFile(const OptsStrAny& opts);
+std::string getUnpackerConfigFile(const OptsStrAny& opts);
+std::string getUnpackerCalibFile(const OptsStrAny& opts);
 std::string getConfigFileName(const OptsStrAny& optsMap);
 
 void printOptions(const OptsStrAny& opts);

--- a/Tasks/JPetParamBankHandlerTask/JPetParamBankHandlerTask.cpp
+++ b/Tasks/JPetParamBankHandlerTask/JPetParamBankHandlerTask.cpp
@@ -99,7 +99,7 @@ bool JPetParamBankHandlerTask::generateParamBankFromRootFile(const JPetParams& p
   }
 
   JPetReader fReader;
-  fReader.openFileAndLoadData(getInputFile(options));
+  fReader.openFileAndLoadData(getInputFile(options).c_str());
   auto paramMgr = params.getParamManager();
 
   return paramMgr->readParametersFromFile(&fReader);

--- a/Tasks/JPetScopeLoader/JPetScopeLoader.cpp
+++ b/Tasks/JPetScopeLoader/JPetScopeLoader.cpp
@@ -65,7 +65,7 @@ bool JPetScopeLoader::createInputObjects(const char*)
     assert(fStatistics);
     fHeader = new JPetTreeHeader(getRunNumber(opts));
     assert(fHeader);
-    fHeader->setBaseFileName(getInputFile(opts));
+    fHeader->setBaseFileName(getInputFile(opts).c_str());
     fHeader->addStageInfo(task->getName(), "", 0, JPetCommonTools::getTimeString());
   }
   return true;

--- a/Tasks/JPetUnzipAndUnpackTask/JPetUnzipAndUnpackTask.cpp
+++ b/Tasks/JPetUnzipAndUnpackTask/JPetUnzipAndUnpackTask.cpp
@@ -35,10 +35,10 @@ bool JPetUnzipAndUnpackTask::init(const JPetParamsInterface& inOptions)
 bool JPetUnzipAndUnpackTask::run(const JPetDataInterface&)
 {
   using namespace jpet_options_tools;
-  auto inputFile = std::string(getInputFile(fOptions));
+  auto inputFile = getInputFile(fOptions);
   auto inputFileType = FileTypeChecker::getInputFileType(fOptions);
-  auto unpackerConfigFile = std::string(getUnpackerConfigFile(fOptions));
-  auto unpackerCalibFile = std::string(getUnpackerCalibFile(fOptions));
+  auto unpackerConfigFile = getUnpackerConfigFile(fOptions);
+  auto unpackerCalibFile = getUnpackerCalibFile(fOptions);
 
   if (inputFileType == FileTypeChecker::kHld) {
     unpackFile(inputFile, getTotalEvents(fOptions), unpackerConfigFile, unpackerCalibFile);
@@ -60,7 +60,7 @@ bool JPetUnzipAndUnpackTask::run(const JPetDataInterface&)
   }
 
   if (FileTypeChecker::getInputFileType(fOptions) == FileTypeChecker::kUndefinedFileType) {
-    ERROR( Form("Unknown file type provided for file: %s", getInputFile(fOptions)) );
+    ERROR( Form("Unknown file type provided for file: %s", getInputFile(fOptions).c_str()) );
     return false;
   }
   return true;


### PR DESCRIPTION
Fix issue with JPetOptionsTools functions returning pointers to local std::string variables.