### PR TITLE
 Add option to print different levels of log

### DIFF
--- a/Core/JPetLogger/JPetLogger.cpp
+++ b/Core/JPetLogger/JPetLogger.cpp
@@ -14,13 +14,11 @@
  */
 
 #include "./JPetLogger.h"
-#include <boost/log/utility/record_ordering.hpp>
 
 JPetLogger::JPetLogger() { init(); }
 
 void JPetLogger::init() {
-  sink = boost::make_shared<sink_t>();
-  sink->locked_backend()->add_stream(boost::make_shared<std::ofstream>(generateFilename()));
+  sink = boost::make_shared<sink_t>(boost::log::keywords::file_name = "JPet_%Y-%m-%d_%H-%M-%S.%N.log", boost::log::keywords::auto_flush = true);
   sink->set_formatter(&JPetLogger::formatter);
   boost::log::core::get()->add_sink(sink);
   boost::log::add_common_attributes();
@@ -44,8 +42,4 @@ void JPetLogger::formatter(boost::log::record_view const& rec, boost::log::forma
 boost::log::sources::severity_logger<boost::log::trivial::severity_level>& JPetLogger::getSeverity() {
   static boost::log::sources::severity_logger<boost::log::trivial::severity_level> sev;
   return sev;
-}
-
-const std::string JPetLogger::generateFilename() {
-  return std::string("JPet_") + to_string(boost::uuids::random_generator()()) + std::string(".log");
 }

--- a/Core/JPetLogger/JPetLogger.cpp
+++ b/Core/JPetLogger/JPetLogger.cpp
@@ -14,3 +14,38 @@
  */
 
 #include "./JPetLogger.h"
+#include <boost/log/utility/record_ordering.hpp>
+
+JPetLogger::JPetLogger() { init(); }
+
+void JPetLogger::init() {
+  sink = boost::make_shared<sink_t>();
+  sink->locked_backend()->add_stream(boost::make_shared<std::ofstream>(generateFilename()));
+  sink->set_formatter(&JPetLogger::formatter);
+  boost::log::core::get()->add_sink(sink);
+  boost::log::add_common_attributes();
+  boost::log::core::get()->set_filter(boost::log::trivial::severity >= boost::log::trivial::info);
+}
+
+void JPetLogger::setLogLevel(boost::log::trivial::severity_level level) { sink->set_filter(boost::log::trivial::severity >= level); }
+
+void JPetLogger::formatter(boost::log::record_view const& rec, boost::log::formatting_ostream& out_stream) {
+  boost::log::value_ref<std::string> fullpath = boost::log::extract<std::string>("File", rec);
+  boost::log::value_ref<std::string> fullfunction = boost::log::extract<std::string>("Function", rec);
+  out_stream << boost::log::extract<unsigned int>("LineID", rec) << ": [";
+  out_stream << boost::filesystem::path(fullpath.get()).filename().string() << ":";
+  out_stream << fullfunction << "@";
+  out_stream << boost::log::extract<int>("Line", rec) << "] ";
+  out_stream << "ThreadID: " << boost::log::extract<boost::log::attributes::current_thread_id::value_type>("ThreadID", rec) << " ";
+  out_stream << "<" << rec[boost::log::trivial::severity] << "> ";
+  out_stream << rec[boost::log::expressions::smessage];
+}
+
+boost::log::sources::severity_logger<boost::log::trivial::severity_level>& JPetLogger::getSeverity() {
+  static boost::log::sources::severity_logger<boost::log::trivial::severity_level> sev;
+  return sev;
+}
+
+const std::string JPetLogger::generateFilename() {
+  return std::string("JPet_") + to_string(boost::uuids::random_generator()()) + std::string(".log");
+}

--- a/Core/JPetLogger/JPetLogger.cpp
+++ b/Core/JPetLogger/JPetLogger.cpp
@@ -14,5 +14,3 @@
  */
 
 #include "./JPetLogger.h"
-#include <cassert>
-#include <ctime>

--- a/Core/JPetLogger/JPetLogger.h
+++ b/Core/JPetLogger/JPetLogger.h
@@ -66,7 +66,7 @@ public:
     out_stream << rec[boost::log::expressions::smessage];
   }
 
-  inline static void setLogLevel(boost::log::trivial::severity_level level) { sink->set_filter(boost::log::trivial::severity >= level); }
+  inline static void setLogLevel(boost::log::trivial::severity_level level) { JPetLogger::sink->set_filter(boost::log::trivial::severity >= level); }
 #else
   static void getSeverity();
   static void formatter();

--- a/Core/JPetLogger/JPetLogger.h
+++ b/Core/JPetLogger/JPetLogger.h
@@ -44,33 +44,21 @@
 class JPetLogger {
 public:
 #ifndef __CINT__
-  inline static boost::log::sources::severity_logger<boost::log::trivial::severity_level>& getSeverity() {
-    static bool isInitialized = false;
-    if (!isInitialized) {
-      init();
-      isInitialized = true;
-    }
-    static boost::log::sources::severity_logger<boost::log::trivial::severity_level> sev;
-    return sev;
-  }
 
-  inline static void formatter(boost::log::record_view const& rec, boost::log::formatting_ostream& out_stream) {
-    boost::log::value_ref<std::string> fullpath = boost::log::extract<std::string>("File", rec);
-    boost::log::value_ref<std::string> fullfunction = boost::log::extract<std::string>("Function", rec);
-    out_stream << boost::log::extract<unsigned int>("LineID", rec) << ": [";
-    out_stream << boost::filesystem::path(fullpath.get()).filename().string() << ":";
-    out_stream << fullfunction << "@";
-    out_stream << boost::log::extract<int>("Line", rec) << "] ";
-    out_stream << "ThreadID: " << boost::log::extract<boost::log::attributes::current_thread_id::value_type>("ThreadID", rec) << " ";
-    out_stream << "<" << rec[boost::log::trivial::severity] << "> ";
-    out_stream << rec[boost::log::expressions::smessage];
-  }
+  boost::log::sources::severity_logger<boost::log::trivial::severity_level>& getSeverity();
 
-  inline static void setLogLevel(boost::log::trivial::severity_level level) { JPetLogger::sink->set_filter(boost::log::trivial::severity >= level); }
+  static void formatter(boost::log::record_view const& rec, boost::log::formatting_ostream& out_stream);
+
+  void setLogLevel(boost::log::trivial::severity_level level);
+
+  static JPetLogger& getInstance() {
+    static JPetLogger logger;
+    return logger;
+  }
 #else
-  static void getSeverity();
-  static void formatter();
-  static void setLogLevel();
+  void getSeverity();
+  void formatter();
+  void setLogLevel();
 #endif
 
 private:
@@ -80,22 +68,13 @@ private:
 
 #ifndef __CINT__
 
-  typedef boost::log::sinks::text_ostream_backend backend;
-  typedef boost::log::sinks::synchronous_sink<backend> text_sink;
-  static boost::shared_ptr<text_sink> sink;
+  typedef boost::log::sinks::text_ostream_backend backend_t;
+  typedef boost::log::sinks::synchronous_sink<backend_t> sink_t;
+  boost::shared_ptr<sink_t> sink;
 
-  inline static const std::string generateFilename() {
-    return std::string("JPet_") + to_string(boost::uuids::random_generator()()) + std::string(".log");
-  }
+  const std::string generateFilename();
 
-  inline static void init() {
-    JPetLogger::sink.reset(new text_sink(boost::make_shared<backend>()));
-    JPetLogger::sink->locked_backend()->add_stream(boost::make_shared<std::ofstream>(generateFilename()));
-    JPetLogger::sink->set_formatter(&JPetLogger::formatter);
-    boost::log::core::get()->add_sink(JPetLogger::sink);
-    boost::log::add_common_attributes();
-    boost::log::core::get()->set_filter(boost::log::trivial::severity >= boost::log::trivial::info);
-  }
+  void init();
 #endif
 };
 

--- a/Core/JPetLogger/JPetLogger.h
+++ b/Core/JPetLogger/JPetLogger.h
@@ -16,20 +16,20 @@
 #ifndef JPETLOGGER_H
 #define JPETLOGGER_H
 
+#include <fstream>
 #include <iostream>
 #include <ostream>
-#include <fstream>
 #include <string>
 
 #ifndef __CINT__
-#include <boost/log/utility/setup/common_attributes.hpp>
+#include <boost/log/core.hpp>
 #include <boost/log/sinks/text_ostream_backend.hpp>
+#include <boost/log/trivial.hpp>
+#include <boost/log/utility/setup/common_attributes.hpp>
 #include <boost/log/utility/setup/file.hpp>
+#include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
-#include <boost/log/trivial.hpp>
-#include <boost/uuid/uuid.hpp>
-#include <boost/log/core.hpp>
 #endif
 
 /**
@@ -41,69 +41,62 @@
  * that is multithread safe and implements own formatter.
 */
 
-class JPetLogger
-{
+class JPetLogger {
 public:
-  #ifndef __CINT__
-    inline static boost::log::sources::severity_logger<boost::log::trivial::severity_level>& getSeverity()
-    {
-      static bool isInitialized = false;
-      if (!isInitialized) {
-        init();
-        setLogLevel(boost::log::trivial::info);
-        isInitialized = true;
-      }
-      static boost::log::sources::severity_logger<boost::log::trivial::severity_level> sev;
-      return sev;
+#ifndef __CINT__
+  inline static boost::log::sources::severity_logger<boost::log::trivial::severity_level>& getSeverity() {
+    static bool isInitialized = false;
+    if (!isInitialized) {
+      init();
+      isInitialized = true;
     }
+    static boost::log::sources::severity_logger<boost::log::trivial::severity_level> sev;
+    return sev;
+  }
 
-    inline static void formatter(boost::log::record_view const& rec, boost::log::formatting_ostream& out_stream)
-    {
-      boost::log::value_ref<std::string> fullpath = boost::log::extract<std::string>("File", rec);
-      boost::log::value_ref<std::string> fullfunction = boost::log::extract<std::string>("Function", rec);
-      out_stream << boost::log::extract<unsigned int>("LineID", rec) << ": [";
-      out_stream << boost::filesystem::path(fullpath.get()).filename().string() << ":";
-      out_stream << fullfunction << "@";
-      out_stream << boost::log::extract<int>("Line", rec) << "] ";
-      out_stream << "ThreadID: " << boost::log::extract<boost::log::attributes::current_thread_id::value_type>("ThreadID", rec) << " ";
-      out_stream << "<" << rec[boost::log::trivial::severity] << "> ";
-      out_stream << rec[boost::log::expressions::smessage];
-    }
+  inline static void formatter(boost::log::record_view const& rec, boost::log::formatting_ostream& out_stream) {
+    boost::log::value_ref<std::string> fullpath = boost::log::extract<std::string>("File", rec);
+    boost::log::value_ref<std::string> fullfunction = boost::log::extract<std::string>("Function", rec);
+    out_stream << boost::log::extract<unsigned int>("LineID", rec) << ": [";
+    out_stream << boost::filesystem::path(fullpath.get()).filename().string() << ":";
+    out_stream << fullfunction << "@";
+    out_stream << boost::log::extract<int>("Line", rec) << "] ";
+    out_stream << "ThreadID: " << boost::log::extract<boost::log::attributes::current_thread_id::value_type>("ThreadID", rec) << " ";
+    out_stream << "<" << rec[boost::log::trivial::severity] << "> ";
+    out_stream << rec[boost::log::expressions::smessage];
+  }
 
-    inline static void setLogLevel(boost::log::trivial::severity_level level)
-    {
-      boost::log::core::get()->set_filter (
-        boost::log::trivial::severity >= level
-      );
-    }
-  #else
-    static void getSeverity();
-    static void formatter();
-    static void setLogLevel();
-  #endif
+  inline static void setLogLevel(boost::log::trivial::severity_level level) { sink->set_filter(boost::log::trivial::severity >= level); }
+#else
+  static void getSeverity();
+  static void formatter();
+  static void setLogLevel();
+#endif
 
 private:
   JPetLogger();
   JPetLogger(const JPetLogger&);
   JPetLogger& operator=(const JPetLogger&);
 
-  #ifndef __CINT__
-    inline static const std::string generateFilename()
-    {
-      return std::string("JPet_") + to_string(boost::uuids::random_generator()()) + std::string(".log");
-    }
+#ifndef __CINT__
 
-    inline static void init()
-    {
-      typedef boost::log::sinks::synchronous_sink<boost::log::sinks::text_ostream_backend> text_sink;
-      boost::shared_ptr<text_sink> sink = boost::make_shared<text_sink>();
-      sink->locked_backend()->add_stream(
-        boost::make_shared<std::ofstream>(generateFilename()));
-      sink->set_formatter(&JPetLogger::formatter);
-      boost::log::core::get()->add_sink(sink);
-      boost::log::add_common_attributes();
-    }
-  #endif
+  typedef boost::log::sinks::text_ostream_backend backend;
+  typedef boost::log::sinks::synchronous_sink<backend> text_sink;
+  static boost::shared_ptr<text_sink> sink;
+
+  inline static const std::string generateFilename() {
+    return std::string("JPet_") + to_string(boost::uuids::random_generator()()) + std::string(".log");
+  }
+
+  inline static void init() {
+    JPetLogger::sink.reset(new text_sink(boost::make_shared<backend>()));
+    JPetLogger::sink->locked_backend()->add_stream(boost::make_shared<std::ofstream>(generateFilename()));
+    JPetLogger::sink->set_formatter(&JPetLogger::formatter);
+    boost::log::core::get()->add_sink(JPetLogger::sink);
+    boost::log::add_common_attributes();
+    boost::log::core::get()->set_filter(boost::log::trivial::severity >= boost::log::trivial::info);
+  }
+#endif
 };
 
 #endif /* !JPETLOGGER_H */

--- a/Core/JPetLogger/JPetLogger.h
+++ b/Core/JPetLogger/JPetLogger.h
@@ -27,9 +27,6 @@
 #include <boost/log/trivial.hpp>
 #include <boost/log/utility/setup/common_attributes.hpp>
 #include <boost/log/utility/setup/file.hpp>
-#include <boost/uuid/uuid.hpp>
-#include <boost/uuid/uuid_generators.hpp>
-#include <boost/uuid/uuid_io.hpp>
 #endif
 
 /**
@@ -68,11 +65,8 @@ private:
 
 #ifndef __CINT__
 
-  typedef boost::log::sinks::text_ostream_backend backend_t;
-  typedef boost::log::sinks::synchronous_sink<backend_t> sink_t;
+  typedef boost::log::sinks::synchronous_sink<boost::log::sinks::text_file_backend> sink_t;
   boost::shared_ptr<sink_t> sink;
-
-  const std::string generateFilename();
 
   void init();
 #endif

--- a/Core/JPetLoggerInclude.h
+++ b/Core/JPetLoggerInclude.h
@@ -47,10 +47,10 @@
 #define DEBUG(X) CUSTOM_LOG(JPetLogger::getInstance().getSeverity(), boost::log::trivial::debug, X)
 #define LOG(X, sev) CUSTOM_LOG(JPetLogger::getInstance().getSevarity(), sev, X)
 
-#define SET_MINIMAL_LOG_ERROR JPetLogger::getInstance().setLogLevel(boost::log::trivial::error)     // prints only error messages
-#define SET_MINIMAL_LOG_WARNING JPetLogger::getInstance().setLogLevel(boost::log::trivial::warning) // prints error + warning messages
-#define SET_MINIMAL_LOG_INFO JPetLogger::getInstance().setLogLevel(boost::log::trivial::info)       // prints error + warning + info messages
-#define SET_MINIMAL_LOG_DEBUG JPetLogger::getInstance().setLogLevel(boost::log::trivial::debug)     // prints error + warning + info + debug messages
+#define SET_MINIMAL_LOG_ERROR() JPetLogger::getInstance().setLogLevel(boost::log::trivial::error)     // prints only error messages
+#define SET_MINIMAL_LOG_WARNING() JPetLogger::getInstance().setLogLevel(boost::log::trivial::warning) // prints error + warning messages
+#define SET_MINIMAL_LOG_INFO() JPetLogger::getInstance().setLogLevel(boost::log::trivial::info)       // prints error + warning + info messages
+#define SET_MINIMAL_LOG_DEBUG() JPetLogger::getInstance().setLogLevel(boost::log::trivial::debug) // prints error + warning + info + debug messages
 
 #define SET_MINIMAL_LOG_LEVEL(X) JPetLogger::getInstance().setLogLevel(X)
 

--- a/Core/JPetLoggerInclude.h
+++ b/Core/JPetLoggerInclude.h
@@ -16,7 +16,7 @@
  *  Also general macro is defined that allows to create user own level of logging.
  */
 
- /**
+/**
   * @brief Configuration file for the Logger class
   * Four independent level of logging are defined: INFO, WARNING, ERROR and DEBUG.
   * Also general macro is defined that allows to create user own level of logging.
@@ -34,16 +34,16 @@
 #include <boost/log/attributes/scoped_attribute.hpp>
 #endif
 
-#define CUSTOM_LOG(logger, sev, X)                 \
-  if(true)                                         \
-  {                                                \
-    BOOST_LOG_SEV(logger, sev)                     \
-    << boost::log::add_value("Line", __LINE__)     \
-    << boost::log::add_value("File", __FILE__)     \
-    << boost::log::add_value("Function", __func__) \
-    << X;                                          \
-  }                                                \
-  else                                             \
+#define CUSTOM_LOG(logger, sev, X)                     \
+  if (true)                                            \
+  {                                                    \
+    BOOST_LOG_SEV(logger, sev)                         \
+        << boost::log::add_value("Line", __LINE__)     \
+        << boost::log::add_value("File", __FILE__)     \
+        << boost::log::add_value("Function", __func__) \
+        << X;                                          \
+  }                                                    \
+  else                                                 \
     (void)0
 
 #define INFO(X) CUSTOM_LOG(JPetLogger::getSeverity(), boost::log::trivial::info, X)
@@ -51,6 +51,15 @@
 #define ERROR(X) CUSTOM_LOG(JPetLogger::getSeverity(), boost::log::trivial::error, X)
 #define DEBUG(X) CUSTOM_LOG(JPetLogger::getSeverity(), boost::log::trivial::debug, X)
 #define LOG(X, sev) CUSTOM_LOG(JPetLogger::getSevarity(), sev, X)
+
+#define SET_MINIMAL_LOG_ERROR setLogLevel(boost::log::trivial::error)     //prints only error messages
+#define SET_MINIMAL_LOG_WARNING setLogLevel(boost::log::trivial::warning) //prints error + warning messages
+#define SET_MINIMAL_LOG_INFO setLogLevel(boost::log::trivial::info)       //prints error + warning + info messages
+#define SET_MINIMAL_LOG_DEBUG setLogLevel(boost::log::trivial::debug)     //prints error + warning + info + debug messages
+
+#define SET_MINIMAL_LOG_LEVEL(X) setLogLevel(X)
+
+//for backward compability
 #define ENABLE_DEBUG setLogLevel(boost::log::trivial::debug)
 #define DISABLE_DEBUG setLogLevel(boost::log::trivial::info)
 

--- a/Core/JPetLoggerInclude.h
+++ b/Core/JPetLoggerInclude.h
@@ -30,37 +30,32 @@
 #include "./JPetLogger/JPetLogger.h"
 
 #ifndef __CINT__
-#include <boost/log/utility/manipulators/add_value.hpp>
 #include <boost/log/attributes/scoped_attribute.hpp>
+#include <boost/log/utility/manipulators/add_value.hpp>
 #endif
 
-#define CUSTOM_LOG(logger, sev, X)                     \
-  if (true)                                            \
-  {                                                    \
-    BOOST_LOG_SEV(logger, sev)                         \
-        << boost::log::add_value("Line", __LINE__)     \
-        << boost::log::add_value("File", __FILE__)     \
-        << boost::log::add_value("Function", __func__) \
-        << X;                                          \
-  }                                                    \
-  else                                                 \
-    (void)0
+#define CUSTOM_LOG(logger, sev, X)                                                                                                                   \
+  if (true) {                                                                                                                                        \
+    BOOST_LOG_SEV(logger, sev) << boost::log::add_value("Line", __LINE__) << boost::log::add_value("File", __FILE__)                                 \
+                               << boost::log::add_value("Function", __func__) << X;                                                                  \
+  } else                                                                                                                                             \
+  (void)0
 
-#define INFO(X) CUSTOM_LOG(JPetLogger::getSeverity(), boost::log::trivial::info, X)
-#define WARNING(X) CUSTOM_LOG(JPetLogger::getSeverity(), boost::log::trivial::warning, X)
-#define ERROR(X) CUSTOM_LOG(JPetLogger::getSeverity(), boost::log::trivial::error, X)
-#define DEBUG(X) CUSTOM_LOG(JPetLogger::getSeverity(), boost::log::trivial::debug, X)
-#define LOG(X, sev) CUSTOM_LOG(JPetLogger::getSevarity(), sev, X)
+#define INFO(X) CUSTOM_LOG(JPetLogger::getInstance().getSeverity(), boost::log::trivial::info, X)
+#define WARNING(X) CUSTOM_LOG(JPetLogger::getInstance().getSeverity(), boost::log::trivial::warning, X)
+#define ERROR(X) CUSTOM_LOG(JPetLogger::getInstance().getSeverity(), boost::log::trivial::error, X)
+#define DEBUG(X) CUSTOM_LOG(JPetLogger::getInstance().getSeverity(), boost::log::trivial::debug, X)
+#define LOG(X, sev) CUSTOM_LOG(JPetLogger::getInstance().getSevarity(), sev, X)
 
-#define SET_MINIMAL_LOG_ERROR setLogLevel(boost::log::trivial::error)     //prints only error messages
-#define SET_MINIMAL_LOG_WARNING setLogLevel(boost::log::trivial::warning) //prints error + warning messages
-#define SET_MINIMAL_LOG_INFO setLogLevel(boost::log::trivial::info)       //prints error + warning + info messages
-#define SET_MINIMAL_LOG_DEBUG setLogLevel(boost::log::trivial::debug)     //prints error + warning + info + debug messages
+#define SET_MINIMAL_LOG_ERROR JPetLogger::getInstance().setLogLevel(boost::log::trivial::error)     // prints only error messages
+#define SET_MINIMAL_LOG_WARNING JPetLogger::getInstance().setLogLevel(boost::log::trivial::warning) // prints error + warning messages
+#define SET_MINIMAL_LOG_INFO JPetLogger::getInstance().setLogLevel(boost::log::trivial::info)       // prints error + warning + info messages
+#define SET_MINIMAL_LOG_DEBUG JPetLogger::getInstance().setLogLevel(boost::log::trivial::debug)     // prints error + warning + info + debug messages
 
-#define SET_MINIMAL_LOG_LEVEL(X) setLogLevel(X)
+#define SET_MINIMAL_LOG_LEVEL(X) JPetLogger::getInstance().setLogLevel(X)
 
-//for backward compability
-#define ENABLE_DEBUG setLogLevel(boost::log::trivial::debug)
-#define DISABLE_DEBUG setLogLevel(boost::log::trivial::info)
+// for backward compability
+#define ENABLE_DEBUG JPetLogger::getInstance().setLogLevel(boost::log::trivial::debug)
+#define DISABLE_DEBUG JPetLogger::getInstance().setLogLevel(boost::log::trivial::info)
 
 #endif /* !JPETLOGGER_INCLUDE_H */

--- a/Core/JPetLoggerInclude.h
+++ b/Core/JPetLoggerInclude.h
@@ -20,8 +20,6 @@
   * @brief Configuration file for the Logger class
   * Four independent level of logging are defined: INFO, WARNING, ERROR and DEBUG.
   * Also general macro is defined that allows to create user own level of logging.
-  * See
-  * http://www.cs.technion.ac.il/users/yechiel/c++-faq/macros-with-multi-stmts.html
   */
 
 #ifndef JPETLOGGER_INCLUDE_H
@@ -34,6 +32,9 @@
 #include <boost/log/utility/manipulators/add_value.hpp>
 #endif
 
+/* Macro with multi-line statement
+ * See: http://www.cs.technion.ac.il/users/yechiel/c++-faq/macros-with-multi-stmts.html
+ */
 #define CUSTOM_LOG(logger, sev, X)                                                                                                                   \
   if (true) {                                                                                                                                        \
     BOOST_LOG_SEV(logger, sev) << boost::log::add_value("Line", __LINE__) << boost::log::add_value("File", __FILE__)                                 \
@@ -41,10 +42,21 @@
   } else                                                                                                                                             \
   (void)0
 
+/* To log information you should use macros INFO(X), WARNING(X), ERROR(X), DEBUG(X) or
+ * if you want to provie your own level of sevarity of message use macro LOG(X, sev).
+ *
+ * DO not use macro CUSTOM_LOG.
+ *
+ * Example usage: INFO("Log message");
+ *
+ * This message will be logged to file "JPet_%Y-%m-%d_%H-%M-%S.%N.log" if minimal log level is above or equal info.
+ *
+*/
 #define INFO(X) CUSTOM_LOG(JPetLogger::getInstance().getSeverity(), boost::log::trivial::info, X)
 #define WARNING(X) CUSTOM_LOG(JPetLogger::getInstance().getSeverity(), boost::log::trivial::warning, X)
 #define ERROR(X) CUSTOM_LOG(JPetLogger::getInstance().getSeverity(), boost::log::trivial::error, X)
 #define DEBUG(X) CUSTOM_LOG(JPetLogger::getInstance().getSeverity(), boost::log::trivial::debug, X)
+
 #define LOG(X, sev) CUSTOM_LOG(JPetLogger::getInstance().getSevarity(), sev, X)
 
 #define SET_MINIMAL_LOG_ERROR() JPetLogger::getInstance().setLogLevel(boost::log::trivial::error)     // prints only error messages

--- a/Core/JPetLoggerInclude.h
+++ b/Core/JPetLoggerInclude.h
@@ -33,6 +33,7 @@
 #endif
 
 /* Macro with multi-line statement
+ * DO not use directly, instead use INFO, WARNING, ERROR, DEBUG or LOG macros
  * See: http://www.cs.technion.ac.il/users/yechiel/c++-faq/macros-with-multi-stmts.html
  */
 #define CUSTOM_LOG(logger, sev, X)                                                                                                                   \
@@ -50,6 +51,19 @@
  * Example usage: INFO("Log message");
  *
  * This message will be logged to file "JPet_%Y-%m-%d_%H-%M-%S.%N.log" if minimal log level is above or equal info.
+ *
+ * To use LOG macro you need to define your own enum with severity levels e.g.:
+ *
+ * enum severity_level
+ * {
+ *   normal,
+ *   notification,
+ *   warning,
+ *   error,
+ *   critical
+ * };
+ *
+ * And then use it as LOG("Log message", critical);
  *
 */
 #define INFO(X) CUSTOM_LOG(JPetLogger::getInstance().getSeverity(), boost::log::trivial::info, X)


### PR DESCRIPTION
Add option to print different levels of log only or disable logging at all.
It is replacement of #182 because there was some problems with github and it didn't automatically update PR commits.

This PR is also removing uuid include and warnings: 
In file included from /framework-dependencies/include/boost/uuid/uuid.hpp:203:
/framework-dependencies/include/boost/uuid/detail/uuid_x86.hpp:42:5: warning: 'register' storage class specifier is deprecated and incompatible with C++1z [-Wdeprecated-register]
    register __m128i mm = uuids::detail::load_unaligned_si128(data);
    ^~~~~~~~~

and changing log output file name to: JPet_%Y-%m-%d_%H-%M-%S.%N.log (%N means number of log) e.g.: JPet_2018-07-16_19-50-05.0.log