### PR TITLE
 Add possibility to control used tasks from UserParams

### DIFF
--- a/Core/JPetCommonTools/JPetCommonTools.cpp
+++ b/Core/JPetCommonTools/JPetCommonTools.cpp
@@ -123,10 +123,16 @@ std::string JPetCommonTools::replaceDataTypeInFileName(const std::string& filena
       return result;
     }
 
+    // handle only root files as a special case
+    if ( suffix == "root" ) {
+      auto result = prefix.append(newType).append(".root");
+      if ( !path.empty() ) result = path.append("/").append(result);
+      return result;
+    }
+
     auto pos2 = suffix.find(".root");
     if ( pos2 != std::string::npos ) {
-      auto root_extension = suffix.substr(pos2);
-      auto result = prefix.append(newType).append(root_extension);
+      auto result = prefix.append(newType).append(".root");
       if ( !path.empty() ) result = path.append("/").append(result);
       return result;
     }

--- a/Core/JPetCommonTools/JPetCommonTools.cpp
+++ b/Core/JPetCommonTools/JPetCommonTools.cpp
@@ -67,6 +67,7 @@ std::vector<const char*> JPetCommonTools::createArgs(const std::string& commandL
 /**
  * Get std::string with current date and time
  */
+// cppcheck-supress unusedFunction
 const std::string JPetCommonTools::currentDateTime()
 {
   time_t now = time(0);

--- a/Core/JPetCommonTools/JPetCommonToolsTest.cpp
+++ b/Core/JPetCommonTools/JPetCommonToolsTest.cpp
@@ -207,6 +207,11 @@ BOOST_AUTO_TEST_CASE(fileTypeSuffixOperations)
   path2 = JPetCommonTools::replaceDataTypeInFileName(path, "tslot.raw");
   BOOST_REQUIRE_EQUAL(path2, "/some/path/foo.tslot.raw.root");
   BOOST_REQUIRE_EQUAL(JPetCommonTools::extractDataTypeFromFileName(path2), "tslot.raw");
+
+  path = "/some/path/foo.root";
+  path2 = JPetCommonTools::replaceDataTypeInFileName(path, "tslot.raw");
+  BOOST_REQUIRE_EQUAL(path2, "/some/path/foo.tslot.raw.root");
+  BOOST_REQUIRE_EQUAL(JPetCommonTools::extractDataTypeFromFileName(path2), "tslot.raw");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/Core/JPetManager/JPetManager.cpp
+++ b/Core/JPetManager/JPetManager.cpp
@@ -149,8 +149,6 @@ void JPetManager::addUserParamsUsedTasks(
     const std::map<std::string, boost::any> &opts) {
   using namespace jpet_options_tools;
   std::vector<std::string> useTasksValue;
-  const std::string kUseTasksKey =
-      "JPetManager_useTasks_std::vector<std::string>";
   if (isOptionSet(opts, kUseTasksKey)) {
     useTasksValue = getOptionAsVectorOfStrings(opts, kUseTasksKey);
   }

--- a/Core/JPetManager/JPetManager.cpp
+++ b/Core/JPetManager/JPetManager.cpp
@@ -50,7 +50,7 @@ void JPetManager::run(int argc, const char **argv) {
                                                     /// check if the examples
                                                     /// are working
   }
-  registerDefaultTasks();
+  JPetManager::registerDefaultTasks();
   addUserParamsUsedTasks(allValidatedOptions);
   auto chainOfTasks =
       fTaskFactory.createTaskGeneratorChain(allValidatedOptions);
@@ -112,7 +112,6 @@ JPetManager::parseCmdLine(int argc, const char **argv) {
   return std::make_pair(true, allValidatedOptions);
 }
 
-// cppcheck-suppress unusedFunction
 void JPetManager::useTask(const std::string &name,
                           const std::string &inputFileType,
                           const std::string &outputFileType, int numTimes) {
@@ -142,7 +141,7 @@ void JPetManager::setThreadsEnabled(bool enable) {
 /// the map of tasks generators in advance. This provate method is intended to
 /// register all such tasks in advance of creation of the task generator chain.
 void JPetManager::registerDefaultTasks() {
-  registerTask<JPetGeantParser>("JPetGeantParser");
+  JPetManager::getManager().registerTask<JPetGeantParser>("JPetGeantParser");
 }
 
 void JPetManager::addUserParamsUsedTasks(

--- a/Core/JPetManager/JPetManager.cpp
+++ b/Core/JPetManager/JPetManager.cpp
@@ -32,53 +32,51 @@ using namespace jpet_options_tools;
 
 JPetManager::JPetManager() {}
 
-JPetManager& JPetManager::getManager()
-{
+JPetManager &JPetManager::getManager() {
   static JPetManager instance;
   return instance;
 }
 
-void JPetManager::run(int argc, const char** argv)
-{
+void JPetManager::run(int argc, const char **argv) {
   bool isOk = true;
   std::map<std::string, boost::any> allValidatedOptions;
   std::tie(isOk, allValidatedOptions) = parseCmdLine(argc, argv);
-  if (!isOk)
-  {
+  if (!isOk) {
     ERROR("While parsing command line arguments");
-    std::cerr << "Error has occurred while parsing command line! Check the log!" << std::endl;
-    throw std::invalid_argument("Error in parsing command line arguments"); /// temporary change to
-                                                                            /// check if the examples
-                                                                            /// are working
+    std::cerr << "Error has occurred while parsing command line! Check the log!"
+              << std::endl;
+    throw std::invalid_argument(
+        "Error in parsing command line arguments"); /// temporary change to
+                                                    /// check if the examples
+                                                    /// are working
   }
   JPetManager::registerDefaultTasks();
-  addUserParamsUsedTasks(allValidatedOptions);
-  auto chainOfTasks = fTaskFactory.createTaskGeneratorChain(allValidatedOptions);
+  useTasksFromUserParams(allValidatedOptions);
+  auto chainOfTasks =
+      fTaskFactory.createTaskGeneratorChain(allValidatedOptions);
   JPetOptionsGenerator optionsGenerator;
-  auto options = optionsGenerator.generateOptionsForTasks(allValidatedOptions, chainOfTasks.size());
+  auto options = optionsGenerator.generateOptionsForTasks(allValidatedOptions,
+                                                          chainOfTasks.size());
 
-  INFO("======== Starting processing all tasks: " + JPetCommonTools::getTimeString() + " ========\n");
-  std::vector<TThread*> threads;
+  INFO("======== Starting processing all tasks: " +
+       JPetCommonTools::getTimeString() + " ========\n");
+  std::vector<TThread *> threads;
   auto inputDataSeq = 0;
   /// For every input option, new TaskChainExecutor is created, which creates
   /// the chain of previously registered tasks. The inputDataSeq is the
   /// identifier of given chain.
-  for (auto opt : options)
-  {
-    auto executor = jpet_common_tools::make_unique<JPetTaskChainExecutor>(chainOfTasks, inputDataSeq, opt.second);
-    if (areThreadsEnabled())
-    {
+  for (auto opt : options) {
+    auto executor = jpet_common_tools::make_unique<JPetTaskChainExecutor>(
+        chainOfTasks, inputDataSeq, opt.second);
+    if (areThreadsEnabled()) {
       auto thr = executor->run();
-      if (thr) { threads.push_back(thr); }
-      else
-      {
+      if (thr) {
+        threads.push_back(thr);
+      } else {
         ERROR("thread pointer is null");
       }
-    }
-    else
-    {
-      if (!executor->process())
-      {
+    } else {
+      if (!executor->process()) {
         ERROR("While running process");
         std::cerr << "Stopping program, error has occurred while calling "
                      "executor->process! Check the log!"
@@ -88,73 +86,67 @@ void JPetManager::run(int argc, const char** argv)
     }
     inputDataSeq++;
   }
-  if (areThreadsEnabled())
-  {
-    for (auto thread : threads)
-    {
+  if (areThreadsEnabled()) {
+    for (auto thread : threads) {
       assert(thread);
       thread->Join();
     }
   }
-  INFO("======== Finished processing all tasks: " + JPetCommonTools::getTimeString() + " ========\n");
+  INFO("======== Finished processing all tasks: " +
+       JPetCommonTools::getTimeString() + " ========\n");
 }
 
-std::pair<bool, std::map<std::string, boost::any>> JPetManager::parseCmdLine(int argc, const char** argv)
-{
+std::pair<bool, std::map<std::string, boost::any>>
+JPetManager::parseCmdLine(int argc, const char **argv) {
   std::map<std::string, boost::any> allValidatedOptions;
-  try
-  {
+  try {
     JPetOptionsGenerator optionsGenerator;
     JPetCmdParser parser;
     auto optionsFromCmdLine = parser.parseCmdLineArgs(argc, argv);
-    allValidatedOptions = optionsGenerator.generateAndValidateOptions(optionsFromCmdLine);
-  }
-  catch (std::exception& e)
-  {
+    allValidatedOptions =
+        optionsGenerator.generateAndValidateOptions(optionsFromCmdLine);
+  } catch (std::exception &e) {
     ERROR(e.what());
     return std::make_pair(false, std::map<std::string, boost::any>{});
   }
   return std::make_pair(true, allValidatedOptions);
 }
 
-void JPetManager::useTask(const std::string& name, const std::string& inputFileType, const std::string& outputFileType, int numTimes)
-{
-  if (!fTaskFactory.addTaskInfo(name, inputFileType, outputFileType, numTimes))
-  {
-    std::cerr << "Error has occurred while calling useTask! Check the log!" << std::endl;
+void JPetManager::useTask(const std::string &name,
+                          const std::string &inputFileType,
+                          const std::string &outputFileType, int numTimes) {
+  if (!fTaskFactory.addTaskInfo(name, inputFileType, outputFileType,
+                                numTimes)) {
+    std::cerr << "Error has occurred while calling useTask! Check the log!"
+              << std::endl;
     throw std::runtime_error("error in addTaskInfo");
   }
 }
 
 bool JPetManager::areThreadsEnabled() const { return fThreadsEnabled; }
 
-void JPetManager::setThreadsEnabled(bool enable)
-{
+void JPetManager::setThreadsEnabled(bool enable) {
   fThreadsEnabled = enable;
   ENABLE_THREADS_INFO(enable);
 }
 
-/// @brief Adds any built-in tasks based on JPetTaskIO to the map of taska
-/// generators to facilitate their later generation on demand
-///
-/// Any built-in tasks which are handled by JPetTaskIO the same way as
-/// user-defined tasks (rather than using a dedicated task wrapper as is the
-/// case for JPetUnzipAndUpackTask or JPetParamBankHandlerTask) can be easily
-/// added to the chain of tasks using the same mehanics as exposed to the user
-/// for adding users' tasks prvided that the built-in tasks are registered in
-/// the map of tasks generators in advance. This provate method is intended to
-/// register all such tasks in advance of creation of the task generator chain.
-void JPetManager::registerDefaultTasks() { JPetManager::getManager().registerTask<JPetGeantParser>("JPetGeantParser"); }
+void JPetManager::registerDefaultTasks() {
+  JPetManager::getManager().registerTask<JPetGeantParser>("JPetGeantParser");
+}
 
-void JPetManager::addUserParamsUsedTasks(const std::map<std::string, boost::any>& opts)
-{
+void JPetManager::useTasksFromUserParams(
+    const std::map<std::string, boost::any> &opts) {
   using namespace jpet_options_tools;
   std::vector<std::string> useTasksValue;
-  if (isOptionSet(opts, kUseTasksKey)) { useTasksValue = getOptionAsVectorOfStrings(opts, kUseTasksKey); }
-  if (useTasksValue.size() % 3 != 0)
-  {
-    ERROR("WRONG number of parameters in " + kUseTasksKey + " userparam, do not adding any tasks from userParams");
+  if (isOptionSet(opts, kUseTasksFromParamsKey)) {
+    useTasksValue = getOptionAsVectorOfStrings(opts, kUseTasksFromParamsKey);
+  }
+  if (useTasksValue.size() % 3 != 0) {
+    ERROR("WRONG number of parameters in " + kUseTasksFromParamsKey +
+          " userparam, do not adding any tasks from userParams");
     return;
   }
-  for (unsigned int i = 0; i < useTasksValue.size(); i += 3) { useTask(useTasksValue[i], useTasksValue[i + 1], useTasksValue[i + 2]); }
+  for (unsigned int i = 0; i < useTasksValue.size(); i += 3) {
+    useTask(useTasksValue[i], useTasksValue[i + 1], useTasksValue[i + 2]);
+  }
 }

--- a/Core/JPetManager/JPetManager.cpp
+++ b/Core/JPetManager/JPetManager.cpp
@@ -32,51 +32,53 @@ using namespace jpet_options_tools;
 
 JPetManager::JPetManager() {}
 
-JPetManager &JPetManager::getManager() {
+JPetManager& JPetManager::getManager()
+{
   static JPetManager instance;
   return instance;
 }
 
-void JPetManager::run(int argc, const char **argv) {
+void JPetManager::run(int argc, const char** argv)
+{
   bool isOk = true;
   std::map<std::string, boost::any> allValidatedOptions;
   std::tie(isOk, allValidatedOptions) = parseCmdLine(argc, argv);
-  if (!isOk) {
+  if (!isOk)
+  {
     ERROR("While parsing command line arguments");
-    std::cerr << "Error has occurred while parsing command line! Check the log!"
-              << std::endl;
-    throw std::invalid_argument(
-        "Error in parsing command line arguments"); /// temporary change to
-                                                    /// check if the examples
-                                                    /// are working
+    std::cerr << "Error has occurred while parsing command line! Check the log!" << std::endl;
+    throw std::invalid_argument("Error in parsing command line arguments"); /// temporary change to
+                                                                            /// check if the examples
+                                                                            /// are working
   }
   JPetManager::registerDefaultTasks();
   addUserParamsUsedTasks(allValidatedOptions);
-  auto chainOfTasks =
-      fTaskFactory.createTaskGeneratorChain(allValidatedOptions);
+  auto chainOfTasks = fTaskFactory.createTaskGeneratorChain(allValidatedOptions);
   JPetOptionsGenerator optionsGenerator;
-  auto options = optionsGenerator.generateOptionsForTasks(allValidatedOptions,
-                                                          chainOfTasks.size());
+  auto options = optionsGenerator.generateOptionsForTasks(allValidatedOptions, chainOfTasks.size());
 
-  INFO("======== Starting processing all tasks: " +
-       JPetCommonTools::getTimeString() + " ========\n");
-  std::vector<TThread *> threads;
+  INFO("======== Starting processing all tasks: " + JPetCommonTools::getTimeString() + " ========\n");
+  std::vector<TThread*> threads;
   auto inputDataSeq = 0;
   /// For every input option, new TaskChainExecutor is created, which creates
   /// the chain of previously registered tasks. The inputDataSeq is the
   /// identifier of given chain.
-  for (auto opt : options) {
-    auto executor = jpet_common_tools::make_unique<JPetTaskChainExecutor>(
-        chainOfTasks, inputDataSeq, opt.second);
-    if (areThreadsEnabled()) {
+  for (auto opt : options)
+  {
+    auto executor = jpet_common_tools::make_unique<JPetTaskChainExecutor>(chainOfTasks, inputDataSeq, opt.second);
+    if (areThreadsEnabled())
+    {
       auto thr = executor->run();
-      if (thr) {
-        threads.push_back(thr);
-      } else {
+      if (thr) { threads.push_back(thr); }
+      else
+      {
         ERROR("thread pointer is null");
       }
-    } else {
-      if (!executor->process()) {
+    }
+    else
+    {
+      if (!executor->process())
+      {
         ERROR("While running process");
         std::cerr << "Stopping program, error has occurred while calling "
                      "executor->process! Check the log!"
@@ -86,46 +88,48 @@ void JPetManager::run(int argc, const char **argv) {
     }
     inputDataSeq++;
   }
-  if (areThreadsEnabled()) {
-    for (auto thread : threads) {
+  if (areThreadsEnabled())
+  {
+    for (auto thread : threads)
+    {
       assert(thread);
       thread->Join();
     }
   }
-  INFO("======== Finished processing all tasks: " +
-       JPetCommonTools::getTimeString() + " ========\n");
+  INFO("======== Finished processing all tasks: " + JPetCommonTools::getTimeString() + " ========\n");
 }
 
-std::pair<bool, std::map<std::string, boost::any>>
-JPetManager::parseCmdLine(int argc, const char **argv) {
+std::pair<bool, std::map<std::string, boost::any>> JPetManager::parseCmdLine(int argc, const char** argv)
+{
   std::map<std::string, boost::any> allValidatedOptions;
-  try {
+  try
+  {
     JPetOptionsGenerator optionsGenerator;
     JPetCmdParser parser;
     auto optionsFromCmdLine = parser.parseCmdLineArgs(argc, argv);
-    allValidatedOptions =
-        optionsGenerator.generateAndValidateOptions(optionsFromCmdLine);
-  } catch (std::exception &e) {
+    allValidatedOptions = optionsGenerator.generateAndValidateOptions(optionsFromCmdLine);
+  }
+  catch (std::exception& e)
+  {
     ERROR(e.what());
     return std::make_pair(false, std::map<std::string, boost::any>{});
   }
   return std::make_pair(true, allValidatedOptions);
 }
 
-void JPetManager::useTask(const std::string &name,
-                          const std::string &inputFileType,
-                          const std::string &outputFileType, int numTimes) {
-  if (!fTaskFactory.addTaskInfo(name, inputFileType, outputFileType,
-                                numTimes)) {
-    std::cerr << "Error has occurred while calling useTask! Check the log!"
-              << std::endl;
+void JPetManager::useTask(const std::string& name, const std::string& inputFileType, const std::string& outputFileType, int numTimes)
+{
+  if (!fTaskFactory.addTaskInfo(name, inputFileType, outputFileType, numTimes))
+  {
+    std::cerr << "Error has occurred while calling useTask! Check the log!" << std::endl;
     throw std::runtime_error("error in addTaskInfo");
   }
 }
 
 bool JPetManager::areThreadsEnabled() const { return fThreadsEnabled; }
 
-void JPetManager::setThreadsEnabled(bool enable) {
+void JPetManager::setThreadsEnabled(bool enable)
+{
   fThreadsEnabled = enable;
   ENABLE_THREADS_INFO(enable);
 }
@@ -140,23 +144,17 @@ void JPetManager::setThreadsEnabled(bool enable) {
 /// for adding users' tasks prvided that the built-in tasks are registered in
 /// the map of tasks generators in advance. This provate method is intended to
 /// register all such tasks in advance of creation of the task generator chain.
-void JPetManager::registerDefaultTasks() {
-  JPetManager::getManager().registerTask<JPetGeantParser>("JPetGeantParser");
-}
+void JPetManager::registerDefaultTasks() { JPetManager::getManager().registerTask<JPetGeantParser>("JPetGeantParser"); }
 
-void JPetManager::addUserParamsUsedTasks(
-    const std::map<std::string, boost::any> &opts) {
+void JPetManager::addUserParamsUsedTasks(const std::map<std::string, boost::any>& opts)
+{
   using namespace jpet_options_tools;
   std::vector<std::string> useTasksValue;
-  if (isOptionSet(opts, kUseTasksKey)) {
-    useTasksValue = getOptionAsVectorOfStrings(opts, kUseTasksKey);
-  }
-  if (useTasksValue.size() % 3 != 0) {
-    ERROR("WRONG number of parameters in " + kUseTasksKey +
-          " userparam, do not adding any tasks from userParams");
+  if (isOptionSet(opts, kUseTasksKey)) { useTasksValue = getOptionAsVectorOfStrings(opts, kUseTasksKey); }
+  if (useTasksValue.size() % 3 != 0)
+  {
+    ERROR("WRONG number of parameters in " + kUseTasksKey + " userparam, do not adding any tasks from userParams");
     return;
   }
-  for (unsigned int i = 0; i < useTasksValue.size(); i += 3) {
-    useTask(useTasksValue[i], useTasksValue[i + 1], useTasksValue[i + 2]);
-  }
+  for (unsigned int i = 0; i < useTasksValue.size(); i += 3) { useTask(useTasksValue[i], useTasksValue[i + 1], useTasksValue[i + 2]); }
 }

--- a/Core/JPetManager/JPetManager.h
+++ b/Core/JPetManager/JPetManager.h
@@ -30,26 +30,28 @@
  * which executes the chain of registered tasks.
  *
  */
-class JPetManager {
+class JPetManager
+{
 public:
-  static JPetManager &getManager();
+  static JPetManager& getManager();
 
   /// @throws exceptions in case of errors.
-  void run(int argc, const char **argv);
+  void run(int argc, const char** argv);
 
   /// @brief Method parses command line arguments and returns the set of
   /// validated option generated based on it.
   /// @return pair of boolean status and the map of validated options. In case
   /// of errors the status is set to false.
-  static std::pair<bool, std::map<std::string, boost::any>>
-  parseCmdLine(int argc, const char **argv);
+  static std::pair<bool, std::map<std::string, boost::any>> parseCmdLine(int argc, const char** argv);
 
   /// @brief Method to register tasks that can form a chain of tasks to be
   /// executed. The registered tasks can be used later by calling useTask
   /// method. The task must inherit from JPetTaskInterface.
   /// @param name string that identifies given registered task. Also, this
   /// string is passed to the constructor as argument.
-  template <typename T> void registerTask(const std::string &name) {
+  template <typename T>
+  void registerTask(const std::string& name)
+  {
     fTaskFactory.registerTask<T>(name);
   }
 
@@ -72,23 +74,21 @@ public:
   /// value is less then zero, the task will be executed in infinite loop and
   /// some condition must be given to stop it.
   /// @throws exception in case of errors.
-  void useTask(const std::string &name, const std::string &inputFileType = "",
-               const std::string &outputFileType = "", int numTimes = 1);
+  void useTask(const std::string& name, const std::string& inputFileType = "", const std::string& outputFileType = "", int numTimes = 1);
 
   bool areThreadsEnabled() const;
   void setThreadsEnabled(bool enable);
 
 private:
-  JPetManager(const JPetManager &);
-  void operator=(const JPetManager &);
+  JPetManager(const JPetManager&);
+  void operator=(const JPetManager&);
 
   static void registerDefaultTasks();
-  void addUserParamsUsedTasks(const std::map<std::string, boost::any> &opts);
+  void addUserParamsUsedTasks(const std::map<std::string, boost::any>& opts);
 
   JPetManager();
   bool fThreadsEnabled = false;
   jpet_task_factory::JPetTaskFactory fTaskFactory;
-  const std::string kUseTasksKey =
-      "JPetManager_useTasks_std::vector<std::string>";
+  const std::string kUseTasksKey = "JPetManager_useTasks_std::vector<std::string>";
 };
 #endif /* !JPETMANAGER_H */

--- a/Core/JPetManager/JPetManager.h
+++ b/Core/JPetManager/JPetManager.h
@@ -30,28 +30,26 @@
  * which executes the chain of registered tasks.
  *
  */
-class JPetManager
-{
+class JPetManager {
 public:
-  static JPetManager& getManager();
+  static JPetManager &getManager();
 
   /// @throws exceptions in case of errors.
-  void run(int argc, const char** argv);
+  void run(int argc, const char **argv);
 
   /// @brief Method parses command line arguments and returns the set of
   /// validated option generated based on it.
   /// @return pair of boolean status and the map of validated options. In case
   /// of errors the status is set to false.
-  static std::pair<bool, std::map<std::string, boost::any>> parseCmdLine(int argc, const char** argv);
+  static std::pair<bool, std::map<std::string, boost::any>>
+  parseCmdLine(int argc, const char **argv);
 
   /// @brief Method to register tasks that can form a chain of tasks to be
   /// executed. The registered tasks can be used later by calling useTask
   /// method. The task must inherit from JPetTaskInterface.
   /// @param name string that identifies given registered task. Also, this
   /// string is passed to the constructor as argument.
-  template <typename T>
-  void registerTask(const std::string& name)
-  {
+  template <typename T> void registerTask(const std::string &name) {
     fTaskFactory.registerTask<T>(name);
   }
 
@@ -74,21 +72,44 @@ public:
   /// value is less then zero, the task will be executed in infinite loop and
   /// some condition must be given to stop it.
   /// @throws exception in case of errors.
-  void useTask(const std::string& name, const std::string& inputFileType = "", const std::string& outputFileType = "", int numTimes = 1);
+  void useTask(const std::string &name, const std::string &inputFileType = "",
+               const std::string &outputFileType = "", int numTimes = 1);
 
   bool areThreadsEnabled() const;
   void setThreadsEnabled(bool enable);
 
 private:
-  JPetManager(const JPetManager&);
-  void operator=(const JPetManager&);
+  JPetManager(const JPetManager &);
+  void operator=(const JPetManager &);
 
+  /// @brief Adds any built-in tasks based on JPetTaskIO to the map of taska
+  /// generators to facilitate their later generation on demand
+  ///
+  /// Any built-in tasks which are handled by JPetTaskIO the same way as
+  /// user-defined tasks (rather than using a dedicated task wrapper as is the
+  /// case for JPetUnzipAndUpackTask or JPetParamBankHandlerTask) can be easily
+  /// added to the chain of tasks using the same mehanics as exposed to the user
+  /// for adding users' tasks prvided that the built-in tasks are registered in
+  /// the map of tasks generators in advance. This provate method is intended to
+  /// register all such tasks in advance of creation of the task generator
+  /// chain.
   static void registerDefaultTasks();
-  void addUserParamsUsedTasks(const std::map<std::string, boost::any>& opts);
+
+  /**
+   * @brief Adds any tasks definded in userParams.json
+   *
+   * Adds any user-defined task and registered dynamically from userParams to
+   * run setup.
+   * Example: JPetManager_useTasks_std::vector<std::string>: ["TaskName", "input
+   * type", "output type", "TaskName2", "input type", "output type"]
+   * Will add 2 user defined tasks: TaskName and TaskName2 to run.
+   **/
+  void useTasksFromUserParams(const std::map<std::string, boost::any> &opts);
 
   JPetManager();
   bool fThreadsEnabled = false;
   jpet_task_factory::JPetTaskFactory fTaskFactory;
-  const std::string kUseTasksKey = "JPetManager_useTasks_std::vector<std::string>";
+  const std::string kUseTasksFromParamsKey =
+      "JPetManager_useTasks_std::vector<std::string>";
 };
 #endif /* !JPETMANAGER_H */

--- a/Core/JPetManager/JPetManager.h
+++ b/Core/JPetManager/JPetManager.h
@@ -41,7 +41,7 @@ public:
   /// validated option generated based on it.
   /// @return pair of boolean status and the map of validated options. In case
   /// of errors the status is set to false.
-  std::pair<bool, std::map<std::string, boost::any>>
+  static std::pair<bool, std::map<std::string, boost::any>>
   parseCmdLine(int argc, const char **argv);
 
   /// @brief Method to register tasks that can form a chain of tasks to be
@@ -82,7 +82,7 @@ private:
   JPetManager(const JPetManager &);
   void operator=(const JPetManager &);
 
-  void registerDefaultTasks();
+  static void registerDefaultTasks();
   void addUserParamsUsedTasks(const std::map<std::string, boost::any> &opts);
 
   JPetManager();

--- a/Core/JPetManager/JPetManager.h
+++ b/Core/JPetManager/JPetManager.h
@@ -16,10 +16,10 @@
 #ifndef JPETMANAGER_H
 #define JPETMANAGER_H
 
+#include "./JPetTaskFactory/JPetTaskFactory.h"
+#include <boost/any.hpp>
 #include <map>
 #include <string>
-#include <boost/any.hpp>
-#include "./JPetTaskFactory/JPetTaskFactory.h"
 
 /**
  * @brief Main Manager of the analyses performed with the J-PET Framework.
@@ -30,47 +30,59 @@
  * which executes the chain of registered tasks.
  *
  */
-class JPetManager
-{
+class JPetManager {
 public:
-  static JPetManager& getManager();
+  static JPetManager &getManager();
 
   /// @throws exceptions in case of errors.
-  void run(int argc, const char** argv);
+  void run(int argc, const char **argv);
 
-  /// @brief Method parses command line arguments and returns the set of validated option generated based on it.
-  /// @return pair of boolean status and the map of validated options. In case of errors the status is set to false.
-  std::pair<bool, std::map<std::string, boost::any> > parseCmdLine(int argc, const char** argv);
+  /// @brief Method parses command line arguments and returns the set of
+  /// validated option generated based on it.
+  /// @return pair of boolean status and the map of validated options. In case
+  /// of errors the status is set to false.
+  std::pair<bool, std::map<std::string, boost::any>>
+  parseCmdLine(int argc, const char **argv);
 
-  /// @brief Method to register tasks that can form a chain of tasks to be executed.
-  /// The registered tasks can be used later by calling useTask method.
-  /// The task must inherit from JPetTaskInterface.
-  /// @param name string that identifies given registered task. Also, this string is passed to the constructor as argument.
-  template<typename T>
-  void registerTask(const std::string& name)
-  {
+  /// @brief Method to register tasks that can form a chain of tasks to be
+  /// executed. The registered tasks can be used later by calling useTask
+  /// method. The task must inherit from JPetTaskInterface.
+  /// @param name string that identifies given registered task. Also, this
+  /// string is passed to the constructor as argument.
+  template <typename T> void registerTask(const std::string &name) {
     fTaskFactory.registerTask<T>(name);
   }
 
-  /// @brief Method to add the task to the chain of tasks that will be executed later by JPetTaskExecutor.
-  /// The task must be registered before (e.g. using registerTask) using the same name label.
-  /// The input and output file type arguments correspond to labels that form a part of the input/output file extension.
-  /// The following format is used: fileNameRoot.fileType.root  e.g. if inputFileType is "raw" and file name is "bla", then
-  /// the input file name is expected to be "bla.raw.root". There are some labels that are treated separately e.g.
-  /// "zip" or "hld". If the outputFileType is the empty string then the task is assumed to have no output tree.
-  /// @param name string that identifies registered task. Also, this string is passed to the constructor as argument.
-  /// @param inputFileType string corresponding to the input file extension. If empty, the task with no typical input is assumed.
-  /// @param outputFileType string corresponding to the output file extension. If empty, the task with no typical output is assumed.
-  /// @param numTimes Number of times given task will be executed in a row. If value is less then zero, the task will be executed in infinite loop and some condition must be given to stop it.
+  /// @brief Method to add the task to the chain of tasks that will be executed
+  /// later by JPetTaskExecutor. The task must be registered before (e.g. using
+  /// registerTask) using the same name label. The input and output file type
+  /// arguments correspond to labels that form a part of the input/output file
+  /// extension. The following format is used: fileNameRoot.fileType.root  e.g.
+  /// if inputFileType is "raw" and file name is "bla", then the input file name
+  /// is expected to be "bla.raw.root". There are some labels that are treated
+  /// separately e.g. "zip" or "hld". If the outputFileType is the empty string
+  /// then the task is assumed to have no output tree.
+  /// @param name string that identifies registered task. Also, this string is
+  /// passed to the constructor as argument.
+  /// @param inputFileType string corresponding to the input file extension. If
+  /// empty, the task with no typical input is assumed.
+  /// @param outputFileType string corresponding to the output file extension.
+  /// If empty, the task with no typical output is assumed.
+  /// @param numTimes Number of times given task will be executed in a row. If
+  /// value is less then zero, the task will be executed in infinite loop and
+  /// some condition must be given to stop it.
   /// @throws exception in case of errors.
-  void useTask(const std::string& name, const std::string& inputFileType = "", const std::string& outputFileType = "", int numTimes = 1);
+  void useTask(const std::string &name, const std::string &inputFileType = "",
+               const std::string &outputFileType = "", int numTimes = 1);
 
   bool areThreadsEnabled() const;
   void setThreadsEnabled(bool enable);
 
+  void addUserParamsUsedTasks(const std::map<std::string, boost::any> &opts);
+
 private:
-  JPetManager(const JPetManager&);
-  void operator=(const JPetManager&);
+  JPetManager(const JPetManager &);
+  void operator=(const JPetManager &);
 
   void registerDefaultTasks();
 

--- a/Core/JPetManager/JPetManager.h
+++ b/Core/JPetManager/JPetManager.h
@@ -30,28 +30,26 @@
  * which executes the chain of registered tasks.
  *
  */
-class JPetManager {
+class JPetManager
+{
 public:
-  static JPetManager &getManager();
+  static JPetManager& getManager();
 
   /// @throws exceptions in case of errors.
-  void run(int argc, const char **argv);
+  void run(int argc, const char** argv);
 
   /// @brief Method parses command line arguments and returns the set of
   /// validated option generated based on it.
   /// @return pair of boolean status and the map of validated options. In case
   /// of errors the status is set to false.
-  static std::pair<bool, std::map<std::string, boost::any>>
-  parseCmdLine(int argc, const char **argv);
+  static std::pair<bool, std::map<std::string, boost::any>> parseCmdLine(int argc, const char** argv);
 
   /// @brief Method to register tasks that can form a chain of tasks to be
   /// executed. The registered tasks can be used later by calling useTask
   /// method. The task must inherit from JPetTaskInterface.
   /// @param name string that identifies given registered task. Also, this
   /// string is passed to the constructor as argument.
-  template <typename T> void registerTask(const std::string &name) {
-    fTaskFactory.registerTask<T>(name);
-  }
+  template <typename T> void registerTask(const std::string& name) { fTaskFactory.registerTask<T>(name); }
 
   /// @brief Method to add the task to the chain of tasks that will be executed
   /// later by JPetTaskExecutor. The task must be registered before (e.g. using
@@ -72,15 +70,14 @@ public:
   /// value is less then zero, the task will be executed in infinite loop and
   /// some condition must be given to stop it.
   /// @throws exception in case of errors.
-  void useTask(const std::string &name, const std::string &inputFileType = "",
-               const std::string &outputFileType = "", int numTimes = 1);
+  void useTask(const std::string& name, const std::string& inputFileType = "", const std::string& outputFileType = "", int numTimes = 1);
 
   bool areThreadsEnabled() const;
   void setThreadsEnabled(bool enable);
 
 private:
-  JPetManager(const JPetManager &);
-  void operator=(const JPetManager &);
+  JPetManager(const JPetManager&);
+  void operator=(const JPetManager&);
 
   /// @brief Adds any built-in tasks based on JPetTaskIO to the map of taska
   /// generators to facilitate their later generation on demand
@@ -100,16 +97,14 @@ private:
    *
    * Adds any user-defined task and registered dynamically from userParams to
    * run setup.
-   * Example: JPetManager_useTasks_std::vector<std::string>: ["TaskName", "input
-   * type", "output type", "TaskName2", "input type", "output type"]
+   * Example: JPetManager_useTasks_std::vector<std::string>: ["TaskName", "input type", "output type", "TaskName2", "input type", "output type"]
    * Will add 2 user defined tasks: TaskName and TaskName2 to run.
    **/
-  void useTasksFromUserParams(const std::map<std::string, boost::any> &opts);
+  void useTasksFromUserParams(const std::map<std::string, boost::any>& opts);
 
   JPetManager();
   bool fThreadsEnabled = false;
   jpet_task_factory::JPetTaskFactory fTaskFactory;
-  const std::string kUseTasksFromParamsKey =
-      "JPetManager_useTasks_std::vector<std::string>";
+  const std::string kUseTasksFromParamsKey = "JPetManager_useTasks_std::vector<std::string>";
 };
 #endif /* !JPETMANAGER_H */

--- a/Core/JPetManager/JPetManager.h
+++ b/Core/JPetManager/JPetManager.h
@@ -78,16 +78,17 @@ public:
   bool areThreadsEnabled() const;
   void setThreadsEnabled(bool enable);
 
-  void addUserParamsUsedTasks(const std::map<std::string, boost::any> &opts);
-
 private:
   JPetManager(const JPetManager &);
   void operator=(const JPetManager &);
 
   void registerDefaultTasks();
+  void addUserParamsUsedTasks(const std::map<std::string, boost::any> &opts);
 
   JPetManager();
   bool fThreadsEnabled = false;
   jpet_task_factory::JPetTaskFactory fTaskFactory;
+  const std::string kUseTasksKey =
+      "JPetManager_useTasks_std::vector<std::string>";
 };
 #endif /* !JPETMANAGER_H */

--- a/Core/JPetManager/JPetManagerTest.cpp
+++ b/Core/JPetManager/JPetManagerTest.cpp
@@ -23,7 +23,7 @@
 class TestTask: public JPetUserTask
 {
 public:
-  TestTask(const char* name = ""): JPetUserTask(name) {}
+  explicit TestTask(const char* name = ""): JPetUserTask(name) {}
   bool init() override
   {
     fOutputEvents = new JPetTimeWindow("JPetEvent");
@@ -131,6 +131,22 @@ BOOST_AUTO_TEST_CASE(notRegisteredTask)
     "unitTestData/JPetManagerTest/userParamsUnregisteredTask.json",
   };
   BOOST_CHECK_THROW(manager.run(args.size(), args.data()), std::runtime_error);
+}
+
+BOOST_AUTO_TEST_CASE(badOptionsTask)
+{
+  JPetManager& manager = JPetManager::getManager();
+  std::vector<const char*> args = {
+    "test/Path",
+    "--file",
+    "unitTestData/JPetManagerTest/goodRootFile.root",
+    "--type",
+    "root",
+    "-u",
+    "unitTestData/JPetManagerTest/userParamsBadOptions.json",
+  };
+  manager.registerTask<TestTask>("BadOptionsTask");
+  BOOST_REQUIRE_NO_THROW(manager.run(args.size(), args.data()));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/Core/JPetManager/JPetManagerTest.cpp
+++ b/Core/JPetManager/JPetManagerTest.cpp
@@ -118,4 +118,19 @@ BOOST_AUTO_TEST_CASE(goodControlTasks)
   BOOST_REQUIRE_NO_THROW(manager.run(args.size(), args.data()));
 }
 
+BOOST_AUTO_TEST_CASE(notRegisteredTask)
+{
+  JPetManager& manager = JPetManager::getManager();
+  std::vector<const char*> args = {
+    "test/Path",
+    "--file",
+    "unitTestData/JPetManagerTest/goodRootFile.root",
+    "--type",
+    "root",
+    "-u",
+    "unitTestData/JPetManagerTest/userParamsUnregisteredTask.json",
+  };
+  BOOST_CHECK_THROW(manager.run(args.size(), args.data()), std::runtime_error);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/Core/JPetManager/JPetManagerTest.cpp
+++ b/Core/JPetManager/JPetManagerTest.cpp
@@ -17,7 +17,28 @@
 #define BOOST_TEST_MODULE JPetManagerTest
 
 #include "./JPetManager/JPetManager.h"
+#include "JPetUserTask/JPetUserTask.h"
 #include <boost/test/unit_test.hpp>
+
+class TestTask: public JPetUserTask
+{
+public:
+  TestTask(const char* name = ""): JPetUserTask(name) {}
+  bool init() override
+  {
+    fOutputEvents = new JPetTimeWindow("JPetEvent");
+    return true;
+  }
+  bool exec() override
+  {
+    fOutputEvents = dynamic_cast<JPetTimeWindow*>(fEvent);
+    return true;
+  }
+  bool terminate() override
+  {
+    return true;
+  }
+};
 
 BOOST_AUTO_TEST_SUITE(FirstSuite)
 BOOST_AUTO_TEST_CASE(create_unique_manager)
@@ -48,15 +69,7 @@ BOOST_AUTO_TEST_CASE(emptyRun)
 BOOST_AUTO_TEST_CASE(goodRootRun)
 {
   JPetManager& manager = JPetManager::getManager();
-  const char* args[7] = {
-    "test/Path",
-    "--file",
-    "unitTestData/JPetManagerTest/goodRootFile.root",
-    "--type",
-    "root",
-    "-p",
-    "conf_trb3.xml"
-  };
+  const char* args[7] = {"test/Path", "--file", "unitTestData/JPetManagerTest/goodRootFile.root", "--type", "root", "-p", "conf_trb3.xml"};
   BOOST_REQUIRE_NO_THROW(manager.run(7, args));
 }
 
@@ -64,27 +77,45 @@ BOOST_AUTO_TEST_CASE(goodZipRun)
 {
   std::remove("unitTestData/JPetManagerTest/xx14099113231.hld");
   JPetManager& manager = JPetManager::getManager();
-  const char* args[14] = {"test/Path", "--file", "unitTestData/JPetManagerTest/xx14099113231.hld.xz", "--type", "zip", "-p", "unitTestData/JPetManagerTest/conf_trb3.xml", "-r", "0", "10", "-l", "unitTestData/JPetManagerTest/large_barrel.json", "-i", "44"};
+  const char* args[14] = {"test/Path",
+                          "--file",
+                          "unitTestData/JPetManagerTest/xx14099113231.hld.xz",
+                          "--type",
+                          "zip",
+                          "-p",
+                          "unitTestData/JPetManagerTest/conf_trb3.xml",
+                          "-r",
+                          "0",
+                          "10",
+                          "-l",
+                          "unitTestData/JPetManagerTest/large_barrel.json",
+                          "-i",
+                          "44"};
   BOOST_REQUIRE_NO_THROW(manager.run(14, args));
 }
 
 BOOST_AUTO_TEST_CASE(goodMCRun)
 {
-  JPetManager &manager = JPetManager::getManager();
-  const char* args[11] = {
+  JPetManager& manager = JPetManager::getManager();
+  const char* args[11] = {"test/Path",     "--file", "unitTestData/JPetManagerTest/goodMCFile.mcGeant.root", "--type", "mcGeant", "-p",
+                          "conf_trb3.xml", "-l",     "unitTestData/JPetManagerTest/large_barrel.json",       "-i",     "44"};
+  BOOST_REQUIRE_NO_THROW(manager.run(11, args));
+}
+
+BOOST_AUTO_TEST_CASE(goodControlTasks)
+{
+  JPetManager& manager = JPetManager::getManager();
+  std::vector<const char*> args = {
     "test/Path",
     "--file",
-    "unitTestData/JPetManagerTest/goodMCFile.mcGeant.root",
+    "unitTestData/JPetManagerTest/goodRootFile.root",
     "--type",
-    "mcGeant",
-    "-p",
-    "conf_trb3.xml",
-    "-l",
-    "unitTestData/JPetManagerTest/large_barrel.json",
-    "-i",
-    "44"
+    "root",
+    "-u",
+    "unitTestData/JPetManagerTest/userParamsControlTasksGood.json",
   };
-  BOOST_REQUIRE_NO_THROW(manager.run(11, args));
+  manager.registerTask<TestTask>("TestTask");
+  BOOST_REQUIRE_NO_THROW(manager.run(args.size(), args.data()));
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Add possibility to control used tasks from UserParams.
Based on PR: #212 and should be accepted after that PR.

I didn't test it much, but did small tests by hand and it semms to work. 

Because of limits of current JPetOptionsTools/json tasks to use are stored in vector, not vector of vectors/key pair values e.g.:
 - "JPetManager_useTasks_std::vector<std::string>": ["FilterEvents", "reco.unk.evt", "sino.mc", "SinogramCreatorMC", "sino.mc", "sino.mc.r"]
