### PR TITLE
Universal CMake configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,7 @@ foreach(dir ${FOLDERS_WITH_SOURCE})
 endforeach()
 
 list(APPEND FOLDERS ${CMAKE_CURRENT_SOURCE_DIR}) # for include to dictionaries for unpacker2
+list(APPEND FOLDERS ${Boost_INCLUDE_DIRS}) # add boost includes to dictionaries
 
 ##download test files
 # the script shouldn't do anything if the data is present and correct

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,30 +17,32 @@ if(NOT MSVC)
   add_definitions(-std=c++11 -Wall -Wunused-parameter)
 endif()
 
-foreach(mode QUIET REQUIRED)
-  find_package(ROOT 5 ${mode} COMPONENTS
-    Hist
-    Physics
-    RIO
-    Thread
-    Tree
-    )
-  if(ROOT_USE_FILE)
-    include(${ROOT_USE_FILE})
-  endif()
-  if(ROOT_FOUND)
-    break()
-  endif()
+################################################################################
+# Handling of ROOT 
+################################################################################
+
+# first, try the old-school ROOTSYS variable
+set(root_prefix $ENV{ROOTSYS})
+if(root_prefix)
+  list(APPEND CMAKE_MODULE_PATH ${root_prefix})  
+endif()
+
+find_package(ROOT QUIET)
+
+if(NOT ROOT_FOUND)
   # if we failed with CMake based find_package, use fallback
   # root-config version from cmake/fallback/
   list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/fallback)
-endforeach()
+  message(WARNING "No CMake modules from a ROOT installation found. Trying fallback mode.")
+endif()
+
+find_package(ROOT ${REQUIRED})
+
+if(ROOT_USE_FILE)
+  include(${ROOT_USE_FILE})
+endif()
 
 message(STATUS "ROOT version: ${ROOT_VERSION}")
-
-if(ROOT_FOUND AND NOT ROOT_VERSION VERSION_LESS "6.0")
-  message(FATAL_ERROR "ROOT 6.0 is not compatible")
-endif()
 
 set(BOOST_LOG_DYN_LINK -DBOOST_LOG_DYN_LINK)
 add_definitions(${BOOST_LOG_DYN_LINK})
@@ -193,6 +195,11 @@ target_link_libraries(JPetFramework
   Unpacker2
   ${ROOT_LIBRARIES}
   ${Boost_LIBRARIES}
+  )
+
+# handle the ROOT's *.pcm files in case they were generated not in the buld dir
+add_custom_command(TARGET JPetFramework POST_BUILD
+  COMMAND cp ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/Dictionaries/*.pcm ${CMAKE_CURRENT_BINARY_DIR}
   )
 
 # read the version from git tag and git revision

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,9 +24,9 @@ endif()
 ################################################################################
 
 # first, try the old-school ROOTSYS variable
-set(root_prefix $ENV{ROOTSYS}/etc/cmake/)
+set(root_prefix $ENV{ROOTSYS})
 if(root_prefix)
-  list(APPEND CMAKE_MODULE_PATH ${root_prefix})  
+  list(APPEND CMAKE_MODULE_PATH ${root_prefix}/etc/cmake/)  
 endif()
 
 find_package(ROOT QUIET)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,9 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 include(JPetFramework-Utilities) # for generate_root_dictionaries
 
 project(JPetFramework CXX C) # using only C++
+
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pthread")
+
 # enable C++11 and warnings
 if(NOT MSVC)
   add_definitions(-std=c++11 -Wall -Wunused-parameter)
@@ -199,7 +201,7 @@ target_link_libraries(JPetFramework
 
 # handle the ROOT's *.pcm files in case they were generated not in the buld dir
 add_custom_command(TARGET JPetFramework POST_BUILD
-  COMMAND cp ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/Dictionaries/*.pcm ${CMAKE_CURRENT_BINARY_DIR}
+  COMMAND if [ -e ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/Dictionaries/*.pcm ]\;then mv ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/Dictionaries/*.pcm ${CMAKE_CURRENT_BINARY_DIR}\;fi
   )
 
 # read the version from git tag and git revision
@@ -275,4 +277,8 @@ if(has_parent)
   set(ROOTCINT_EXECUTABLE ${ROOTCINT_EXECUTABLE} PARENT_SCOPE)
   # export ROOT rpath needed for OS X
   set(ROOT_LIBRARY_DIR    ${ROOT_LIBRARY_DIR}    PARENT_SCOPE)
+
+  set(CMAKE_EXE_LINKER_FLAGS ${CMAKE_EXE_LINKER_FLAGS} PARENT_SCOPE)
 endif()
+
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,9 +200,20 @@ target_link_libraries(JPetFramework
   )
 
 # handle the ROOT's *.pcm files in case they were generated not in the buld dir
-add_custom_command(TARGET JPetFramework POST_BUILD
-  COMMAND if [ -e ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/Dictionaries/*.pcm ]\;then mv ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/Dictionaries/*.pcm ${CMAKE_CURRENT_BINARY_DIR}\;fi
-  )
+find_program(SHELL bash)
+
+if(SHELL)
+  set(pcm_script ${CMAKE_CURRENT_BINARY_DIR}/move_pcm.sh)
+  
+  FILE(WRITE ${pcm_script}  "#!${SHELL}\n")
+  FILE(APPEND ${pcm_script} "for f in ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/Dictionaries/*.pcm; do\n")
+  FILE(APPEND ${pcm_script} "[ -e \$f ] && mv \$f ${CMAKE_CURRENT_BINARY_DIR}\n")
+  FILE(APPEND ${pcm_script} "done\n")
+  
+  add_custom_command(TARGET JPetFramework POST_BUILD
+    COMMAND ${SHELL}  ${pcm_script}
+    )
+endif(SHELL)
 
 # read the version from git tag and git revision
 exec_program(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,7 +209,8 @@ if(SHELL)
   FILE(APPEND ${pcm_script} "for f in ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/Dictionaries/*.pcm; do\n")
   FILE(APPEND ${pcm_script} "[ -e \$f ] && mv \$f ${CMAKE_CURRENT_BINARY_DIR}\n")
   FILE(APPEND ${pcm_script} "done\n")
-  
+  FILE(APPEND ${pcm_script} "return 0\n")
+
   add_custom_command(TARGET JPetFramework POST_BUILD
     COMMAND ${SHELL}  ${pcm_script}
     )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ endif()
 ################################################################################
 
 # first, try the old-school ROOTSYS variable
-set(root_prefix $ENV{ROOTSYS})
+set(root_prefix $ENV{ROOTSYS}/etc/cmake/)
 if(root_prefix)
   list(APPEND CMAKE_MODULE_PATH ${root_prefix})  
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,22 +29,27 @@ if(root_prefix)
   list(APPEND CMAKE_MODULE_PATH ${root_prefix}/etc/cmake/)  
 endif()
 
+# try also a search based on root-config
+execute_process(COMMAND root-config --etcdir OUTPUT_VARIABLE ROOT_ETCDIR OUTPUT_STRIP_TRAILING_WHITESPACE)
+list(APPEND CMAKE_MODULE_PATH ${ROOT_ETCDIR}/cmake)
+
 find_package(ROOT QUIET)
 
-if(NOT ROOT_FOUND)
+if(ROOT_FOUND)
+  message(STATUS "Found ROOT version: ${ROOT_VERSION} (${ROOT_CONFIG_EXECUTABLE})")
+else()
   # if we failed with CMake based find_package, use fallback
   # root-config version from cmake/fallback/
   list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/fallback)
   message(WARNING "No CMake modules from a ROOT installation found. Trying fallback mode.")
+  find_package(ROOT 5 REQUIRED)
 endif()
-
-find_package(ROOT ${REQUIRED})
 
 if(ROOT_USE_FILE)
   include(${ROOT_USE_FILE})
 endif()
 
-message(STATUS "ROOT version: ${ROOT_VERSION}")
+message(STATUS "ROOT version: ")
 
 set(BOOST_LOG_DYN_LINK -DBOOST_LOG_DYN_LINK)
 add_definitions(${BOOST_LOG_DYN_LINK})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,7 +209,7 @@ if(SHELL)
   FILE(APPEND ${pcm_script} "for f in ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/Dictionaries/*.pcm; do\n")
   FILE(APPEND ${pcm_script} "[ -e \$f ] && mv \$f ${CMAKE_CURRENT_BINARY_DIR}\n")
   FILE(APPEND ${pcm_script} "done\n")
-  FILE(APPEND ${pcm_script} "return 0\n")
+  FILE(APPEND ${pcm_script} "exit 0\n")
 
   add_custom_command(TARGET JPetFramework POST_BUILD
     COMMAND ${SHELL}  ${pcm_script}

--- a/Options/JPetOptionValidator/JPetOptionValidator.h
+++ b/Options/JPetOptionValidator/JPetOptionValidator.h
@@ -18,6 +18,7 @@
 
 #include <map>
 #include <string>
+#include <vector>
 #include <boost/any.hpp>
 
 /**

--- a/Options/JPetOptionsGenerator/JPetOptionsTypeHandler.h
+++ b/Options/JPetOptionsGenerator/JPetOptionsTypeHandler.h
@@ -17,6 +17,7 @@
 #define JPETOPTIONSTYPEHANDLER_H
 
 #include <map>
+#include <vector>
 #include <string>
 #include <boost/any.hpp>
 

--- a/Options/JPetOptionsTools/JPetOptionsTools.h
+++ b/Options/JPetOptionsTools/JPetOptionsTools.h
@@ -16,6 +16,7 @@
 #ifndef JPETOPTIONSTOOLS_H
 #define JPETOPTIONSTOOLS_H
 #include <map>
+#include <vector>
 #include <boost/any.hpp>
 #include "./JPetOptionsTools/JPetOptionsTransformators.h"
 

--- a/cmake/JPetFramework-Utilities.cmake
+++ b/cmake/JPetFramework-Utilities.cmake
@@ -45,9 +45,7 @@ function(generate_root_dictionaries OUT_VAR)
       set(dictionary
         ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/Dictionaries/${name}Dictionary)
       set_directory_properties(PROPERTIES INCLUDE_DIRECTORIES "${ARG_INCLUDE_DIRS};/")
-      string(REGEX REPLACE ^/ "" header "${header}")
       if(EXISTS ${linkdef})
-        string(REGEX REPLACE ^/ "" linkdef "${linkdef}")
         root_generate_dictionary(${dictionary} ${header}
           LINKDEF ${linkdef}
           OPTIONS -p


### PR DESCRIPTION
The new CMake configuration should correctly find ROOT CMake modules independently of whether ROOT was build with autotools or with CMake. The fallback ROOTConfig.cmake module included in the framework should now be used only if no ROOTSYS nor CMake-related env variables are present (i.e. practically only in case of ROOT installed from a system repository).

Besides CMake changes, compilation with g++ 8 required adding includes for std::vector in a few places where it is used and exporting the "-pthread" linker flag to parent scope to correctly build the examples. 