### PR TITLE
Restoring unit tests after PR #190 + setting Unpacker submodule

### DIFF
--- a/Core/JPetManager/JPetManagerTest.cpp
+++ b/Core/JPetManager/JPetManagerTest.cpp
@@ -45,7 +45,6 @@ BOOST_AUTO_TEST_CASE(emptyRun)
   BOOST_CHECK_THROW(manager.run(0, nullptr), std::exception);
 }
 
-/*
 BOOST_AUTO_TEST_CASE(goodRootRun)
 {
   JPetManager& manager = JPetManager::getManager();
@@ -60,7 +59,6 @@ BOOST_AUTO_TEST_CASE(goodRootRun)
   };
   BOOST_REQUIRE_NO_THROW(manager.run(7, args));
 }
-*/
 
 BOOST_AUTO_TEST_CASE(goodZipRun)
 {

--- a/Core/JPetTaskChainExecutor/JPetTaskChainExecutorTest.cpp
+++ b/Core/JPetTaskChainExecutor/JPetTaskChainExecutorTest.cpp
@@ -52,7 +52,7 @@ BOOST_AUTO_TEST_CASE(test0)
   // TODO restore tests with files with new structures
 }
 
-/*
+
 BOOST_AUTO_TEST_CASE(test1)
 {
   auto opt = jpet_options_generator_tools::getDefaultOptions();
@@ -99,5 +99,5 @@ BOOST_AUTO_TEST_CASE(test2)
   JPetTaskChainExecutor taskExecutor(chain, 1, opt);
   BOOST_REQUIRE(taskExecutor.process());
 }
-*/
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/Tasks/JPetParamBankHandlerTask/JPetParamBankHandlerTaskTest.cpp
+++ b/Tasks/JPetParamBankHandlerTask/JPetParamBankHandlerTaskTest.cpp
@@ -25,7 +25,7 @@
 #include <boost/test/unit_test.hpp>
 
 BOOST_AUTO_TEST_SUITE(FirstSuite)
-/*
+
 BOOST_AUTO_TEST_CASE(goodRootFile)
 {
   JPetParamBankHandlerTask task;
@@ -43,7 +43,6 @@ BOOST_AUTO_TEST_CASE(goodRootFile)
   auto& bank2 = manager->getParamBank();
   BOOST_REQUIRE(!bank2.isDummy());
 }
-*/
 
 BOOST_AUTO_TEST_CASE(badRootFile)
 {


### PR DESCRIPTION
After PR #190 certain UTs were commented out because the tests failed due to old format of data structures in the ROOT files used as input to these tests. However, it turns out that the incompatibility was caused by the changes which were eventually reverted before merging the PR. In the final version of the PR, the test files are compatible again so that no modifications to the files were necessary.

I have restored the commented UTs.
By the way, updated the Unpacker submodule to the newest version without L-T pairing.