### PR TITLE
Change CUSTOM_LOG macro to single line

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,9 @@ find_package(Boost 1.50.0 REQUIRED COMPONENTS
   unit_test_framework
   log_setup
   log
+  date_time
+  thread
+  chrono
   )
 
 message(STATUS "Boost_INCLUDE_DIRS: ${Boost_INCLUDE_DIRS}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,8 @@ if(ROOT_FOUND AND NOT ROOT_VERSION VERSION_LESS "6.0")
   message(FATAL_ERROR "ROOT 6.0 is not compatible")
 endif()
 
-add_definitions(-DBOOST_LOG_DYN_LINK)
+set(BOOST_LOG_DYN_LINK -DBOOST_LOG_DYN_LINK)
+add_definitions(${BOOST_LOG_DYN_LINK})
 find_package(Boost 1.50.0 REQUIRED COMPONENTS
   filesystem
   program_options
@@ -248,16 +249,11 @@ if(has_parent)
     ${framework_include}
     PARENT_SCOPE
     )
-  set(Framework_DEFINITIONS
-    ${ROOT_DEFINITIONS}
-    ${Boost_DEFINITIONS}
-    PARENT_SCOPE
-    )
+  list(APPEND Framework_DEFINITIONS "${BOOST_LOG_DYN_LINK} ${ROOT_DEFINITIONS}")
   # ensure that projects use C++11 too
   if(NOT MSVC)
     set(Framework_DEFINITIONS
-      -std=c++11
-      ${Framework_DEFINITIONS}
+      "-std=c++11 ${Framework_DEFINITIONS}"
       PARENT_SCOPE
       )
   endif()

--- a/Core/JPetLoggerInclude.h
+++ b/Core/JPetLoggerInclude.h
@@ -26,17 +26,17 @@
 #endif
 
 // see http://www.cs.technion.ac.il/users/yechiel/c++-faq/macros-with-multi-stmts.html
-#define CUSTOM_LOG(logger, sev, X)                \
- if(true)                                         \
- {                                                \
-   BOOST_LOG_SEV(logger, sev)                     \
-   << boost::log::add_value("Line", __LINE__)     \
-   << boost::log::add_value("File", __FILE__)     \
-   << boost::log::add_value("Function", __func__) \
-    << X;                                         \
-}                                                 \
-else                                              \
-  (void)0
+#define CUSTOM_LOG(logger, sev, X)                 \
+  if(true)                                         \
+  {                                                \
+    BOOST_LOG_SEV(logger, sev)                     \
+    << boost::log::add_value("Line", __LINE__)     \
+    << boost::log::add_value("File", __FILE__)     \
+    << boost::log::add_value("Function", __func__) \
+    << X;                                          \
+  }                                                \
+  else                                             \
+    (void)0
 
 #define INFO(X) CUSTOM_LOG(JPetLogger::getSeverity(), boost::log::trivial::info, X)
 #define WARNING(X) CUSTOM_LOG(JPetLogger::getSeverity(), boost::log::trivial::warning, X)

--- a/Core/JPetLoggerInclude.h
+++ b/Core/JPetLoggerInclude.h
@@ -25,7 +25,18 @@
 #include <boost/log/attributes/scoped_attribute.hpp>    //for BOOST_LOG_SCOPED_THREAD_TAG
 #endif
 
-#define CUSTOM_LOG(logger, sev, X) BOOST_LOG_SEV(logger, sev) << boost::log::add_value("Line", __LINE__) << boost::log::add_value("File", __FILE__) << boost::log::add_value("Function", __func__) << X;
+// see http://www.cs.technion.ac.il/users/yechiel/c++-faq/macros-with-multi-stmts.html
+#define CUSTOM_LOG(logger, sev, X)                \
+ if(true)                                         \
+ {                                                \
+   BOOST_LOG_SEV(logger, sev)                     \
+   << boost::log::add_value("Line", __LINE__)     \
+   << boost::log::add_value("File", __FILE__)     \
+   << boost::log::add_value("Function", __func__) \
+    << X;                                         \
+}                                                 \
+else                                              \
+  (void)0
 
 #define INFO(X) CUSTOM_LOG(JPetLogger::getSeverity(), boost::log::trivial::info, X)
 #define WARNING(X) CUSTOM_LOG(JPetLogger::getSeverity(), boost::log::trivial::warning, X)

--- a/Core/JPetLoggerInclude.h
+++ b/Core/JPetLoggerInclude.h
@@ -25,14 +25,7 @@
 #include <boost/log/attributes/scoped_attribute.hpp>    //for BOOST_LOG_SCOPED_THREAD_TAG
 #endif
 
-#define CUSTOM_LOG(logger, sev, X)                                       \
-{                                                                        \
-  BOOST_LOG_SEV(logger, sev)                                             \
-  << boost::log::add_value("Line", __LINE__)                             \
-  << boost::log::add_value("File", __FILE__)                             \
-  << boost::log::add_value("Function", __func__)                         \
-  << X;                                                                  \
-}
+#define CUSTOM_LOG(logger, sev, X) BOOST_LOG_SEV(logger, sev) << boost::log::add_value("Line", __LINE__) << boost::log::add_value("File", __FILE__) << boost::log::add_value("Function", __func__) << X;
 
 #define INFO(X) CUSTOM_LOG(JPetLogger::getSeverity(), boost::log::trivial::info, X)
 #define WARNING(X) CUSTOM_LOG(JPetLogger::getSeverity(), boost::log::trivial::warning, X)


### PR DESCRIPTION
Small fix for single line without brackets statements (e.g. for, if, while).
Also fixing exporting Framework_DEFINITIONS to parent scope, not sure why, but old version exported only -std=c++11 definition
Also add explicit three BOOST packages to cmake