### PR TITLE
Unpacker-related user options

### DIFF
--- a/Core/JPetUnpacker/JPetUnpacker.cpp
+++ b/Core/JPetUnpacker/JPetUnpacker.cpp
@@ -19,7 +19,7 @@
 #include <cassert>
 
 JPetUnpacker::JPetUnpacker(): fUnpacker(0), fEventsToProcess(0), fHldFile(""),
-			      fCfgFile(""), fTOTCalibFile(""), fTDCCalibFile("") {}
+  fCfgFile(""), fTOTCalibFile(""), fTDCCalibFile("") {}
 
 JPetUnpacker::~JPetUnpacker()
 {
@@ -30,8 +30,8 @@ JPetUnpacker::~JPetUnpacker()
 }
 
 void JPetUnpacker::setParams(const std::string& hldFile, int numOfEvents,
-			     const std::string& cfgFile, const std::string& totCalibFile,
-			     const std::string& tdcCalibFile)
+                             const std::string& cfgFile, const std::string& totCalibFile,
+                             const std::string& tdcCalibFile)
 {
   fHldFile = hldFile;
   fCfgFile = cfgFile;
@@ -50,15 +50,15 @@ bool JPetUnpacker::exec()
     ERROR("The config file doesnt exist");
     return false;
   }
-  if (getTOTCalibFile()!="" && !boost::filesystem::exists(getTOTCalibFile())) {
+  if (getTOTCalibFile() != "" && !boost::filesystem::exists(getTOTCalibFile())) {
     ERROR("The provided calibration file with TOT stretcher offsets does not exist");
     return false;
   }
-  if (getTDCCalibFile()!="" && !boost::filesystem::exists(getTDCCalibFile())) {
+  if (getTDCCalibFile() != "" && !boost::filesystem::exists(getTDCCalibFile())) {
     ERROR("The provided file with TDC nonlinearity calibration does not exist");
     return false;
   }
-  if(getEventsToProcess() <= 0) {
+  if (getEventsToProcess() <= 0) {
     ERROR("No events to process");
     return false;
   }
@@ -69,8 +69,8 @@ bool JPetUnpacker::exec()
   fUnpacker = new Unpacker2();
   int refChannelOffset = 65;
   fUnpacker->UnpackSingleStep(fHldFile.c_str(), fCfgFile.c_str(),
-			      fEventsToProcess, refChannelOffset,
-			      fTOTCalibFile.c_str(), fTDCCalibFile.c_str()
-  );
+                              fEventsToProcess, refChannelOffset,
+                              fTOTCalibFile.c_str(), fTDCCalibFile.c_str()
+                             );
   return true;
 }

--- a/Core/JPetUnpacker/JPetUnpacker.cpp
+++ b/Core/JPetUnpacker/JPetUnpacker.cpp
@@ -18,8 +18,6 @@
 #include "./JPetUnpacker.h"
 #include <cassert>
 
-ClassImp(JPetUnpacker);
-
 JPetUnpacker::JPetUnpacker(): fUnpacker(0), fEventsToProcess(0), fHldFile(""),
 			      fCfgFile(""), fTOTCalibFile(""), fTDCCalibFile("") {}
 

--- a/Core/JPetUnpacker/JPetUnpacker.cpp
+++ b/Core/JPetUnpacker/JPetUnpacker.cpp
@@ -21,7 +21,7 @@
 ClassImp(JPetUnpacker);
 
 JPetUnpacker::JPetUnpacker(): fUnpacker(0), fEventsToProcess(0), fHldFile(""),
-  fCfgFile(""), fCalibFile("") {}
+			      fCfgFile(""), fTOTCalibFile(""), fTDCCalibFile("") {}
 
 JPetUnpacker::~JPetUnpacker()
 {
@@ -32,11 +32,13 @@ JPetUnpacker::~JPetUnpacker()
 }
 
 void JPetUnpacker::setParams(const std::string& hldFile, int numOfEvents,
-   const std::string& cfgFile, const std::string& calibFile)
+			     const std::string& cfgFile, const std::string& totCalibFile,
+			     const std::string& tdcCalibFile)
 {
   fHldFile = hldFile;
   fCfgFile = cfgFile;
-  fCalibFile = calibFile;
+  fTOTCalibFile = totCalibFile;
+  fTDCCalibFile = tdcCalibFile;
   fEventsToProcess = numOfEvents;
 }
 
@@ -50,8 +52,12 @@ bool JPetUnpacker::exec()
     ERROR("The config file doesnt exist");
     return false;
   }
-  if (getCalibFile()!="" && !boost::filesystem::exists(getCalibFile())) {
-    ERROR("The provided calib file doesnt exist");
+  if (getTOTCalibFile()!="" && !boost::filesystem::exists(getTOTCalibFile())) {
+    ERROR("The provided calibration file with TOT stretcher offsets does not exist");
+    return false;
+  }
+  if (getTDCCalibFile()!="" && !boost::filesystem::exists(getTDCCalibFile())) {
+    ERROR("The provided file with TDC nonlinearity calibration does not exist");
     return false;
   }
   if(getEventsToProcess() <= 0) {
@@ -65,7 +71,8 @@ bool JPetUnpacker::exec()
   fUnpacker = new Unpacker2();
   int refChannelOffset = 65;
   fUnpacker->UnpackSingleStep(fHldFile.c_str(), fCfgFile.c_str(),
-    fEventsToProcess, refChannelOffset, fCalibFile.c_str()
+			      fEventsToProcess, refChannelOffset,
+			      fTOTCalibFile.c_str(), fTDCCalibFile.c_str()
   );
   return true;
 }

--- a/Core/JPetUnpacker/JPetUnpacker.cpp
+++ b/Core/JPetUnpacker/JPetUnpacker.cpp
@@ -18,9 +18,6 @@
 #include "./JPetUnpacker.h"
 #include <cassert>
 
-JPetUnpacker::JPetUnpacker(): fUnpacker(0), fEventsToProcess(0), fHldFile(""),
-  fCfgFile(""), fTOTCalibFile(""), fTDCCalibFile("") {}
-
 JPetUnpacker::~JPetUnpacker()
 {
   if (fUnpacker) {

--- a/Core/JPetUnpacker/JPetUnpacker.h
+++ b/Core/JPetUnpacker/JPetUnpacker.h
@@ -33,11 +33,14 @@ public:
   inline int getEventsToProcess() const { return fEventsToProcess; }
   inline std::string getHldFile() const { return fHldFile; }
   inline std::string getCfgFile() const { return fCfgFile; }
-  inline std::string getCalibFile() const { return fCalibFile; }
+  inline std::string getTOTCalibFile() const { return fTOTCalibFile; }
+  inline std::string getTDCCalibFile() const { return fTDCCalibFile; }
   void setParams(const std::string& hldFile,
                  int numOfEvents = 100000000,
                  const std::string& cfgFile = "conf_trb3.xml",
-                 const std::string& calibFile = "");
+                 const std::string& totCalibFile = "",
+		 const std::string& tdcCalibFile = ""
+		 );
 
   ClassDef(JPetUnpacker, 2);
 
@@ -46,7 +49,8 @@ private:
   int fEventsToProcess;
   std::string fHldFile;
   std::string fCfgFile;
-  std::string fCalibFile;
+  std::string fTOTCalibFile;
+  std::string fTDCCalibFile;
 };
 
 #endif /* !_JPETUNPACKER_H_ */

--- a/Core/JPetUnpacker/JPetUnpacker.h
+++ b/Core/JPetUnpacker/JPetUnpacker.h
@@ -27,7 +27,6 @@ class Unpacker2;
 class JPetUnpacker: public TObject
 {
 public:
-  JPetUnpacker();
   ~JPetUnpacker();
   bool exec();
   inline int getEventsToProcess() const
@@ -58,12 +57,12 @@ public:
                 );
 
 private:
-  Unpacker2* fUnpacker;
-  int fEventsToProcess;
-  std::string fHldFile;
-  std::string fCfgFile;
-  std::string fTOTCalibFile;
-  std::string fTDCCalibFile;
+  Unpacker2* fUnpacker = nullptr;
+  int fEventsToProcess = 0;
+  std::string fHldFile = "";
+  std::string fCfgFile = "";
+  std::string fTOTCalibFile = "";
+  std::string fTDCCalibFile = "";
 };
 
 #endif /* !_JPETUNPACKER_H_ */

--- a/Core/JPetUnpacker/JPetUnpacker.h
+++ b/Core/JPetUnpacker/JPetUnpacker.h
@@ -42,8 +42,6 @@ public:
 		 const std::string& tdcCalibFile = ""
 		 );
 
-  ClassDef(JPetUnpacker, 2);
-
 private:
   Unpacker2* fUnpacker;
   int fEventsToProcess;

--- a/Core/JPetUnpacker/JPetUnpacker.h
+++ b/Core/JPetUnpacker/JPetUnpacker.h
@@ -30,17 +30,32 @@ public:
   JPetUnpacker();
   ~JPetUnpacker();
   bool exec();
-  inline int getEventsToProcess() const { return fEventsToProcess; }
-  inline std::string getHldFile() const { return fHldFile; }
-  inline std::string getCfgFile() const { return fCfgFile; }
-  inline std::string getTOTCalibFile() const { return fTOTCalibFile; }
-  inline std::string getTDCCalibFile() const { return fTDCCalibFile; }
+  inline int getEventsToProcess() const
+  {
+    return fEventsToProcess;
+  }
+  inline std::string getHldFile() const
+  {
+    return fHldFile;
+  }
+  inline std::string getCfgFile() const
+  {
+    return fCfgFile;
+  }
+  inline std::string getTOTCalibFile() const
+  {
+    return fTOTCalibFile;
+  }
+  inline std::string getTDCCalibFile() const
+  {
+    return fTDCCalibFile;
+  }
   void setParams(const std::string& hldFile,
                  int numOfEvents = 100000000,
                  const std::string& cfgFile = "conf_trb3.xml",
                  const std::string& totCalibFile = "",
-		 const std::string& tdcCalibFile = ""
-		 );
+                 const std::string& tdcCalibFile = ""
+                );
 
 private:
   Unpacker2* fUnpacker;

--- a/Core/JPetUnpacker/JPetUnpackerTest.cpp
+++ b/Core/JPetUnpacker/JPetUnpackerTest.cpp
@@ -39,18 +39,20 @@ BOOST_AUTO_TEST_CASE( my_test )
   BOOST_REQUIRE(unpack.getEventsToProcess() == 0);
   BOOST_REQUIRE(unpack.getHldFile() == "");
   BOOST_REQUIRE(unpack.getCfgFile() == "");
-  BOOST_REQUIRE(unpack.getCalibFile() == "");
+  BOOST_REQUIRE(unpack.getTOTCalibFile() == "");
+  BOOST_REQUIRE(unpack.getTDCCalibFile() == "");
   BOOST_REQUIRE(!unpack.exec());
 }
 
 BOOST_AUTO_TEST_CASE( my_test2 )
 {
   JPetUnpacker unpack;
-  unpack.setParams("test.hld", 10, "conf_test.xml", "calib.root");
+  unpack.setParams("test.hld", 10, "conf_test.xml", "calib.root", "calib2.root");
   BOOST_REQUIRE(unpack.getEventsToProcess() == 10);
   BOOST_REQUIRE(unpack.getHldFile() == "test.hld");
   BOOST_REQUIRE(unpack.getCfgFile() == "conf_test.xml");
-  BOOST_REQUIRE(unpack.getCalibFile() == "calib.root");
+  BOOST_REQUIRE(unpack.getTOTCalibFile() == "calib.root");
+  BOOST_REQUIRE(unpack.getTDCCalibFile() == "calib2.root");
   BOOST_REQUIRE(!unpack.exec());
 }
 
@@ -58,12 +60,14 @@ BOOST_FIXTURE_TEST_CASE( my_test3, Fixture )
 {
   JPetUnpacker unpack;
   unpack.setParams("unitTestData/JPetUnpackerTest/xx14099113231.hld", 10,
-    "unitTestData/JPetUnpackerTest/conf_trb3.xml", "unitTestData/JPetUnpackerTest/calib.root");
+                   "unitTestData/JPetUnpackerTest/conf_trb3.xml", "unitTestData/JPetUnpackerTest/calib.root",
+                   "unitTestData/JPetUnpackerTest/tdccalib.root");
   BOOST_REQUIRE(unpack.exec());
   BOOST_REQUIRE(unpack.getEventsToProcess() == 10);
   BOOST_REQUIRE(unpack.getHldFile() == "unitTestData/JPetUnpackerTest/xx14099113231.hld");
   BOOST_REQUIRE(unpack.getCfgFile() == "unitTestData/JPetUnpackerTest/conf_trb3.xml");
-  BOOST_REQUIRE(unpack.getCalibFile() == "unitTestData/JPetUnpackerTest/calib.root");
+  BOOST_REQUIRE(unpack.getTOTCalibFile() == "unitTestData/JPetUnpackerTest/calib.root");
+  BOOST_REQUIRE(unpack.getTDCCalibFile() == "unitTestData/JPetUnpackerTest/tdccalib.root");
   BOOST_REQUIRE(unpack.exec());
 }
 
@@ -71,16 +75,20 @@ BOOST_FIXTURE_TEST_CASE( my_test4, Fixture )
 {
   JPetUnpacker unpack;
   unpack.setParams("unitTestData/JPetUnpackerTest/xx14099113231.hld", 10,
-    "unitTestData/JPetUnpackerTest/conf_trb3.xml");
+                   "unitTestData/JPetUnpackerTest/conf_trb3.xml");
   BOOST_REQUIRE(unpack.exec());
   unpack.setParams("unitTestData/JPetUnpackerTest/xx14099113231.hld", 10,
-    "unitTestData/JPetUnpackerTest/conf_trb.xml");
+                   "unitTestData/JPetUnpackerTest/conf_trb.xml");
   BOOST_REQUIRE(!unpack.exec());
   unpack.setParams("unitTestData/JPetUnpackerTest/xx14099113231.hld", 10,
-    "unitTestData/JPetUnpackerTest/conf_trb3.xml", "unitTestData/JPetUnpackerTest/calib.root");
+                   "unitTestData/JPetUnpackerTest/conf_trb3.xml", "unitTestData/JPetUnpackerTest/calib.root");
   BOOST_REQUIRE(unpack.exec());
   unpack.setParams("unitTestData/JPetUnpackerTest/xx14099113231.hld", 10,
-    "unitTestData/JPetUnpackerTest/conf_trb3.xml", "unitTestData/JPetUnpackerTest/calib2.root");
+                   "unitTestData/JPetUnpackerTest/conf_trb3.xml", "unitTestData/JPetUnpackerTest/calib2.root");
+  BOOST_REQUIRE(!unpack.exec());
+  unpack.setParams("unitTestData/JPetUnpackerTest/xx14099113231.hld", 10,
+                   "unitTestData/JPetUnpackerTest/conf_trb3.xml", "unitTestData/JPetUnpackerTest/calib.root",
+                   "unitTestData/JPetUnpackerTest/calib2.root");
   BOOST_REQUIRE(!unpack.exec());
 }
 

--- a/Tasks/JPetUnzipAndUnpackTask/JPetUnzipAndUnpackTask.cpp
+++ b/Tasks/JPetUnzipAndUnpackTask/JPetUnzipAndUnpackTask.cpp
@@ -24,7 +24,7 @@
 using namespace jpet_options_tools;
 
 JPetUnzipAndUnpackTask::JPetUnzipAndUnpackTask(const char* name):
-  JPetTask(name), fUnpackHappened(false){}
+  JPetTask(name), fUnpackHappened(false) {}
 
 bool JPetUnzipAndUnpackTask::init(const JPetParams& inParams)
 {
@@ -33,14 +33,14 @@ bool JPetUnzipAndUnpackTask::init(const JPetParams& inParams)
   auto unpackerCalibFileFromCmdLine = getUnpackerCalibFile(fOptions);
   if (isOptionSet(inParams.getOptions(), kTOToffsetCalibKey)) {
     fTOToffsetCalibFile = getOptionAsString(inParams.getOptions(), kTOToffsetCalibKey);
-    if(!unpackerCalibFileFromCmdLine.empty()){
+    if (!unpackerCalibFileFromCmdLine.empty()) {
       WARNING("The calibration file with TOT stretcher offsets was defined both on the command line and in user parameters\n"
               "The file given as a user parameter will be used.");
     }
   } else {
-    if(unpackerCalibFileFromCmdLine.empty()){
+    if (unpackerCalibFileFromCmdLine.empty()) {
       WARNING("No calibration file with TOT stretcher offsets was provided by the user. Expect incorrect TOT values.");
-    }else{
+    } else {
       fTOToffsetCalibFile = unpackerCalibFileFromCmdLine;
       WARNING("Using the calibration file with TOT stretcher offsets defined on the command line.\n"
               "Note that it can also be given as a user parameter in the JSON file.");
@@ -62,12 +62,11 @@ bool JPetUnzipAndUnpackTask::run(const JPetDataInterface&)
   auto inputFile = getInputFile(fOptions);
   auto inputFileType = FileTypeChecker::getInputFileType(fOptions);
   auto unpackerConfigFile = getUnpackerConfigFile(fOptions);
-  
+
   if (inputFileType == FileTypeChecker::kHld) {
     unpackFile(inputFile, getTotalEvents(fOptions), unpackerConfigFile, fTOToffsetCalibFile, fTDCnonlinearityCalibFile);
     fUnpackHappened = true;
-  }
-  else if ( inputFileType == FileTypeChecker::kZip) {
+  } else if ( inputFileType == FileTypeChecker::kZip) {
     INFO( std::string("Unzipping file before unpacking") );
     if ( !unzipFile(inputFile) ) {
       ERROR( std::string("Problem with unpacking file: ") + inputFile );
@@ -94,15 +93,15 @@ bool JPetUnzipAndUnpackTask::terminate(JPetParams& outParams)
     OptsStrAny new_opts;
     jpet_options_generator_tools::setOutputFileType(new_opts, "hldRoot");
     if (jpet_options_tools::isOptionSet(fOptions, "firstEvent_int") &&
-      jpet_options_tools::isOptionSet(fOptions, "lastEvent_int")) {
+        jpet_options_tools::isOptionSet(fOptions, "lastEvent_int")) {
       if ( jpet_options_tools::getOptionAsInt(fOptions, "firstEvent_int") != -1 &&
-        jpet_options_tools::getOptionAsInt(fOptions, "lastEvent_int") != -1 ) {
+           jpet_options_tools::getOptionAsInt(fOptions, "lastEvent_int") != -1 ) {
         jpet_options_generator_tools::setResetEventRangeOption(new_opts, true);
       }
     }
     jpet_options_generator_tools::setOutputFile(new_opts,
-      JPetCommonTools::replaceDataTypeInFileName(getInputFile(fOptions), "hld")
-    );
+        JPetCommonTools::replaceDataTypeInFileName(getInputFile(fOptions), "hld")
+                                               );
     outParams = JPetParams(new_opts, outParams.getParamManagerAsShared());
   }
   return true;
@@ -123,16 +122,16 @@ bool JPetUnzipAndUnpackTask::unzipFile(const std::string& filename)
 }
 
 void JPetUnzipAndUnpackTask::unpackFile(const std::string& filename,
-					long long nevents, const std::string& configfile = "",
-					const std::string& totCalibFile = "", const std::string& tdcCalibFile = "")
+                                        long long nevents, const std::string& configfile = "",
+                                        const std::string& totCalibFile = "", const std::string& tdcCalibFile = "")
 {
   JPetUnpacker unpacker;
   if (nevents > 0) {
     unpacker.setParams(filename, nevents, configfile, totCalibFile, tdcCalibFile);
     WARNING(std::string("Even though the range of events was set, only the first ")
-      + JPetCommonTools::intToString(nevents)
-      + std::string(" will be unpacked by the unpacker. \n The unpacker always starts from the beginning of the file.")
-    );
+            + JPetCommonTools::intToString(nevents)
+            + std::string(" will be unpacked by the unpacker. \n The unpacker always starts from the beginning of the file.")
+           );
   } else {
     unpacker.setParams(filename, 100000000, configfile, totCalibFile, tdcCalibFile);
   }

--- a/Tasks/JPetUnzipAndUnpackTask/JPetUnzipAndUnpackTask.cpp
+++ b/Tasks/JPetUnzipAndUnpackTask/JPetUnzipAndUnpackTask.cpp
@@ -30,10 +30,21 @@ bool JPetUnzipAndUnpackTask::init(const JPetParams& inParams)
 {
   fOptions = inParams.getOptions();
 
+  auto unpackerCalibFileFromCmdLine = getUnpackerCalibFile(fOptions);
   if (isOptionSet(inParams.getOptions(), kTOToffsetCalibKey)) {
     fTOToffsetCalibFile = getOptionAsString(inParams.getOptions(), kTOToffsetCalibKey);
+    if(!unpackerCalibFileFromCmdLine.empty()){
+      WARNING("The calibration file with TOT stretcher offsets was defined both on the command line and in user parameters\n"
+              "The file given as a user parameter will be used.");
+    }
   } else {
-    WARNING("No calibration file with TOT stretcher offsets was provided by the user. Expect incorrect TOT values.");
+    if(unpackerCalibFileFromCmdLine.empty()){
+      WARNING("No calibration file with TOT stretcher offsets was provided by the user. Expect incorrect TOT values.");
+    }else{
+      fTOToffsetCalibFile = unpackerCalibFileFromCmdLine;
+      WARNING("Using the calibration file with TOT stretcher offsets defined on the command line.\n"
+              "Note that it can also be given as a user parameter in the JSON file.");
+    }
   }
 
   if (isOptionSet(inParams.getOptions(), kTDCnonlinearityCalibKey)) {
@@ -51,6 +62,7 @@ bool JPetUnzipAndUnpackTask::run(const JPetDataInterface&)
   auto inputFile = getInputFile(fOptions);
   auto inputFileType = FileTypeChecker::getInputFileType(fOptions);
   auto unpackerConfigFile = getUnpackerConfigFile(fOptions);
+  
   if (inputFileType == FileTypeChecker::kHld) {
     unpackFile(inputFile, getTotalEvents(fOptions), unpackerConfigFile, fTOToffsetCalibFile, fTDCnonlinearityCalibFile);
     fUnpackHappened = true;

--- a/Tasks/JPetUnzipAndUnpackTask/JPetUnzipAndUnpackTask.h
+++ b/Tasks/JPetUnzipAndUnpackTask/JPetUnzipAndUnpackTask.h
@@ -29,12 +29,17 @@ public:
   bool run(const JPetDataInterface& inData) override;
   bool terminate(JPetParams& outOptions) override;
   static void unpackFile(const std::string& filename, long long nevents,
-    const std::string& configfile, const std::string& calibfile);
+			 const std::string& configfile, const std::string& totCalibFile,
+			 const std::string& tdcCalibFile);
   static bool unzipFile(const std::string& filename);
 
 protected:
   OptsStrAny fOptions;
   bool fUnpackHappened = false;
+  const std::string kTOToffsetCalibKey = "Unpacker_TOToffsetCalib_std::string";
+  const std::string kTDCnonlinearityCalibKey = "Unpacker_TDCnonlinearityCalib_std::string";
+  std::string fTOToffsetCalibFile;
+  std::string fTDCnonlinearityCalibFile;
 };
 
 #endif /* !JPETUNZIPANDUNPACKTASK_H */


### PR DESCRIPTION
* Adds possibility to define the path to TDC nonlinearity calibration file as a user parameter in the json file
* Allow to pass the path to TOT stretcher offsets calibration file as a user parameter alternatively to the "-c" command line parameter
