### PR TITLE
New data class for reconstructed o-Ps->3 events

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,6 +160,7 @@ generate_root_dictionaries(DICTIONARIES SOURCES ${SOURCES}
   JPetUser
   JPetUnpacker
   JPetEvent
+  JPetOpsEvent
   JPetMCHit
   JPetTimeWindowMC
   JPetMCDecayTree

--- a/DataObjects/JPetOpsEvent/JPetOpsEvent.cpp
+++ b/DataObjects/JPetOpsEvent/JPetOpsEvent.cpp
@@ -33,27 +33,33 @@ JPetOpsEvent::JPetOpsEvent(const std::vector<JPetHit>& hits, JPetEventType event
 }
 
 
-void JPetOpsEvent::Clear(Option_t *){
+void JPetOpsEvent::Clear(Option_t*)
+{
   fType = kUnknown;
   fHits.clear();
 }
 
-void JPetOpsEvent::setAnnihilationPoint(double x, double y, double z){
-  setAnnihilationPoint(TVector3(x,y,z));
+void JPetOpsEvent::setAnnihilationPoint(double x, double y, double z)
+{
+  setAnnihilationPoint(TVector3(x, y, z));
 }
 
-void JPetOpsEvent::setAnnihilationPoint(const TVector3& point){
+void JPetOpsEvent::setAnnihilationPoint(const TVector3& point)
+{
   fAnnihilationPoint = point;
 }
 
-const TVector3& JPetOpsEvent::getAnnihilationPoint() const{
+const TVector3& JPetOpsEvent::getAnnihilationPoint() const
+{
   return fAnnihilationPoint;
 }
 
-void JPetOpsEvent::setAnnihilationTime(double t){
+void JPetOpsEvent::setAnnihilationTime(double t)
+{
   fAnnihilationTime = t;
 }
 
-double JPetOpsEvent::getAnnihilationTime() const{
+double JPetOpsEvent::getAnnihilationTime() const
+{
   return fAnnihilationTime;
 }

--- a/DataObjects/JPetOpsEvent/JPetOpsEvent.cpp
+++ b/DataObjects/JPetOpsEvent/JPetOpsEvent.cpp
@@ -1,0 +1,59 @@
+/**
+ *  @copyright Copyright 2018 The J-PET Framework Authors. All rights reserved.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may find a copy of the License in the LICENCE file.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  @file JPetOpsEvent.cpp
+ */
+
+#include "./JPetOpsEvent.h"
+
+ClassImp(JPetOpsEvent);
+
+JPetOpsEvent::JPetOpsEvent(): JPetEvent()
+{
+  /**/
+}
+
+JPetOpsEvent::JPetOpsEvent(const JPetEvent& event): JPetEvent(event)
+{
+  /**/
+}
+
+JPetOpsEvent::JPetOpsEvent(const std::vector<JPetHit>& hits, JPetEventType eventType, bool orderedByTime):
+  JPetEvent(hits, eventType, orderedByTime)
+{
+}
+
+
+void JPetOpsEvent::Clear(Option_t *){
+  fType = kUnknown;
+  fHits.clear();
+}
+
+void JPetOpsEvent::setAnnihilationPoint(double x, double y, double z){
+  setAnnihilationPoint(TVector3(x,y,z));
+}
+
+void JPetOpsEvent::setAnnihilationPoint(const TVector3& point){
+  fAnnihilationPoint = point;
+}
+
+const TVector3& JPetOpsEvent::getAnnihilationPoint() const{
+  return fAnnihilationPoint;
+}
+
+void JPetOpsEvent::setAnnihilationTime(double t){
+  fAnnihilationTime = t;
+}
+
+double JPetOpsEvent::getAnnihilationTime() const{
+  return fAnnihilationTime;
+}

--- a/DataObjects/JPetOpsEvent/JPetOpsEvent.h
+++ b/DataObjects/JPetOpsEvent/JPetOpsEvent.h
@@ -33,20 +33,20 @@ public:
   JPetOpsEvent(const JPetEvent& event);
   JPetOpsEvent(const std::vector<JPetHit>& hits, JPetEventType eventType = JPetEventType::kUnknown, bool orderedByTime = true);
 
-  void Clear(Option_t * opt = "");
+  void Clear(Option_t* opt = "");
 
   void setAnnihilationPoint(double x, double y, double z);
   void setAnnihilationPoint(const TVector3& point);
   void setAnnihilationTime(double t);
-  
+
   const TVector3& getAnnihilationPoint() const;
   double getAnnihilationTime() const;
-  
+
 protected:
 
   TVector3 fAnnihilationPoint;
   double fAnnihilationTime;
-  
+
   ClassDef(JPetOpsEvent, 1);
 };
 #endif /*  !JPETOPSEVENT_H */

--- a/DataObjects/JPetOpsEvent/JPetOpsEvent.h
+++ b/DataObjects/JPetOpsEvent/JPetOpsEvent.h
@@ -1,0 +1,52 @@
+/**
+ *  @copyright Copyright 2018 The J-PET Framework Authors. All rights reserved.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may find a copy of the License in the LICENCE file.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  @file JPetOpsEvent.h
+ *  @brief Class representing an event from a single o-Ps->3g annihilation.
+ */
+
+#ifndef JPETOPSEVENT_H
+#define JPETOPSEVENT_H
+
+#include "./JPetEvent/JPetEvent.h"
+
+/**
+ * @brief Data class representing an event from a single o-Ps->3g annihilation.
+ *
+ * Extends JPetEvent to contain the reconstructed annihilation point and time.
+ */
+
+class JPetOpsEvent : public JPetEvent
+{
+
+public:
+  JPetOpsEvent();
+  JPetOpsEvent(const JPetEvent& event);
+  JPetOpsEvent(const std::vector<JPetHit>& hits, JPetEventType eventType = JPetEventType::kUnknown, bool orderedByTime = true);
+
+  void Clear(Option_t * opt = "");
+
+  void setAnnihilationPoint(double x, double y, double z);
+  void setAnnihilationPoint(const TVector3& point);
+  void setAnnihilationTime(double t);
+  
+  const TVector3& getAnnihilationPoint() const;
+  double getAnnihilationTime() const;
+  
+protected:
+
+  TVector3 fAnnihilationPoint;
+  double fAnnihilationTime;
+  
+  ClassDef(JPetOpsEvent, 1);
+};
+#endif /*  !JPETOPSEVENT_H */

--- a/DataObjects/JPetOpsEvent/JPetOpsEventTest.cpp
+++ b/DataObjects/JPetOpsEvent/JPetOpsEventTest.cpp
@@ -90,7 +90,8 @@ BOOST_AUTO_TEST_CASE(annihilation_position_setter2)
 
 }
 
-BOOST_AUTO_TEST_CASE(annihilation_time){
+BOOST_AUTO_TEST_CASE(annihilation_time)
+{
 
   double epsilon = 0.0001;
   JPetOpsEvent event;
@@ -98,7 +99,7 @@ BOOST_AUTO_TEST_CASE(annihilation_time){
   event.setAnnihilationTime(t);
 
   BOOST_REQUIRE_CLOSE(event.getAnnihilationTime(), t, epsilon);
-  
+
 }
 
 

--- a/DataObjects/JPetOpsEvent/JPetOpsEventTest.cpp
+++ b/DataObjects/JPetOpsEvent/JPetOpsEventTest.cpp
@@ -1,0 +1,105 @@
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE JPetOpsEventTest
+#include <boost/test/unit_test.hpp>
+
+#include "./JPetWriter/JPetWriter.h"
+#include "./JPetEventTest/JPetEventTest.h"
+#include "./JPetLoggerInclude.h"
+
+
+BOOST_AUTO_TEST_SUITE(FirstSuite)
+BOOST_AUTO_TEST_CASE( default_constructor )
+{
+  JPetEvent event;
+  BOOST_REQUIRE(event.getHits().empty());
+}
+
+BOOST_AUTO_TEST_CASE(constructor)
+{
+
+  JPetBarrelSlot slot1(43, true, "", 0, 43);
+  JPetBarrelSlot slot2(44, true, "", 0, 44);
+  JPetHit firstHit;
+  JPetHit secondHit;
+  firstHit.setBarrelSlot(slot1);
+  secondHit.setBarrelSlot(slot2);
+  JPetOpsEvent event({firstHit, secondHit}, JPetEventType::kUnknown);
+
+  BOOST_REQUIRE(!event.getHits().empty());
+  BOOST_REQUIRE_EQUAL(event.getHits().size(), 2u);
+}
+
+BOOST_AUTO_TEST_CASE(constructor_orderedHits)
+{
+  std::vector<JPetHit> hits(4);
+  hits[0].setTime(2);
+  hits[1].setTime(1);
+  hits[2].setTime(4);
+  hits[3].setTime(3);
+  JPetOpsEvent event(hits, JPetEventType::kUnknown);
+  auto results = event.getHits();
+  BOOST_REQUIRE_EQUAL(results[0].getTime(), 1);
+  BOOST_REQUIRE_EQUAL(results[1].getTime(), 2);
+  BOOST_REQUIRE_EQUAL(results[2].getTime(), 3);
+  BOOST_REQUIRE_EQUAL(results[3].getTime(), 4);
+}
+
+BOOST_AUTO_TEST_CASE(constructor_unorderedHits)
+{
+  std::vector<JPetHit> hits(4);
+  hits[0].setTime(2);
+  hits[1].setTime(1);
+  hits[2].setTime(4);
+  hits[3].setTime(3);
+  JPetOpsEvent event(hits, JPetEventType::kUnknown, false);
+  auto results = event.getHits();
+  BOOST_REQUIRE_EQUAL(results[0].getTime(), 2);
+  BOOST_REQUIRE_EQUAL(results[1].getTime(), 1);
+  BOOST_REQUIRE_EQUAL(results[2].getTime(), 4);
+  BOOST_REQUIRE_EQUAL(results[3].getTime(), 3);
+}
+
+BOOST_AUTO_TEST_CASE(annihilation_position_setter1)
+{
+  double epsilon = 0.0001;
+  JPetOpsEvent event;
+  double x = 11.5;
+  double y = -20.1;
+  double z = 0.1;
+  event.setAnninihationPoint(x, y, z);
+
+  BOOST_REQUIRE_CLOSE(event.getAnnihilationPoint().X(), x, epsilon );
+  BOOST_REQUIRE_CLOSE(event.getAnnihilationPoint().Y(), y, epsilon );
+  BOOST_REQUIRE_CLOSE(event.getAnnihilationPoint().Z(), z, epsilon );
+
+}
+
+BOOST_AUTO_TEST_CASE(annihilation_position_setter2)
+{
+  double epsilon = 0.0001;
+  JPetOpsEvent event;
+  double x = 11.5;
+  double y = -20.1;
+  double z = 0.1;
+  TVector3 vec(x, y, z);
+  event.setAnninihationPoint(vec);
+
+  BOOST_REQUIRE_CLOSE(event.getAnnihilationPoint().X(), x, epsilon );
+  BOOST_REQUIRE_CLOSE(event.getAnnihilationPoint().Y(), y, epsilon );
+  BOOST_REQUIRE_CLOSE(event.getAnnihilationPoint().Z(), z, epsilon );
+
+}
+
+BOOST_AUTO_TEST_CASE(annihilation_time){
+
+  double epsilon = 0.0001;
+  JPetOpsEvent event;
+  double t = 43.21;
+  event.setAnnihilationTime(t);
+
+  BOOST_REQUIRE_CLOSE(event.getAnnihilationTime(), t, epsilon);
+  
+}
+
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/DataObjects/JPetOpsEvent/JPetOpsEventTest.cpp
+++ b/DataObjects/JPetOpsEvent/JPetOpsEventTest.cpp
@@ -3,7 +3,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include "./JPetWriter/JPetWriter.h"
-#include "./JPetEventTest/JPetEventTest.h"
+#include "./JPetOpsEvent/JPetOpsEvent.h"
 #include "./JPetLoggerInclude.h"
 
 
@@ -66,7 +66,7 @@ BOOST_AUTO_TEST_CASE(annihilation_position_setter1)
   double x = 11.5;
   double y = -20.1;
   double z = 0.1;
-  event.setAnninihationPoint(x, y, z);
+  event.setAnnihilationPoint(x, y, z);
 
   BOOST_REQUIRE_CLOSE(event.getAnnihilationPoint().X(), x, epsilon );
   BOOST_REQUIRE_CLOSE(event.getAnnihilationPoint().Y(), y, epsilon );
@@ -82,7 +82,7 @@ BOOST_AUTO_TEST_CASE(annihilation_position_setter2)
   double y = -20.1;
   double z = 0.1;
   TVector3 vec(x, y, z);
-  event.setAnninihationPoint(vec);
+  event.setAnnihilationPoint(vec);
 
   BOOST_REQUIRE_CLOSE(event.getAnnihilationPoint().X(), x, epsilon );
   BOOST_REQUIRE_CLOSE(event.getAnnihilationPoint().Y(), y, epsilon );


### PR DESCRIPTION
Necessary for analysis of o-Ps->3g in data of runs with extensive-size annihilation chambers.
The new class extends JPetEvent to contain the reconstructed annihilation point and time.

To be considered after #190.