### PR TITLE
Cleanups of OptionsGenerator and OptionTools

### DIFF
--- a/Options/JPetOptionsGenerator/JPetOptionsTypeHandler.cpp
+++ b/Options/JPetOptionsGenerator/JPetOptionsTypeHandler.cpp
@@ -26,7 +26,7 @@ std::map<std::string, std::string> JPetOptionsTypeHandler::anyMapToStringMap(con
   std::map<std::string, std::string> newOptionsMap;
   for (const auto& option : optionsMap) {
     std::string typeOfOption = getTypeOfOption(option.first);
-    switch (kAllowedTypesMap[typeOfOption]) {
+    switch (getAllowedTypes()[typeOfOption]) {
     case JPetOptionsTypeHandler::kAllowedTypes::kInt:
       newOptionsMap[getNameOfOption(option.first)] = std::to_string(any_cast<int>(option.second));
       break;
@@ -88,15 +88,16 @@ std::string JPetOptionsTypeHandler::getNameOfOption(const std::string& option) {
 }
 
 std::map<std::string, int> JPetOptionsTypeHandler::getAllowedTypes() {
-  if (JPetOptionsTypeHandler::kAllowedTypesMap.empty()) {
-    JPetOptionsTypeHandler::kAllowedTypesMap["int"] = JPetOptionsTypeHandler::kAllowedTypes::kInt;
-    JPetOptionsTypeHandler::kAllowedTypesMap["std::string"] = JPetOptionsTypeHandler::kAllowedTypes::kString;
-    JPetOptionsTypeHandler::kAllowedTypesMap["std::vector<std::string>"] = JPetOptionsTypeHandler::kAllowedTypes::kVectorString;
-    JPetOptionsTypeHandler::kAllowedTypesMap["std::vector<int>"] = JPetOptionsTypeHandler::kAllowedTypes::kVectorInt;
-    JPetOptionsTypeHandler::kAllowedTypesMap["float"] = JPetOptionsTypeHandler::kAllowedTypes::kFloat;
-    JPetOptionsTypeHandler::kAllowedTypesMap["double"] = JPetOptionsTypeHandler::kAllowedTypes::kDouble;
-    JPetOptionsTypeHandler::kAllowedTypesMap["bool"] = JPetOptionsTypeHandler::kAllowedTypes::kBool;
-    JPetOptionsTypeHandler::kAllowedTypesMap["noType"] = JPetOptionsTypeHandler::kAllowedTypes::kNoType;
+  static std::map<std::string, int> kAllowedTypesMap;
+  if (kAllowedTypesMap.empty()) {
+    kAllowedTypesMap["int"] = JPetOptionsTypeHandler::kAllowedTypes::kInt;
+    kAllowedTypesMap["std::string"] = JPetOptionsTypeHandler::kAllowedTypes::kString;
+    kAllowedTypesMap["std::vector<std::string>"] = JPetOptionsTypeHandler::kAllowedTypes::kVectorString;
+    kAllowedTypesMap["std::vector<int>"] = JPetOptionsTypeHandler::kAllowedTypes::kVectorInt;
+    kAllowedTypesMap["float"] = JPetOptionsTypeHandler::kAllowedTypes::kFloat;
+    kAllowedTypesMap["double"] = JPetOptionsTypeHandler::kAllowedTypes::kDouble;
+    kAllowedTypesMap["bool"] = JPetOptionsTypeHandler::kAllowedTypes::kBool;
+    kAllowedTypesMap["noType"] = JPetOptionsTypeHandler::kAllowedTypes::kNoType;
   }
-  return JPetOptionsTypeHandler::kAllowedTypesMap;
+  return kAllowedTypesMap;
 }

--- a/Options/JPetOptionsGenerator/JPetOptionsTypeHandler.cpp
+++ b/Options/JPetOptionsGenerator/JPetOptionsTypeHandler.cpp
@@ -21,12 +21,15 @@
 
 namespace pt = boost::property_tree;
 
-std::map<std::string, std::string> JPetOptionsTypeHandler::anyMapToStringMap(const std::map<std::string, boost::any>& optionsMap) {
+std::map<std::string, std::string> JPetOptionsTypeHandler::anyMapToStringMap(const std::map<std::string, boost::any>& optionsMap)
+{
   using boost::any_cast;
   std::map<std::string, std::string> newOptionsMap;
-  for (const auto& option : optionsMap) {
+  for (const auto& option : optionsMap)
+  {
     std::string typeOfOption = getTypeOfOption(option.first);
-    switch (getAllowedTypes()[typeOfOption]) {
+    switch (getAllowedTypes()[typeOfOption])
+    {
     case JPetOptionsTypeHandler::kAllowedTypes::kInt:
       newOptionsMap[getNameOfOption(option.first)] = std::to_string(any_cast<int>(option.second));
       break;
@@ -36,25 +39,19 @@ std::map<std::string, std::string> JPetOptionsTypeHandler::anyMapToStringMap(con
     case JPetOptionsTypeHandler::kAllowedTypes::kDouble:
       newOptionsMap[getNameOfOption(option.first)] = std::to_string(any_cast<double>(option.second));
       break;
-    case JPetOptionsTypeHandler::kAllowedTypes::kString:
-      newOptionsMap[getNameOfOption(option.first)] = any_cast<std::string>(option.second);
-      break;
+    case JPetOptionsTypeHandler::kAllowedTypes::kString: newOptionsMap[getNameOfOption(option.first)] = any_cast<std::string>(option.second); break;
     case JPetOptionsTypeHandler::kAllowedTypes::kBool:
       if (any_cast<bool>(option.second))
         newOptionsMap[getNameOfOption(option.first)] = "true";
       else
         newOptionsMap[getNameOfOption(option.first)] = "false";
       break;
-    case JPetOptionsTypeHandler::kAllowedTypes::kNoType:
-      newOptionsMap[option.first] = any_cast<std::string>(option.second);
-      break;
+    case JPetOptionsTypeHandler::kAllowedTypes::kNoType: newOptionsMap[option.first] = any_cast<std::string>(option.second); break;
     case JPetOptionsTypeHandler::kAllowedTypes::kVectorString:
       newOptionsMap[option.first] = [&option]() -> std::string {
         std::string result = "[";
 
-        for (const auto& s : any_cast<std::vector<std::string>>(option.second)) {
-          result += "\"" + s + "\", ";
-        }
+        for (const auto& s : any_cast<std::vector<std::string>>(option.second)) { result += "\"" + s + "\", "; }
         result += "]";
         return result;
       }();
@@ -62,36 +59,34 @@ std::map<std::string, std::string> JPetOptionsTypeHandler::anyMapToStringMap(con
     case JPetOptionsTypeHandler::kAllowedTypes::kVectorInt:
       newOptionsMap[option.first] = [&option]() -> std::string {
         std::string result = "";
-        for (const auto& s : any_cast<std::vector<int>>(option.second)) {
-          result += std::to_string(s) + " ";
-        }
+        for (const auto& s : any_cast<std::vector<int>>(option.second)) { result += std::to_string(s) + " "; }
         return result;
       }();
       break;
-    default:
-      WARNING("Cant convert " + typeOfOption + " to string map, skipping it");
-      break;
+    default: WARNING("Cant convert " + typeOfOption + " to string map, skipping it"); break;
     }
   }
   return newOptionsMap;
 }
 
-std::string JPetOptionsTypeHandler::getTypeOfOption(const std::string& nameOfOption) {
+std::string JPetOptionsTypeHandler::getTypeOfOption(const std::string& nameOfOption)
+{
   std::size_t pos = nameOfOption.rfind("_");
-  if (pos == std::string::npos) {
-    return "noType";
-  }
+  if (pos == std::string::npos) { return "noType"; }
   return nameOfOption.substr(pos + 1);
 }
 
-std::string JPetOptionsTypeHandler::getNameOfOption(const std::string& option) {
+std::string JPetOptionsTypeHandler::getNameOfOption(const std::string& option)
+{
   std::size_t pos = option.rfind("_");
   return option.substr(0, pos);
 }
 
-std::map<std::string, int> JPetOptionsTypeHandler::getAllowedTypes() {
+std::map<std::string, int> JPetOptionsTypeHandler::getAllowedTypes()
+{
   static std::map<std::string, int> kAllowedTypesMap;
-  if (kAllowedTypesMap.empty()) {
+  if (kAllowedTypesMap.empty())
+  {
     kAllowedTypesMap["int"] = JPetOptionsTypeHandler::kAllowedTypes::kInt;
     kAllowedTypesMap["std::string"] = JPetOptionsTypeHandler::kAllowedTypes::kString;
     kAllowedTypesMap["std::vector<std::string>"] = JPetOptionsTypeHandler::kAllowedTypes::kVectorString;

--- a/Options/JPetOptionsGenerator/JPetOptionsTypeHandler.cpp
+++ b/Options/JPetOptionsGenerator/JPetOptionsTypeHandler.cpp
@@ -50,10 +50,12 @@ std::map<std::string, std::string> JPetOptionsTypeHandler::anyMapToStringMap(con
       break;
     case JPetOptionsTypeHandler::kAllowedTypes::kVectorString:
       newOptionsMap[option.first] = [&option]() -> std::string {
-        std::string result = "";
+        std::string result = "[";
+
         for (const auto& s : any_cast<std::vector<std::string>>(option.second)) {
-          result += s + " ";
+          result += "\"" + s + "\", ";
         }
+        result += "]";
         return result;
       }();
       break;

--- a/Options/JPetOptionsGenerator/JPetOptionsTypeHandler.h
+++ b/Options/JPetOptionsGenerator/JPetOptionsTypeHandler.h
@@ -17,23 +17,36 @@
 #define JPETOPTIONSTYPEHANDLER_H
 
 #include <boost/any.hpp>
-#include <vector>
-#include <string>
 #include <map>
+#include <string>
+#include <vector>
 
 /**
  * @brief Class handling the type of option provided by the user.
  */
-class JPetOptionsTypeHandler
-{
+class JPetOptionsTypeHandler {
 public:
-  static std::map<std::string, std::string> anyMapToStringMap(
-    const std::map<std::string, boost::any>& optionsMap);
-  static std::vector<std::string> getAllowedTypes();
+  enum kAllowedTypes {
+    kNotFound,
+    kInt,
+    kString,
+    kBool,
+    kVectorString,
+    kVectorInt,
+    kFloat,
+    kDouble,
+    kNoType
+  }; // if map do not find value it returns 0, so make extra type to handle this
+
+  static std::map<std::string, std::string> anyMapToStringMap(const std::map<std::string, boost::any>& optionsMap);
+  static std::map<std::string, int> getAllowedTypes();
   static std::string getTypeOfOption(const std::string& option);
   static std::string getNameOfOption(const std::string& option);
 
 private:
-  static const std::vector<std::string> kAllowedTypes;
+  JPetOptionsTypeHandler() = delete;
+  JPetOptionsTypeHandler(const JPetOptionsTypeHandler&) = delete;
+
+  static std::map<std::string, int> kAllowedTypesMap;
 };
 #endif /* !JPETOPTIONSTYPEHANDLER_H */

--- a/Options/JPetOptionsGenerator/JPetOptionsTypeHandler.h
+++ b/Options/JPetOptionsGenerator/JPetOptionsTypeHandler.h
@@ -46,7 +46,5 @@ public:
 private:
   JPetOptionsTypeHandler() = delete;
   JPetOptionsTypeHandler(const JPetOptionsTypeHandler&) = delete;
-
-  static std::map<std::string, int> kAllowedTypesMap;
 };
 #endif /* !JPETOPTIONSTYPEHANDLER_H */

--- a/Options/JPetOptionsGenerator/JPetOptionsTypeHandler.h
+++ b/Options/JPetOptionsGenerator/JPetOptionsTypeHandler.h
@@ -24,9 +24,11 @@
 /**
  * @brief Class handling the type of option provided by the user.
  */
-class JPetOptionsTypeHandler {
+class JPetOptionsTypeHandler
+{
 public:
-  enum kAllowedTypes {
+  enum kAllowedTypes
+  {
     kNotFound,
     kInt,
     kString,

--- a/Options/JPetOptionsGenerator/JPetOptionsTypeHandlerTest.cpp
+++ b/Options/JPetOptionsGenerator/JPetOptionsTypeHandlerTest.cpp
@@ -22,7 +22,8 @@
 
 BOOST_AUTO_TEST_SUITE(FirstSuite)
 
-BOOST_AUTO_TEST_CASE(getTypeOfOption) {
+BOOST_AUTO_TEST_CASE(getTypeOfOption)
+{
   BOOST_REQUIRE_EQUAL(JPetOptionsTypeHandler::getTypeOfOption(""), "noType");
   BOOST_REQUIRE_EQUAL(JPetOptionsTypeHandler::getTypeOfOption("blabla"), "noType");
   BOOST_REQUIRE_EQUAL(JPetOptionsTypeHandler::getTypeOfOption("blabla_int"), "int");
@@ -31,7 +32,8 @@ BOOST_AUTO_TEST_CASE(getTypeOfOption) {
   BOOST_REQUIRE_EQUAL(JPetOptionsTypeHandler::getTypeOfOption("_int"), "int");
 }
 
-BOOST_AUTO_TEST_CASE(getNameOfOption) {
+BOOST_AUTO_TEST_CASE(getNameOfOption)
+{
   BOOST_REQUIRE_EQUAL(JPetOptionsTypeHandler::getNameOfOption(""), "");
   BOOST_REQUIRE_EQUAL(JPetOptionsTypeHandler::getNameOfOption("blabla"), "blabla");
   BOOST_REQUIRE_EQUAL(JPetOptionsTypeHandler::getNameOfOption("blabla_int"), "blabla");

--- a/Options/JPetOptionsGenerator/JPetOptionsTypeHandlerTest.cpp
+++ b/Options/JPetOptionsGenerator/JPetOptionsTypeHandlerTest.cpp
@@ -22,18 +22,16 @@
 
 BOOST_AUTO_TEST_SUITE(FirstSuite)
 
-BOOST_AUTO_TEST_CASE(getTypeOfOption)
-{
-  BOOST_REQUIRE_EQUAL(JPetOptionsTypeHandler::getTypeOfOption(""), "default");
-  BOOST_REQUIRE_EQUAL(JPetOptionsTypeHandler::getTypeOfOption("blabla"), "default");
+BOOST_AUTO_TEST_CASE(getTypeOfOption) {
+  BOOST_REQUIRE_EQUAL(JPetOptionsTypeHandler::getTypeOfOption(""), "noType");
+  BOOST_REQUIRE_EQUAL(JPetOptionsTypeHandler::getTypeOfOption("blabla"), "noType");
   BOOST_REQUIRE_EQUAL(JPetOptionsTypeHandler::getTypeOfOption("blabla_int"), "int");
   BOOST_REQUIRE_EQUAL(JPetOptionsTypeHandler::getTypeOfOption("blwblw_std::string"), "std::string");
   BOOST_REQUIRE_EQUAL(JPetOptionsTypeHandler::getTypeOfOption("bla_bla_int"), "int");
   BOOST_REQUIRE_EQUAL(JPetOptionsTypeHandler::getTypeOfOption("_int"), "int");
 }
 
-BOOST_AUTO_TEST_CASE(getNameOfOption)
-{
+BOOST_AUTO_TEST_CASE(getNameOfOption) {
   BOOST_REQUIRE_EQUAL(JPetOptionsTypeHandler::getNameOfOption(""), "");
   BOOST_REQUIRE_EQUAL(JPetOptionsTypeHandler::getNameOfOption("blabla"), "blabla");
   BOOST_REQUIRE_EQUAL(JPetOptionsTypeHandler::getNameOfOption("blabla_int"), "blabla");

--- a/Options/JPetOptionsTools/JPetOptionsTools.cpp
+++ b/Options/JPetOptionsTools/JPetOptionsTools.cpp
@@ -24,7 +24,8 @@
 namespace pt = boost::property_tree;
 using boost::any_cast;
 
-namespace jpet_options_tools {
+namespace jpet_options_tools
+{
 
 std::map<std::string, FileTypeChecker::FileType> FileTypeChecker::fStringToFileType = {
     {"", kNoType}, {"root", kRoot}, {"mcGeant", kMCGeant}, {"scope", kScope}, {"hld", kHld}, {"hldRoot", kHldRoot}, {"zip", kZip}};
@@ -33,56 +34,94 @@ bool isOptionSet(const OptsStrAny& opts, const std::string& optionName) { return
 
 boost::any getOptionValue(const OptsStrAny& opts, const std::string& optionName) { return opts.at(optionName); }
 
-std::string getOptionAsString(const OptsStrAny& opts, const std::string& optionName) {
-  try {
+std::string getOptionAsString(const OptsStrAny& opts, const std::string& optionName)
+{
+  try
+  {
     return any_cast<std::string>(getOptionValue(opts, optionName));
-  } catch (const std::exception& excep) {
+  }
+  catch (const std::exception& excep)
+  {
     ERROR("Bad option type:" + std::string(excep.what()));
     return "";
   }
 }
 
-int getOptionAsInt(const OptsStrAny& opts, const std::string& optionName) {
-  try {
+int getOptionAsInt(const OptsStrAny& opts, const std::string& optionName)
+{
+  try
+  {
     return any_cast<int>(getOptionValue(opts, optionName));
-  } catch (const std::exception& excep) {
+  }
+  catch (const std::exception& excep)
+  {
     ERROR("Bad option type:" + std::string(excep.what()));
     return -1;
   }
 }
 
-float getOptionAsFloat(const OptsStrAny& opts, const std::string& optionName) {
-  try {
+float getOptionAsFloat(const OptsStrAny& opts, const std::string& optionName)
+{
+  try
+  {
     return any_cast<float>(getOptionValue(opts, optionName));
-  } catch (const std::exception& excep) {
+  }
+  catch (const std::exception& excep)
+  {
     ERROR("Bad option type:" + std::string(excep.what()));
     return -1.;
   }
 }
 
-double getOptionAsDouble(const OptsStrAny& opts, const std::string& optionName) {
-  try {
+double getOptionAsDouble(const OptsStrAny& opts, const std::string& optionName)
+{
+  try
+  {
     return any_cast<double>(getOptionValue(opts, optionName));
-  } catch (const std::exception& excep) {
+  }
+  catch (const std::exception& excep)
+  {
     ERROR("Bad option type:" + std::string(excep.what()));
     return -1.;
   }
 }
 
-std::vector<std::string> getOptionAsVectorOfStrings(const OptsStrAny& opts, const std::string& optionName) {
-  try {
+std::vector<std::string> getOptionAsVectorOfStrings(const OptsStrAny& opts, const std::string& optionName)
+{
+  try
+  {
     return any_cast<std::vector<std::string>>(getOptionValue(opts, optionName));
-  } catch (const std::exception& excep) {
+  }
+  catch (const std::exception& excep)
+  {
     std::vector<std::string> emptyV;
     ERROR("Bad option type:" + std::string(excep.what()));
     return emptyV;
   }
 }
 
-bool getOptionAsBool(const OptsStrAny& opts, const std::string& optionName) {
-  try {
+std::vector<int> getOptionAsVectorOfInts(const OptsStrAny& opts, const std::string& optionName)
+{
+  try
+  {
+    return any_cast<std::vector<int>>(getOptionValue(opts, optionName));
+  }
+  catch (const std::exception& excep)
+  {
+    std::vector<int> emptyV;
+    ERROR("Bad option type:" + std::string(excep.what()));
+    return emptyV;
+  }
+}
+
+bool getOptionAsBool(const OptsStrAny& opts, const std::string& optionName)
+{
+  try
+  {
     return any_cast<bool>(getOptionValue(opts, optionName));
-  } catch (const std::exception& excep) {
+  }
+  catch (const std::exception& excep)
+  {
     ERROR("Bad option type:" + std::string(excep.what()));
     return false;
   }
@@ -93,9 +132,11 @@ bool getOptionAsBool(const OptsStrAny& opts, const std::string& optionName) {
  * This function returns a valid result only if the inputFile option is given
  * in the untransformed form: std::vector<std::string>
  */
-std::vector<std::string> getInputFiles(const std::map<std::string, boost::any>& opts) {
+std::vector<std::string> getInputFiles(const std::map<std::string, boost::any>& opts)
+{
   std::vector<std::string> dummy;
-  if (!isOptionSet(opts, "file_std::vector<std::string>")) {
+  if (!isOptionSet(opts, "file_std::vector<std::string>"))
+  {
     ERROR("key:file_std::vector<std::string> not found in options");
     return dummy;
   }
@@ -108,11 +149,13 @@ std::vector<std::string> getInputFiles(const std::map<std::string, boost::any>& 
  */
 std::string getInputFile(const std::map<std::string, boost::any>& opts) { return any_cast<std::string>(opts.at("inputFile_std::string")); }
 
-std::string getScopeConfigFile(const std::map<std::string, boost::any>& opts) {
+std::string getScopeConfigFile(const std::map<std::string, boost::any>& opts)
+{
   return any_cast<std::string>(opts.at("scopeConfigFile_std::string"));
 }
 
-std::string getScopeInputDirectory(const std::map<std::string, boost::any>& opts) {
+std::string getScopeInputDirectory(const std::map<std::string, boost::any>& opts)
+{
   return any_cast<std::string>(opts.at("scopeInputDirectory_std::string"));
 }
 
@@ -131,13 +174,12 @@ long long getLastEvent(const std::map<std::string, boost::any>& opts) { return a
  * set to -1 then the -1 is returned. If last - first < 0 then -1 is returned.
  * Otherwise last - first +1 is returned.
  */
-long long getTotalEvents(const std::map<std::string, boost::any>& opts) {
+long long getTotalEvents(const std::map<std::string, boost::any>& opts)
+{
   long long first = getFirstEvent(opts);
   long long last = getLastEvent(opts);
   long long diff = -1;
-  if ((first >= 0) && (last >= 0) && ((last - first) >= 0)) {
-    diff = last - first + 1;
-  }
+  if ((first >= 0) && (last >= 0) && ((last - first) >= 0)) { diff = last - first + 1; }
   return diff;
 }
 
@@ -147,69 +189,69 @@ bool isProgressBar(const std::map<std::string, boost::any>& opts) { return any_c
 
 bool isLocalDB(const std::map<std::string, boost::any>& opts) { return (bool)opts.count("localDB_std::string"); }
 
-std::string getLocalDB(const std::map<std::string, boost::any>& opts) {
+std::string getLocalDB(const std::map<std::string, boost::any>& opts)
+{
   std::string result("");
-  if (isLocalDB(opts)) {
-    result = any_cast<std::string>(opts.at("localDB_std::string"));
-  }
+  if (isLocalDB(opts)) { result = any_cast<std::string>(opts.at("localDB_std::string")); }
   return result;
 }
 bool isLocalDBCreate(const std::map<std::string, boost::any>& opts) { return (bool)opts.count("localDBCreate_std::string"); }
 
-std::string getLocalDBCreate(const std::map<std::string, boost::any>& opts) {
+std::string getLocalDBCreate(const std::map<std::string, boost::any>& opts)
+{
   std::string result("");
-  if (isLocalDBCreate(opts)) {
-    result = any_cast<std::string>(opts.at("localDBCreate_std::string"));
-  }
+  if (isLocalDBCreate(opts)) { result = any_cast<std::string>(opts.at("localDBCreate_std::string")); }
   return result;
 }
 
-std::string getUnpackerConfigFile(const std::map<std::string, boost::any>& opts) {
+std::string getUnpackerConfigFile(const std::map<std::string, boost::any>& opts)
+{
   return any_cast<std::string>(opts.at("unpackerConfigFile_std::string"));
 }
 
-std::string getUnpackerCalibFile(const std::map<std::string, boost::any>& opts) {
+std::string getUnpackerCalibFile(const std::map<std::string, boost::any>& opts)
+{
   return any_cast<std::string>(opts.at("unpackerCalibFile_std::string"));
 }
 
-std::string getConfigFileName(const std::map<std::string, boost::any>& optsMap) {
-  if (optsMap.count("userCfg_std::string")) {
-    return any_cast<std::string>(optsMap.at("userCfg_std::string"));
-  } else {
+std::string getConfigFileName(const std::map<std::string, boost::any>& optsMap)
+{
+  if (optsMap.count("userCfg_std::string")) { return any_cast<std::string>(optsMap.at("userCfg_std::string")); }
+  else
+  {
     return "";
   }
 }
 
 // cppcheck-suppress unusedFunction
-void printOptions(const OptsStrAny& opts) {
+void printOptions(const OptsStrAny& opts)
+{
   std::cout << "Current options:" << std::endl;
   auto stringOptions = JPetOptionsTypeHandler::anyMapToStringMap(opts);
-  for (const auto& el : stringOptions) {
-    std::cout << el.first + "=" + el.second << std::endl;
-  }
+  for (const auto& el : stringOptions) { std::cout << el.first + "=" + el.second << std::endl; }
 }
 
-void printOptionsToLog(const OptsStrAny& opts, const std::string& firstLine) {
-  if (!firstLine.empty()) {
-    INFO(firstLine.c_str());
-  }
+void printOptionsToLog(const OptsStrAny& opts, const std::string& firstLine)
+{
+  if (!firstLine.empty()) { INFO(firstLine.c_str()); }
   INFO("Current options:");
   auto stringOptions = JPetOptionsTypeHandler::anyMapToStringMap(opts);
-  for (const auto& el : stringOptions) {
-    INFO(el.first + "=" + el.second);
-  }
+  for (const auto& el : stringOptions) { INFO(el.first + "=" + el.second); }
 }
 
 /**
  * Creates json file based on given options.
  */
-bool createConfigFileFromOptions(const OptsStrStr& options, const std::string& outFile) {
+bool createConfigFileFromOptions(const OptsStrStr& options, const std::string& outFile)
+{
   pt::ptree optionsTree;
-  for (auto& entry : options)
-    optionsTree.put(entry.first, entry.second);
-  try {
+  for (auto& entry : options) optionsTree.put(entry.first, entry.second);
+  try
+  {
     pt::write_json(outFile, optionsTree);
-  } catch (pt::json_parser_error) {
+  }
+  catch (pt::json_parser_error)
+  {
     ERROR("ERROR IN WRITING OPTIONS TO JSON FILE");
     return false;
   }
@@ -219,86 +261,89 @@ bool createConfigFileFromOptions(const OptsStrStr& options, const std::string& o
 /**
  * Creates option map based on the content of the json file.
  */
-std::map<std::string, boost::any> createOptionsFromConfigFile(const std::string& filename) {
+std::map<std::string, boost::any> createOptionsFromConfigFile(const std::string& filename)
+{
   pt::ptree optionsTree;
   std::map<std::string, boost::any> mapOptions, emptyMap;
-  if (JPetCommonTools::ifFileExisting(filename)) {
-    try {
+  if (JPetCommonTools::ifFileExisting(filename))
+  {
+    try
+    {
       pt::read_json(filename, optionsTree);
-      for (auto& item : optionsTree) {
+      for (auto& item : optionsTree)
+      {
         auto key = item.first;
         std::string typeOfOption = JPetOptionsTypeHandler::getTypeOfOption(key);
         auto allowedTypes = JPetOptionsTypeHandler::getAllowedTypes();
-        switch (allowedTypes[typeOfOption]) {
-        case JPetOptionsTypeHandler::kAllowedTypes::kInt:
-          mapOptions.insert(std::make_pair(key, item.second.get_value<int>()));
-          break;
-        case JPetOptionsTypeHandler::kAllowedTypes::kString:
-          mapOptions.insert(std::make_pair(key, item.second.get_value<std::string>()));
-          break;
-        case JPetOptionsTypeHandler::kAllowedTypes::kFloat:
-          mapOptions.insert(std::make_pair(key, item.second.get_value<float>()));
-          break;
-        case JPetOptionsTypeHandler::kAllowedTypes::kDouble:
-          mapOptions.insert(std::make_pair(key, item.second.get_value<double>()));
-          break;
-        case JPetOptionsTypeHandler::kAllowedTypes::kBool:
-          mapOptions.insert(std::make_pair(key, item.second.get_value<bool>()));
-          break;
+        switch (allowedTypes[typeOfOption])
+        {
+        case JPetOptionsTypeHandler::kAllowedTypes::kInt: mapOptions.insert(std::make_pair(key, item.second.get_value<int>())); break;
+        case JPetOptionsTypeHandler::kAllowedTypes::kString: mapOptions.insert(std::make_pair(key, item.second.get_value<std::string>())); break;
+        case JPetOptionsTypeHandler::kAllowedTypes::kFloat: mapOptions.insert(std::make_pair(key, item.second.get_value<float>())); break;
+        case JPetOptionsTypeHandler::kAllowedTypes::kDouble: mapOptions.insert(std::make_pair(key, item.second.get_value<double>())); break;
+        case JPetOptionsTypeHandler::kAllowedTypes::kBool: mapOptions.insert(std::make_pair(key, item.second.get_value<bool>())); break;
         case JPetOptionsTypeHandler::kAllowedTypes::kVectorString:
           mapOptions.insert(std::make_pair(key, [&optionsTree, &key]() -> std::vector<std::string> {
             std::vector<std::string> values;
-            for (pt::ptree::value_type& value : optionsTree.get_child(key)) {
-              values.push_back(value.second.get_value<std::string>());
-            }
+            for (pt::ptree::value_type& value : optionsTree.get_child(key)) { values.push_back(value.second.get_value<std::string>()); }
             return values;
           }()));
           break;
         case JPetOptionsTypeHandler::kAllowedTypes::kVectorInt:
           mapOptions.insert(std::make_pair(key, [&optionsTree, &key]() -> std::vector<int> {
             std::vector<int> values;
-            for (pt::ptree::value_type& value : optionsTree.get_child(key)) {
-              values.push_back(value.second.get_value<int>());
-            }
+            for (pt::ptree::value_type& value : optionsTree.get_child(key)) { values.push_back(value.second.get_value<int>()); }
             return values;
           }()));
           break;
-        default:
-          WARNING("Unknow option type: " + typeOfOption + " skipping option: " + key);
-          break;
+        default: WARNING("Unknow option type: " + typeOfOption + " skipping option: " + key); break;
         }
       }
-    } catch (pt::json_parser_error) {
+    }
+    catch (pt::json_parser_error)
+    {
       ERROR("ERROR IN READINIG OPTIONS FROM JSON FILE! FILENAME:" + filename);
       return emptyMap;
     }
-  } else {
+  }
+  else
+  {
     ERROR("JSON CONFIG FILE DOES NOT EXIST! FILENAME:" + filename);
   }
   return mapOptions;
 }
 
-FileTypeChecker::FileType FileTypeChecker::getInputFileType(const std::map<std::string, boost::any>& opts) {
+FileTypeChecker::FileType FileTypeChecker::getInputFileType(const std::map<std::string, boost::any>& opts)
+{
   return getFileType(opts, "inputFileType_std::string");
 }
 
-FileTypeChecker::FileType FileTypeChecker::getOutputFileType(const std::map<std::string, boost::any>& opts) {
+FileTypeChecker::FileType FileTypeChecker::getOutputFileType(const std::map<std::string, boost::any>& opts)
+{
   return getFileType(opts, "outputFileType_std::string");
 }
 
-void FileTypeChecker::handleErrorMessage(const std::string& errorMessage, const std::out_of_range& outOfRangeException) {
+void FileTypeChecker::handleErrorMessage(const std::string& errorMessage, const std::out_of_range& outOfRangeException)
+{
   std::cerr << errorMessage << outOfRangeException.what() << '\n';
   ERROR(errorMessage);
 }
 
-FileTypeChecker::FileType FileTypeChecker::getFileType(const std::map<std::string, boost::any>& opts, const std::string& fileTypeName) {
-  try {
+FileTypeChecker::FileType FileTypeChecker::getFileType(const std::map<std::string, boost::any>& opts, const std::string& fileTypeName)
+{
+  try
+  {
     auto option = any_cast<std::string>(opts.at(fileTypeName));
-    try {
+    try
+    {
       return fStringToFileType.at(option);
-    } catch (const std::out_of_range& outOfRangeFileTypeException) {
     }
-  } catch (const std::out_of_range& outOfRangeOptionException) {
+    catch (const std::out_of_range& outOfRangeFileTypeException)
+    {
+    }
+  }
+  catch (const std::out_of_range& outOfRangeOptionException)
+  {
     std::string errorMessage = "Out of range error in Options container ";
     handleErrorMessage(errorMessage, outOfRangeOptionException);
   }

--- a/Options/JPetOptionsTools/JPetOptionsTools.cpp
+++ b/Options/JPetOptionsTools/JPetOptionsTools.cpp
@@ -13,42 +13,27 @@
  *  @file JPetOptionsTools.cpp
  */
 
-#include "./JPetOptionsGenerator/JPetOptionsTypeHandler.h"
+#include "./JPetOptionsTools.h"
 #include "./JPetCommonTools/JPetCommonTools.h"
+#include "./JPetLoggerInclude.h"
+#include "./JPetOptionsGenerator/JPetOptionsTypeHandler.h"
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
-#include "./JPetLoggerInclude.h"
-#include "./JPetOptionsTools.h"
 #include <typeinfo>
 
 namespace pt = boost::property_tree;
 using boost::any_cast;
 
-namespace jpet_options_tools
-{
+namespace jpet_options_tools {
 
 std::map<std::string, FileTypeChecker::FileType> FileTypeChecker::fStringToFileType = {
-  {"", kNoType},
-  {"root", kRoot},
-  {"mcGeant", kMCGeant},
-  {"scope", kScope},
-  {"hld", kHld},
-  {"hldRoot", kHldRoot},
-  {"zip", kZip}
-};
+    {"", kNoType}, {"root", kRoot}, {"mcGeant", kMCGeant}, {"scope", kScope}, {"hld", kHld}, {"hldRoot", kHldRoot}, {"zip", kZip}};
 
-bool isOptionSet(const OptsStrAny& opts, const std::string& optionName)
-{
-  return static_cast<bool>(opts.count(optionName));
-}
+bool isOptionSet(const OptsStrAny& opts, const std::string& optionName) { return static_cast<bool>(opts.count(optionName)); }
 
-boost::any getOptionValue(const OptsStrAny& opts, std::string optionName)
-{
-  return opts.at(optionName);
-}
+boost::any getOptionValue(const OptsStrAny& opts, std::string optionName) { return opts.at(optionName); }
 
-std::string getOptionAsString(const OptsStrAny& opts, std::string optionName)
-{
+std::string getOptionAsString(const OptsStrAny& opts, std::string optionName) {
   try {
     return any_cast<std::string>(getOptionValue(opts, optionName));
   } catch (const std::exception& excep) {
@@ -57,8 +42,7 @@ std::string getOptionAsString(const OptsStrAny& opts, std::string optionName)
   }
 }
 
-int getOptionAsInt(const OptsStrAny& opts, std::string optionName)
-{
+int getOptionAsInt(const OptsStrAny& opts, std::string optionName) {
   try {
     return any_cast<int>(getOptionValue(opts, optionName));
   } catch (const std::exception& excep) {
@@ -67,8 +51,7 @@ int getOptionAsInt(const OptsStrAny& opts, std::string optionName)
   }
 }
 
-float getOptionAsFloat(const OptsStrAny& opts, std::string optionName)
-{
+float getOptionAsFloat(const OptsStrAny& opts, std::string optionName) {
   try {
     return any_cast<float>(getOptionValue(opts, optionName));
   } catch (const std::exception& excep) {
@@ -77,8 +60,7 @@ float getOptionAsFloat(const OptsStrAny& opts, std::string optionName)
   }
 }
 
-double getOptionAsDouble(const OptsStrAny& opts, std::string optionName)
-{
+double getOptionAsDouble(const OptsStrAny& opts, std::string optionName) {
   try {
     return any_cast<double>(getOptionValue(opts, optionName));
   } catch (const std::exception& excep) {
@@ -87,8 +69,7 @@ double getOptionAsDouble(const OptsStrAny& opts, std::string optionName)
   }
 }
 
-std::vector<std::string> getOptionAsVectorOfStrings(const OptsStrAny& opts, std::string optionName)
-{
+std::vector<std::string> getOptionAsVectorOfStrings(const OptsStrAny& opts, std::string optionName) {
   try {
     return any_cast<std::vector<std::string>>(getOptionValue(opts, optionName));
   } catch (const std::exception& excep) {
@@ -98,8 +79,7 @@ std::vector<std::string> getOptionAsVectorOfStrings(const OptsStrAny& opts, std:
   }
 }
 
-bool getOptionAsBool(const OptsStrAny& opts, std::string optionName)
-{
+bool getOptionAsBool(const OptsStrAny& opts, std::string optionName) {
   try {
     return any_cast<bool>(getOptionValue(opts, optionName));
   } catch (const std::exception& excep) {
@@ -108,14 +88,12 @@ bool getOptionAsBool(const OptsStrAny& opts, std::string optionName)
   }
 }
 
-
 /**
  * Specialized getter functions to extract option values with predefined names
  * This function returns a valid result only if the inputFile option is given
  * in the untransformed form: std::vector<std::string>
  */
-std::vector<std::string> getInputFiles(const std::map<std::string, boost::any>& opts)
-{
+std::vector<std::string> getInputFiles(const std::map<std::string, boost::any>& opts) {
   std::vector<std::string> dummy;
   if (!isOptionSet(opts, "file_std::vector<std::string>")) {
     ERROR("key:file_std::vector<std::string> not found in options");
@@ -128,40 +106,23 @@ std::vector<std::string> getInputFiles(const std::map<std::string, boost::any>& 
  * This function returns a valid result only if the inputFile option is given
  * in the transformed form with _std::string suffix
  */
-std::string getInputFile(const std::map<std::string, boost::any>& opts)
-{
-  return any_cast<std::string>(opts.at("inputFile_std::string"));
-}
+std::string getInputFile(const std::map<std::string, boost::any>& opts) { return any_cast<std::string>(opts.at("inputFile_std::string")); }
 
-std::string getScopeConfigFile(const std::map<std::string, boost::any>& opts)
-{
+std::string getScopeConfigFile(const std::map<std::string, boost::any>& opts) {
   return any_cast<std::string>(opts.at("scopeConfigFile_std::string"));
 }
 
-std::string getScopeInputDirectory(const std::map<std::string, boost::any>& opts)
-{
+std::string getScopeInputDirectory(const std::map<std::string, boost::any>& opts) {
   return any_cast<std::string>(opts.at("scopeInputDirectory_std::string"));
 }
 
-std::string getOutputFile(const std::map<std::string, boost::any>& opts)
-{
-  return any_cast<std::string>(opts.at("outputFile_std::string"));
-}
+std::string getOutputFile(const std::map<std::string, boost::any>& opts) { return any_cast<std::string>(opts.at("outputFile_std::string")); }
 
-std::string getOutputPath(const std::map<std::string, boost::any>& opts)
-{
-  return any_cast<std::string>(opts.at("outputPath_std::string"));
-}
+std::string getOutputPath(const std::map<std::string, boost::any>& opts) { return any_cast<std::string>(opts.at("outputPath_std::string")); }
 
-long long getFirstEvent(const std::map<std::string, boost::any>& opts)
-{
-  return any_cast<int>(opts.at("firstEvent_int"));
-}
+long long getFirstEvent(const std::map<std::string, boost::any>& opts) { return any_cast<int>(opts.at("firstEvent_int")); }
 
-long long getLastEvent(const std::map<std::string, boost::any>& opts)
-{
-  return any_cast<int>(opts.at("lastEvent_int"));
-}
+long long getLastEvent(const std::map<std::string, boost::any>& opts) { return any_cast<int>(opts.at("lastEvent_int")); }
 
 /**
  * It returns the total number of events calculated from the first and the last
@@ -169,8 +130,7 @@ long long getLastEvent(const std::map<std::string, boost::any>& opts)
  * set to -1 then the -1 is returned. If last - first < 0 then -1 is returned.
  * Otherwise last - first +1 is returned.
  */
-long long getTotalEvents(const std::map<std::string, boost::any>& opts)
-{
+long long getTotalEvents(const std::map<std::string, boost::any>& opts) {
   long long first = getFirstEvent(opts);
   long long last = getLastEvent(opts);
   long long diff = -1;
@@ -180,36 +140,22 @@ long long getTotalEvents(const std::map<std::string, boost::any>& opts)
   return diff;
 }
 
-int getRunNumber(const std::map<std::string, boost::any>& opts)
-{
-  return any_cast<int>(opts.at("runId_int"));
-}
+int getRunNumber(const std::map<std::string, boost::any>& opts) { return any_cast<int>(opts.at("runId_int")); }
 
-bool isProgressBar(const std::map<std::string, boost::any>& opts)
-{
-  return any_cast<bool>(opts.at("progressBar_bool"));
-}
+bool isProgressBar(const std::map<std::string, boost::any>& opts) { return any_cast<bool>(opts.at("progressBar_bool")); }
 
-bool isLocalDB(const std::map<std::string, boost::any>& opts)
-{
-  return (bool)opts.count("localDB_std::string");
-}
+bool isLocalDB(const std::map<std::string, boost::any>& opts) { return (bool)opts.count("localDB_std::string"); }
 
-std::string getLocalDB(const std::map<std::string, boost::any>& opts)
-{
+std::string getLocalDB(const std::map<std::string, boost::any>& opts) {
   std::string result("");
   if (isLocalDB(opts)) {
     result = any_cast<std::string>(opts.at("localDB_std::string"));
   }
   return result;
 }
-bool isLocalDBCreate(const std::map<std::string, boost::any>& opts)
-{
-  return (bool)opts.count("localDBCreate_std::string");
-}
+bool isLocalDBCreate(const std::map<std::string, boost::any>& opts) { return (bool)opts.count("localDBCreate_std::string"); }
 
-std::string getLocalDBCreate(const std::map<std::string, boost::any>& opts)
-{
+std::string getLocalDBCreate(const std::map<std::string, boost::any>& opts) {
   std::string result("");
   if (isLocalDBCreate(opts)) {
     result = any_cast<std::string>(opts.at("localDBCreate_std::string"));
@@ -217,18 +163,15 @@ std::string getLocalDBCreate(const std::map<std::string, boost::any>& opts)
   return result;
 }
 
-std::string getUnpackerConfigFile(const std::map<std::string, boost::any>& opts)
-{
+std::string getUnpackerConfigFile(const std::map<std::string, boost::any>& opts) {
   return any_cast<std::string>(opts.at("unpackerConfigFile_std::string"));
 }
 
-std::string getUnpackerCalibFile(const std::map<std::string, boost::any>& opts)
-{
+std::string getUnpackerCalibFile(const std::map<std::string, boost::any>& opts) {
   return any_cast<std::string>(opts.at("unpackerCalibFile_std::string"));
 }
 
-std::string getConfigFileName(const std::map<std::string, boost::any>& optsMap)
-{
+std::string getConfigFileName(const std::map<std::string, boost::any>& optsMap) {
   if (optsMap.count("userCfg_std::string")) {
     return any_cast<std::string>(optsMap.at("userCfg_std::string"));
   } else {
@@ -236,8 +179,7 @@ std::string getConfigFileName(const std::map<std::string, boost::any>& optsMap)
   }
 }
 
-void printOptions(const OptsStrAny& opts)
-{
+void printOptions(const OptsStrAny& opts) {
   std::cout << "Current options:" << std::endl;
   auto stringOptions = JPetOptionsTypeHandler::anyMapToStringMap(opts);
   for (const auto& el : stringOptions) {
@@ -245,8 +187,7 @@ void printOptions(const OptsStrAny& opts)
   }
 }
 
-void printOptionsToLog(const OptsStrAny& opts, const std::string& firstLine)
-{
+void printOptionsToLog(const OptsStrAny& opts, const std::string& firstLine) {
   if (!firstLine.empty()) {
     INFO(firstLine.c_str());
   }
@@ -260,8 +201,7 @@ void printOptionsToLog(const OptsStrAny& opts, const std::string& firstLine)
 /**
  * Creates json file based on given options.
  */
-bool createConfigFileFromOptions(const OptsStrStr& options, const std::string& outFile)
-{
+bool createConfigFileFromOptions(const OptsStrStr& options, const std::string& outFile) {
   pt::ptree optionsTree;
   for (auto& entry : options)
     optionsTree.put(entry.first, entry.second);
@@ -277,8 +217,7 @@ bool createConfigFileFromOptions(const OptsStrStr& options, const std::string& o
 /**
  * Creates option map based on the content of the json file.
  */
-std::map<std::string, boost::any> createOptionsFromConfigFile(const std::string& filename)
-{
+std::map<std::string, boost::any> createOptionsFromConfigFile(const std::string& filename) {
   pt::ptree optionsTree;
   std::map<std::string, boost::any> mapOptions, emptyMap;
   if (JPetCommonTools::ifFileExisting(filename)) {
@@ -288,39 +227,47 @@ std::map<std::string, boost::any> createOptionsFromConfigFile(const std::string&
         auto key = item.first;
         std::string typeOfOption = JPetOptionsTypeHandler::getTypeOfOption(key);
         auto allowedTypes = JPetOptionsTypeHandler::getAllowedTypes();
-        if (std::find(allowedTypes.begin(), allowedTypes.end(), typeOfOption) != allowedTypes.end()) {
-          if (typeOfOption == "int") {
-            auto value = item.second.get_value<int>();
-            mapOptions.insert(std::make_pair(key, value));
-          } else if (typeOfOption == "std::string") {
-            auto value = item.second.get_value<std::string>();
-            mapOptions.insert(std::make_pair(key, value));
-          } else if (typeOfOption == "float") {
-            auto value = item.second.get_value<float>();
-            mapOptions.insert(std::make_pair(key, value));
-          } else if (typeOfOption == "double") {
-            auto value = item.second.get_value<double>();
-            mapOptions.insert(std::make_pair(key, value));
-          } else if (typeOfOption == "bool") {
-            auto value = item.second.get_value<bool>();
-            mapOptions.insert(std::make_pair(key, value));
-          } else if (typeOfOption == "std::vector<std::string>") {
+        switch (allowedTypes[typeOfOption]) {
+        case JPetOptionsTypeHandler::kAllowedTypes::kInt:
+          mapOptions.insert(std::make_pair(key, item.second.get_value<int>()));
+          break;
+        case JPetOptionsTypeHandler::kAllowedTypes::kString:
+          mapOptions.insert(std::make_pair(key, item.second.get_value<std::string>()));
+          break;
+        case JPetOptionsTypeHandler::kAllowedTypes::kFloat:
+          mapOptions.insert(std::make_pair(key, item.second.get_value<float>()));
+          break;
+        case JPetOptionsTypeHandler::kAllowedTypes::kDouble:
+          mapOptions.insert(std::make_pair(key, item.second.get_value<double>()));
+          break;
+        case JPetOptionsTypeHandler::kAllowedTypes::kBool:
+          mapOptions.insert(std::make_pair(key, item.second.get_value<bool>()));
+          break;
+        case JPetOptionsTypeHandler::kAllowedTypes::kVectorString:
+          mapOptions.insert(std::make_pair(key, [&optionsTree, &key]() -> std::vector<std::string> {
             std::vector<std::string> values;
             for (pt::ptree::value_type& value : optionsTree.get_child(key)) {
               values.push_back(value.second.get_value<std::string>());
             }
-            mapOptions.insert(std::make_pair(key, values));
-          } else if (typeOfOption == "std::vector<int>") {
+            return values;
+          }));
+          break;
+        case JPetOptionsTypeHandler::kAllowedTypes::kVectorInt:
+          mapOptions.insert(std::make_pair(key, [&optionsTree, &key]() -> std::vector<int> {
             std::vector<int> values;
             for (pt::ptree::value_type& value : optionsTree.get_child(key)) {
               values.push_back(value.second.get_value<int>());
             }
-            mapOptions.insert(std::make_pair(key, values));
-          }
+            return values;
+          }));
+          break;
+        default:
+          WARNING("Unknow option type: " + typeOfOption + " skipping option: " + key);
+          break;
         }
       }
     } catch (pt::json_parser_error) {
-      ERROR("ERROR IN READINIG OPTIONS FROM JSON FILE! FILENAME:" + filename );
+      ERROR("ERROR IN READINIG OPTIONS FROM JSON FILE! FILENAME:" + filename);
       return emptyMap;
     }
   } else {
@@ -329,24 +276,20 @@ std::map<std::string, boost::any> createOptionsFromConfigFile(const std::string&
   return mapOptions;
 }
 
-FileTypeChecker::FileType FileTypeChecker::getInputFileType(const std::map<std::string, boost::any>& opts)
-{
+FileTypeChecker::FileType FileTypeChecker::getInputFileType(const std::map<std::string, boost::any>& opts) {
   return getFileType(opts, "inputFileType_std::string");
 }
 
-FileTypeChecker::FileType FileTypeChecker::getOutputFileType(const std::map<std::string, boost::any>& opts)
-{
+FileTypeChecker::FileType FileTypeChecker::getOutputFileType(const std::map<std::string, boost::any>& opts) {
   return getFileType(opts, "outputFileType_std::string");
 }
 
-void FileTypeChecker::handleErrorMessage(const std::string& errorMessage, const std::out_of_range& outOfRangeException)
-{
+void FileTypeChecker::handleErrorMessage(const std::string& errorMessage, const std::out_of_range& outOfRangeException) {
   std::cerr << errorMessage << outOfRangeException.what() << '\n';
   ERROR(errorMessage);
 }
 
-FileTypeChecker::FileType FileTypeChecker::getFileType(const std::map<std::string, boost::any>& opts, const std::string& fileTypeName)
-{
+FileTypeChecker::FileType FileTypeChecker::getFileType(const std::map<std::string, boost::any>& opts, const std::string& fileTypeName) {
   try {
     auto option = any_cast<std::string>(opts.at(fileTypeName));
     try {
@@ -360,4 +303,4 @@ FileTypeChecker::FileType FileTypeChecker::getFileType(const std::map<std::strin
   return FileType::kUndefinedFileType;
 }
 
-}
+} // namespace jpet_options_tools

--- a/Options/JPetOptionsTools/JPetOptionsTools.cpp
+++ b/Options/JPetOptionsTools/JPetOptionsTools.cpp
@@ -31,9 +31,9 @@ std::map<std::string, FileTypeChecker::FileType> FileTypeChecker::fStringToFileT
 
 bool isOptionSet(const OptsStrAny& opts, const std::string& optionName) { return static_cast<bool>(opts.count(optionName)); }
 
-boost::any getOptionValue(const OptsStrAny& opts, std::string optionName) { return opts.at(optionName); }
+boost::any getOptionValue(const OptsStrAny& opts, const std::string& optionName) { return opts.at(optionName); }
 
-std::string getOptionAsString(const OptsStrAny& opts, std::string optionName) {
+std::string getOptionAsString(const OptsStrAny& opts, const std::string& optionName) {
   try {
     return any_cast<std::string>(getOptionValue(opts, optionName));
   } catch (const std::exception& excep) {
@@ -42,7 +42,7 @@ std::string getOptionAsString(const OptsStrAny& opts, std::string optionName) {
   }
 }
 
-int getOptionAsInt(const OptsStrAny& opts, std::string optionName) {
+int getOptionAsInt(const OptsStrAny& opts, const std::string& optionName) {
   try {
     return any_cast<int>(getOptionValue(opts, optionName));
   } catch (const std::exception& excep) {
@@ -51,7 +51,7 @@ int getOptionAsInt(const OptsStrAny& opts, std::string optionName) {
   }
 }
 
-float getOptionAsFloat(const OptsStrAny& opts, std::string optionName) {
+float getOptionAsFloat(const OptsStrAny& opts, const std::string& optionName) {
   try {
     return any_cast<float>(getOptionValue(opts, optionName));
   } catch (const std::exception& excep) {
@@ -60,7 +60,7 @@ float getOptionAsFloat(const OptsStrAny& opts, std::string optionName) {
   }
 }
 
-double getOptionAsDouble(const OptsStrAny& opts, std::string optionName) {
+double getOptionAsDouble(const OptsStrAny& opts, const std::string& optionName) {
   try {
     return any_cast<double>(getOptionValue(opts, optionName));
   } catch (const std::exception& excep) {

--- a/Options/JPetOptionsTools/JPetOptionsTools.cpp
+++ b/Options/JPetOptionsTools/JPetOptionsTools.cpp
@@ -250,7 +250,7 @@ std::map<std::string, boost::any> createOptionsFromConfigFile(const std::string&
               values.push_back(value.second.get_value<std::string>());
             }
             return values;
-          }));
+          }()));
           break;
         case JPetOptionsTypeHandler::kAllowedTypes::kVectorInt:
           mapOptions.insert(std::make_pair(key, [&optionsTree, &key]() -> std::vector<int> {
@@ -259,7 +259,7 @@ std::map<std::string, boost::any> createOptionsFromConfigFile(const std::string&
               values.push_back(value.second.get_value<int>());
             }
             return values;
-          }));
+          }()));
           break;
         default:
           WARNING("Unknow option type: " + typeOfOption + " skipping option: " + key);

--- a/Options/JPetOptionsTools/JPetOptionsTools.cpp
+++ b/Options/JPetOptionsTools/JPetOptionsTools.cpp
@@ -116,6 +116,7 @@ std::string getScopeInputDirectory(const std::map<std::string, boost::any>& opts
   return any_cast<std::string>(opts.at("scopeInputDirectory_std::string"));
 }
 
+// cppcheck-suppress unusedFunction
 std::string getOutputFile(const std::map<std::string, boost::any>& opts) { return any_cast<std::string>(opts.at("outputFile_std::string")); }
 
 std::string getOutputPath(const std::map<std::string, boost::any>& opts) { return any_cast<std::string>(opts.at("outputPath_std::string")); }
@@ -179,6 +180,7 @@ std::string getConfigFileName(const std::map<std::string, boost::any>& optsMap) 
   }
 }
 
+// cppcheck-suppress unusedFunction
 void printOptions(const OptsStrAny& opts) {
   std::cout << "Current options:" << std::endl;
   auto stringOptions = JPetOptionsTypeHandler::anyMapToStringMap(opts);

--- a/Options/JPetOptionsTools/JPetOptionsTools.cpp
+++ b/Options/JPetOptionsTools/JPetOptionsTools.cpp
@@ -69,7 +69,7 @@ double getOptionAsDouble(const OptsStrAny& opts, const std::string& optionName) 
   }
 }
 
-std::vector<std::string> getOptionAsVectorOfStrings(const OptsStrAny& opts, std::string optionName) {
+std::vector<std::string> getOptionAsVectorOfStrings(const OptsStrAny& opts, const std::string& optionName) {
   try {
     return any_cast<std::vector<std::string>>(getOptionValue(opts, optionName));
   } catch (const std::exception& excep) {
@@ -79,7 +79,7 @@ std::vector<std::string> getOptionAsVectorOfStrings(const OptsStrAny& opts, std:
   }
 }
 
-bool getOptionAsBool(const OptsStrAny& opts, std::string optionName) {
+bool getOptionAsBool(const OptsStrAny& opts, const std::string& optionName) {
   try {
     return any_cast<bool>(getOptionValue(opts, optionName));
   } catch (const std::exception& excep) {

--- a/Options/JPetOptionsTools/JPetOptionsTools.h
+++ b/Options/JPetOptionsTools/JPetOptionsTools.h
@@ -27,7 +27,8 @@
  * Options are represented as:
  * std::map<std::string, boost::any> a.k.a. OptsStrAny
  */
-namespace jpet_options_tools {
+namespace jpet_options_tools
+{
 using OptsStrAny = std::map<std::string, boost::any>;
 using OptsStrStr = std::map<std::string, std::string>;
 bool isOptionSet(const OptsStrAny& opts, const std::string& optionName);
@@ -37,6 +38,7 @@ int getOptionAsInt(const OptsStrAny& opts, const std::string& optionName);
 float getOptionAsFloat(const OptsStrAny& opts, const std::string& optionName);
 double getOptionAsDouble(const OptsStrAny& opts, const std::string& optionName);
 std::vector<std::string> getOptionAsVectorOfStrings(const OptsStrAny& opts, const std::string& optionName);
+std::vector<int> getOptionAsVectorOfInts(const OptsStrAny& opts, const std::string& optionName);
 bool getOptionAsBool(const OptsStrAny& opts, const std::string& optionName);
 std::vector<std::string> getInputFiles(const OptsStrAny& opts);
 std::string getInputFile(const OptsStrAny& opts);
@@ -61,9 +63,20 @@ void printOptionsToLog(const OptsStrAny& opts, const std::string& firstLine);
 bool createConfigFileFromOptions(const OptsStrStr& options, const std::string& outFile = "");
 OptsStrAny createOptionsFromConfigFile(const std::string& inFile);
 
-class FileTypeChecker {
+class FileTypeChecker
+{
 public:
-  enum FileType { kNoType, kRoot, kScope, kHld, kHldRoot, kZip, kMCGeant, kUndefinedFileType };
+  enum FileType
+  {
+    kNoType,
+    kRoot,
+    kScope,
+    kHld,
+    kHldRoot,
+    kZip,
+    kMCGeant,
+    kUndefinedFileType
+  };
   static FileType getInputFileType(const OptsStrAny& opts);
   static FileType getOutputFileType(const OptsStrAny& opts);
 

--- a/Options/JPetOptionsTools/JPetOptionsTools.h
+++ b/Options/JPetOptionsTools/JPetOptionsTools.h
@@ -18,8 +18,8 @@
 
 #include "./JPetOptionsTools/JPetOptionsTransformators.h"
 #include <boost/any.hpp>
-#include <vector>
 #include <map>
+#include <vector>
 
 /**
  * @brief Set of helper methods to operate on options.
@@ -27,18 +27,17 @@
  * Options are represented as:
  * std::map<std::string, boost::any> a.k.a. OptsStrAny
  */
-namespace jpet_options_tools
-{
+namespace jpet_options_tools {
 using OptsStrAny = std::map<std::string, boost::any>;
 using OptsStrStr = std::map<std::string, std::string>;
 bool isOptionSet(const OptsStrAny& opts, const std::string& optionName);
-boost::any getOptionValue(const OptsStrAny& opts, std::string optionName);
-std::string getOptionAsString(const OptsStrAny& opts, std::string optionName);
-int getOptionAsInt(const OptsStrAny& opts, std::string optionName);
-float getOptionAsFloat(const OptsStrAny& opts, std::string optionName);
-double getOptionAsDouble(const OptsStrAny& opts, std::string optionName);
-std::vector<std::string> getOptionAsVectorOfStrings(const OptsStrAny& opts, std::string optionName);
-bool getOptionAsBool(const OptsStrAny& opts, std::string optionName);
+boost::any getOptionValue(const OptsStrAny& opts, const std::string& optionName);
+std::string getOptionAsString(const OptsStrAny& opts, const std::string& optionName);
+int getOptionAsInt(const OptsStrAny& opts, const std::string& optionName);
+float getOptionAsFloat(const OptsStrAny& opts, const std::string& optionName);
+double getOptionAsDouble(const OptsStrAny& opts, const std::string& optionName);
+std::vector<std::string> getOptionAsVectorOfStrings(const OptsStrAny& opts, const std::string& optionName);
+bool getOptionAsBool(const OptsStrAny& opts, const std::string& optionName);
 std::vector<std::string> getInputFiles(const OptsStrAny& opts);
 std::string getInputFile(const OptsStrAny& opts);
 std::string getScopeConfigFile(const OptsStrAny& opts);
@@ -62,12 +61,9 @@ void printOptionsToLog(const OptsStrAny& opts, const std::string& firstLine);
 bool createConfigFileFromOptions(const OptsStrStr& options, const std::string& outFile = "");
 OptsStrAny createOptionsFromConfigFile(const std::string& inFile);
 
-class FileTypeChecker
-{
+class FileTypeChecker {
 public:
-  enum FileType {
-    kNoType, kRoot, kScope, kHld, kHldRoot, kZip, kMCGeant, kUndefinedFileType
-  };
+  enum FileType { kNoType, kRoot, kScope, kHld, kHldRoot, kZip, kMCGeant, kUndefinedFileType };
   static FileType getInputFileType(const OptsStrAny& opts);
   static FileType getOutputFileType(const OptsStrAny& opts);
 
@@ -80,5 +76,5 @@ private:
   static std::map<std::string, FileType> fStringToFileType;
 };
 
-}
+} // namespace jpet_options_tools
 #endif /* !JPETOPTIONSTOOLS_H */

--- a/Options/JPetOptionsTools/JPetOptionsToolsTest.cpp
+++ b/Options/JPetOptionsTools/JPetOptionsToolsTest.cpp
@@ -190,18 +190,21 @@ BOOST_AUTO_TEST_CASE(getTotalEventsTest)
 BOOST_AUTO_TEST_CASE(getOptionBy)
 {
   std::vector<std::string> tmp = {"aa", "bb"};
+  std::vector<int> intVector = {1, 2, 3};
   std::map<std::string, boost::any> opts = {{"my_string", std::string("my_value")},
                                             {"my_int", int(12)},
                                             {"my_float", float(12.5)},
                                             {"my_double", double(14.6)},
                                             {"my_bool", false},
-                                            {"my_vectS", tmp}};
+                                            {"my_vectS", tmp},
+                                            {"my_intV", intVector}};
   BOOST_REQUIRE_EQUAL(getOptionAsString(opts, "my_string"), std::string("my_value"));
   BOOST_REQUIRE_EQUAL(getOptionAsInt(opts, "my_int"), 12);
   BOOST_REQUIRE_EQUAL(getOptionAsFloat(opts, "my_float"), 12.5);
   BOOST_REQUIRE_EQUAL(getOptionAsDouble(opts, "my_double"), 14.6);
   BOOST_REQUIRE(!getOptionAsVectorOfStrings(opts, "my_vectS").empty());
   BOOST_REQUIRE_EQUAL(getOptionAsVectorOfStrings(opts, "my_vectS").size(), 2u);
+  BOOST_REQUIRE_EQUAL(getOptionAsVectorOfStrings(opts, "my_intV").size(), 3u);
   BOOST_REQUIRE_EQUAL(getOptionAsBool(opts, "my_bool"), false);
 }
 

--- a/Options/JPetOptionsTools/JPetOptionsToolsTest.cpp
+++ b/Options/JPetOptionsTools/JPetOptionsToolsTest.cpp
@@ -204,7 +204,7 @@ BOOST_AUTO_TEST_CASE(getOptionBy)
   BOOST_REQUIRE_EQUAL(getOptionAsDouble(opts, "my_double"), 14.6);
   BOOST_REQUIRE(!getOptionAsVectorOfStrings(opts, "my_vectS").empty());
   BOOST_REQUIRE_EQUAL(getOptionAsVectorOfStrings(opts, "my_vectS").size(), 2u);
-  BOOST_REQUIRE_EQUAL(getOptionAsVectorOfStrings(opts, "my_intV").size(), 3u);
+  BOOST_REQUIRE_EQUAL(getOptionAsVectorOfInts(opts, "my_intV").size(), 3u);
   BOOST_REQUIRE_EQUAL(getOptionAsBool(opts, "my_bool"), false);
 }
 

--- a/Options/JPetOptionsTools/JPetOptionsToolsTest.cpp
+++ b/Options/JPetOptionsTools/JPetOptionsToolsTest.cpp
@@ -1,13 +1,13 @@
 #define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MODULE JPetOptionsTest
-#include <boost/test/unit_test.hpp>
 #include "JPetOptionsTools.h"
-#include <boost/filesystem.hpp>
-#include <iostream>
+#include "./JPetOptionsGenerator/JPetOptionsTypeHandler.h"
 #include <boost/any.hpp>
+#include <boost/filesystem.hpp>
+#include <boost/test/unit_test.hpp>
+#include <iostream>
 #include <string>
 #include <typeinfo>
-#include "./JPetOptionsGenerator/JPetOptionsTypeHandler.h"
 using boost::any_cast;
 const std::string dataDir = "unitTestData/JPetOptionsToolsTest/";
 using namespace std;
@@ -15,7 +15,7 @@ using namespace jpet_options_tools;
 
 BOOST_AUTO_TEST_SUITE(FirstSuite)
 
-BOOST_AUTO_TEST_CASE( createConfigFileFromOptions )
+BOOST_AUTO_TEST_CASE(createConfigFileFromOptions)
 {
   std::map<std::string, std::string> options = {{"TimeWindow", "10"}, {"SomeOption", "true"}, {"AnotherOption", "4.5"}};
   std::string outFile = "test_cfg.json";
@@ -27,7 +27,8 @@ BOOST_AUTO_TEST_CASE(createOptionsFromConfigFile)
 {
   auto inFile = "unitTestData/JPetOptionsToolsTest/newInputTestCfg.json";
   std::map<std::string, boost::any> options = jpet_options_tools::createOptionsFromConfigFile(inFile);
-  std::map<std::string, std::string> expectedStringMap = {{"myOption_std::string", "great"}, {"myAnotherOption_std::string", "wat"}, {"NumberOption_std::string", "12.2"}};
+  std::map<std::string, std::string> expectedStringMap = {
+      {"myOption_std::string", "great"}, {"myAnotherOption_std::string", "wat"}, {"NumberOption_std::string", "12.2"}};
   std::map<std::string, boost::any> expected(expectedStringMap.begin(), expectedStringMap.end());
   expected["intOption_int"] = 123;
   expected["boolOption_bool"] = true;
@@ -39,37 +40,42 @@ BOOST_AUTO_TEST_CASE(createOptionsFromConfigFile)
 
   std::vector<std::string> keys_expected;
   std::vector<std::string> keys;
-  for (const auto& el : expected) {
-    keys_expected.push_back(el.first);
-  }
-  for (const auto& el : options) {
-    keys.push_back(el.first);
-  }
+  for (const auto& el : expected) { keys_expected.push_back(el.first); }
+  for (const auto& el : options) { keys.push_back(el.first); }
   std::sort(keys.begin(), keys.end());
   std::sort(keys_expected.begin(), keys_expected.end());
   BOOST_REQUIRE_EQUAL_COLLECTIONS(keys.begin(), keys.end(), keys_expected.begin(), keys_expected.end());
 
-  std::vector<std::string> allowedTypes = { "int", "std::string", "bool", "std::vector<std::string>", "std::vector<int>"};
-  for (const auto& opt :  options) {
-    if (JPetOptionsTypeHandler::getTypeOfOption(opt.first) == "std::string") {
-      BOOST_REQUIRE_EQUAL(any_cast<std::string>(opt.second), any_cast<std::string>(expected[opt.first]));
-    } else if (JPetOptionsTypeHandler::getTypeOfOption(opt.first) == "int") {
+  std::vector<std::string> allowedTypes = {"int", "std::string", "bool", "std::vector<std::string>", "std::vector<int>"};
+  for (const auto& opt : options)
+  {
+    if (JPetOptionsTypeHandler::getTypeOfOption(opt.first) == "std::string")
+    { BOOST_REQUIRE_EQUAL(any_cast<std::string>(opt.second), any_cast<std::string>(expected[opt.first])); }
+    else if (JPetOptionsTypeHandler::getTypeOfOption(opt.first) == "int")
+    {
       BOOST_REQUIRE_EQUAL(any_cast<int>(opt.second), any_cast<int>(expected[opt.first]));
-    } else if (JPetOptionsTypeHandler::getTypeOfOption(opt.first) == "bool") {
+    }
+    else if (JPetOptionsTypeHandler::getTypeOfOption(opt.first) == "bool")
+    {
       BOOST_REQUIRE_EQUAL(any_cast<bool>(opt.second), any_cast<bool>(expected[opt.first]));
-    } else if (JPetOptionsTypeHandler::getTypeOfOption(opt.first) == "std::vector<std::string>") {
-      auto vectorStringOption =  any_cast< std::vector<std::string> >(opt.second);
+    }
+    else if (JPetOptionsTypeHandler::getTypeOfOption(opt.first) == "std::vector<std::string>")
+    {
+      auto vectorStringOption = any_cast<std::vector<std::string>>(opt.second);
       BOOST_REQUIRE_EQUAL_COLLECTIONS(vectorStringOption.begin(), vectorStringOption.end(), v1.begin(), v1.end());
-    } else if (JPetOptionsTypeHandler::getTypeOfOption(opt.first) == "std::vector<int>") {
-      auto vectorIntOption =  any_cast< std::vector<int> >(opt.second);
+    }
+    else if (JPetOptionsTypeHandler::getTypeOfOption(opt.first) == "std::vector<int>")
+    {
+      auto vectorIntOption = any_cast<std::vector<int>>(opt.second);
       BOOST_REQUIRE_EQUAL_COLLECTIONS(vectorIntOption.begin(), vectorIntOption.end(), v2.begin(), v2.end());
     }
   }
 }
 
-BOOST_AUTO_TEST_CASE( createConfigFileFromOptionsAndReadItBack )
+BOOST_AUTO_TEST_CASE(createConfigFileFromOptionsAndReadItBack)
 {
-  std::map<std::string, std::string> options = {{"TimeWindow_std::string", "11"}, {"SomeOption_std::string", "false"}, {"AnotherOption_std::string", "4.5"}};
+  std::map<std::string, std::string> options = {
+      {"TimeWindow_std::string", "11"}, {"SomeOption_std::string", "false"}, {"AnotherOption_std::string", "4.5"}};
   std::string cfgFile = "test_cfg2.json";
   BOOST_REQUIRE(jpet_options_tools::createConfigFileFromOptions(options, cfgFile));
   auto loadedOptions = jpet_options_tools::createOptionsFromConfigFile(cfgFile);
@@ -78,11 +84,13 @@ BOOST_AUTO_TEST_CASE( createConfigFileFromOptionsAndReadItBack )
   std::vector<std::string> values_expected;
   std::vector<std::string> keys;
   std::vector<std::string> values;
-  for (const auto& el : loadedOptions) {
+  for (const auto& el : loadedOptions)
+  {
     keys_expected.push_back(el.first);
     values_expected.push_back(any_cast<std::string>(el.second));
   }
-  for (const auto& el : options) {
+  for (const auto& el : options)
+  {
     keys.push_back(el.first);
     values.push_back(el.second);
   }
@@ -93,17 +101,16 @@ BOOST_AUTO_TEST_CASE( createConfigFileFromOptionsAndReadItBack )
   BOOST_REQUIRE_EQUAL_COLLECTIONS(keys.begin(), keys.end(), keys_expected.begin(), keys_expected.end());
   BOOST_REQUIRE_EQUAL_COLLECTIONS(values.begin(), values.end(), values_expected.begin(), values_expected.end());
   boost::filesystem::remove("test_cfg2.json");
-
 }
 
-BOOST_AUTO_TEST_CASE( createOptionsFromConfigFileThatDoesNotExist )
+BOOST_AUTO_TEST_CASE(createOptionsFromConfigFileThatDoesNotExist)
 {
   auto inFile = "nonExistingTestCfg.json";
   auto options = jpet_options_tools::createOptionsFromConfigFile(inFile);
   BOOST_REQUIRE(options.empty());
 }
 
-BOOST_AUTO_TEST_CASE( createConfigFileFromEmptyMap )
+BOOST_AUTO_TEST_CASE(createConfigFileFromEmptyMap)
 {
   jpet_options_tools::OptsStrStr options = {};
   std::string cfgFile = "test_cfg3.json";
@@ -111,24 +118,21 @@ BOOST_AUTO_TEST_CASE( createConfigFileFromEmptyMap )
   boost::filesystem::remove("test_cfg3.json");
 }
 
-
-BOOST_AUTO_TEST_CASE( createOptionsFromConfigFileThatHasWrongFormat )
+BOOST_AUTO_TEST_CASE(createOptionsFromConfigFileThatHasWrongFormat)
 {
   auto inFile = "unitTestData/JPetOptionsToolsTest/wrongInputFile.json";
   auto options = jpet_options_tools::createOptionsFromConfigFile(inFile);
-  BOOST_REQUIRE_EQUAL(options.size(),  0);
+  BOOST_REQUIRE_EQUAL(options.size(), 0);
 }
 
 BOOST_AUTO_TEST_CASE(checkIfGetOptionAndIsOptionWork)
 {
-  std::map<std::string, boost::any> options = {
-    {"firstEvent_int", -1},
-    {"lastEvent_int", -1},
-    {"progressBar_bool", false},
-    {"runId_int", -1},
-    {"unpackerConfigFile_std::string", std::string("conf_trb3.xml")},
-    {"unpackerCalibFile_std::string", std::string("")}
-  };
+  std::map<std::string, boost::any> options = {{"firstEvent_int", -1},
+                                               {"lastEvent_int", -1},
+                                               {"progressBar_bool", false},
+                                               {"runId_int", -1},
+                                               {"unpackerConfigFile_std::string", std::string("conf_trb3.xml")},
+                                               {"unpackerCalibFile_std::string", std::string("")}};
 
   BOOST_REQUIRE(isOptionSet(options, "firstEvent_int"));
   BOOST_REQUIRE(isOptionSet(options, "lastEvent_int"));
@@ -137,23 +141,20 @@ BOOST_AUTO_TEST_CASE(checkIfGetOptionAndIsOptionWork)
   BOOST_REQUIRE_EQUAL(any_cast<int>(getOptionValue(options, "lastEvent_int")), -1);
 }
 
-
 BOOST_AUTO_TEST_CASE(getTotalEventsTest)
 {
-  OptsStrAny options = {
-    {"inputFile_std::string", std::string("input")},
-    {"scopeConfigFile_std::string", std::string("test.json")},
-    {"scopeInputDirectory_std::string", std::string("scopeData")},
-    {"outputFile_std::string", std::string("output")},
-    {"firstEvent_int", -1},
-    {"lastEvent_int", -1},
-    {"runId_int", 2001},
-    {"progressBar_bool", true},
-    {"inputFileType_std::string", std::string("root")},
-    {"outputFileType_std::string", std::string("scope")},
-    {"unpackerConfigFile_std::string", std::string("conf_trb3.xml")},
-    {"unpackerCalibFile_std::string", std::string("")}
-  };
+  OptsStrAny options = {{"inputFile_std::string", std::string("input")},
+                        {"scopeConfigFile_std::string", std::string("test.json")},
+                        {"scopeInputDirectory_std::string", std::string("scopeData")},
+                        {"outputFile_std::string", std::string("output")},
+                        {"firstEvent_int", -1},
+                        {"lastEvent_int", -1},
+                        {"runId_int", 2001},
+                        {"progressBar_bool", true},
+                        {"inputFileType_std::string", std::string("root")},
+                        {"outputFileType_std::string", std::string("scope")},
+                        {"unpackerConfigFile_std::string", std::string("conf_trb3.xml")},
+                        {"unpackerCalibFile_std::string", std::string("")}};
   BOOST_REQUIRE_EQUAL(getTotalEvents(options), -1);
 
   options.at("firstEvent_int") = 0;
@@ -189,14 +190,12 @@ BOOST_AUTO_TEST_CASE(getTotalEventsTest)
 BOOST_AUTO_TEST_CASE(getOptionBy)
 {
   std::vector<std::string> tmp = {"aa", "bb"};
-  std::map<std::string, boost::any> opts = {
-    {"my_string", std::string("my_value")},
-    {"my_int", int(12)},
-    {"my_float", float(12.5)},
-    {"my_double", double(14.6)},
-    {"my_bool", false},
-    {"my_vectS", tmp}
-  };
+  std::map<std::string, boost::any> opts = {{"my_string", std::string("my_value")},
+                                            {"my_int", int(12)},
+                                            {"my_float", float(12.5)},
+                                            {"my_double", double(14.6)},
+                                            {"my_bool", false},
+                                            {"my_vectS", tmp}};
   BOOST_REQUIRE_EQUAL(getOptionAsString(opts, "my_string"), std::string("my_value"));
   BOOST_REQUIRE_EQUAL(getOptionAsInt(opts, "my_int"), 12);
   BOOST_REQUIRE_EQUAL(getOptionAsFloat(opts, "my_float"), 12.5);

--- a/Options/JPetOptionsTools/JPetOptionsToolsTest.cpp
+++ b/Options/JPetOptionsTools/JPetOptionsToolsTest.cpp
@@ -46,7 +46,6 @@ BOOST_AUTO_TEST_CASE(createOptionsFromConfigFile)
   std::sort(keys_expected.begin(), keys_expected.end());
   BOOST_REQUIRE_EQUAL_COLLECTIONS(keys.begin(), keys.end(), keys_expected.begin(), keys_expected.end());
 
-  std::vector<std::string> allowedTypes = {"int", "std::string", "bool", "std::vector<std::string>", "std::vector<int>"};
   for (const auto& opt : options)
   {
     if (JPetOptionsTypeHandler::getTypeOfOption(opt.first) == "std::string")


### PR DESCRIPTION
I needed to use std::vector<std::string>> as userParam and it was not correctly handled, so I cleaned up a little OptionsGenerator and OptionTools.

Now OptionsGenerator correctly handling situation, when it can't find type of userParam(prints WARNING)
Remove double check if userParam have correct type
Correctly handle  std::vector<std::string>> and  std::vector<int>> for changing to string(printing to log)
Adds missing getOptionAsVectorOfInts

Unfortunately it was done using ugly lambdas, but I still think it is better then it was before.