### PR TITLE
Change JPetEvent::getHits to return a reference

### DIFF
--- a/DataObjects/JPetEvent/JPetEvent.cpp
+++ b/DataObjects/JPetEvent/JPetEvent.cpp
@@ -44,7 +44,7 @@ void JPetEvent::addHit(const JPetHit& hit)
   fHits.push_back(hit);
 }
 
-std::vector<JPetHit> JPetEvent::getHits() const
+const std::vector<JPetHit>& JPetEvent::getHits() const
 {
   return fHits;
 }

--- a/DataObjects/JPetEvent/JPetEvent.h
+++ b/DataObjects/JPetEvent/JPetEvent.h
@@ -43,7 +43,7 @@ public:
   JPetEvent();
   JPetEvent(const std::vector<JPetHit>& hits, JPetEventType eventType = JPetEventType::kUnknown, bool orderedByTime = true);
 
-  std::vector<JPetHit> getHits() const;
+  const std::vector<JPetHit>& getHits() const;
   void setHits(const std::vector<JPetHit>& hits, bool orderedByTime = true);
   void addHit(const JPetHit& hit);
 


### PR DESCRIPTION
instead of a copy of vector with hits. In some cases
it lead to a bug when an empty vector was returned.