### PR TITLE
Fix bad auto deduction variable type in JPetUnpacker

### DIFF
--- a/Core/JPetUnpacker/JPetUnpacker.h
+++ b/Core/JPetUnpacker/JPetUnpacker.h
@@ -16,7 +16,6 @@
 #ifndef _JPETUNPACKER_H_
 #define _JPETUNPACKER_H_
 #include "./Unpacker2/Unpacker2/Unpacker2.h"
-#include <TObject.h>
 #include <string>
 
 class Unpacker2;
@@ -24,7 +23,7 @@ class Unpacker2;
 /**
  * @brief Facade for Unpacker program which unpacks raw data to root files
  */
-class JPetUnpacker: public TObject
+class JPetUnpacker
 {
 public:
   ~JPetUnpacker();

--- a/Tasks/JPetUnzipAndUnpackTask/JPetUnzipAndUnpackTask.cpp
+++ b/Tasks/JPetUnzipAndUnpackTask/JPetUnzipAndUnpackTask.cpp
@@ -85,6 +85,7 @@ bool JPetUnzipAndUnpackTask::run(const JPetDataInterface&)
     break;
   case FileTypeChecker::kUndefinedFileType:
     runStatus = false;
+    ERROR("Undefined input file type: " + inputFile);
     break;
   case FileTypeChecker::kNoType:
   case FileTypeChecker::kScope:

--- a/Tasks/JPetUnzipAndUnpackTask/JPetUnzipAndUnpackTask.h
+++ b/Tasks/JPetUnzipAndUnpackTask/JPetUnzipAndUnpackTask.h
@@ -28,9 +28,9 @@ public:
   bool init(const JPetParams& inOptions) override;
   bool run(const JPetDataInterface& inData) override;
   bool terminate(JPetParams& outOptions) override;
-  static void unpackFile(const std::string& filename, long long nevents,
-			 const std::string& configfile, const std::string& totCalibFile,
-			 const std::string& tdcCalibFile);
+  static bool unpackFile(const std::string& filename, long long nevents,
+                         const std::string& configfile, const std::string& totCalibFile,
+                         const std::string& tdcCalibFile);
   static bool unzipFile(const std::string& filename);
 
 protected:


### PR DESCRIPTION
Change auto to std::string to force std::string type after calling JPetCommonTools::stripFileNameSuffix.
Automatic variable type deduced const char *, but it was passed to std::string& and in the log you could see, that unzipped name was not correct:

72: [JPetUnpacker.cpp:exec@43] ThreadID: 0x00007fdaa221ab00 <error> The hld file doesnt exist: \C0\861\B7\ECU

Also add flag to return status of unpacking to exit program if unpacking was not successful.

Beside of that, I removed inheritance of TObject from JPetUnpacker, it produced warning:
Warning in <JPetUnpacker>: The data members of JPetUnpacker will not be stored, because it inherits from TObject but does not have its own ClassDef.
and I couldn't find anywhere where something from TObject was used in JPetUnpacker