### PR TITLE
Add JPetCachedFunction implementations with some tests

### DIFF
--- a/Core/JPetCachedFunction/JPetCachedFunction.cpp
+++ b/Core/JPetCachedFunction/JPetCachedFunction.cpp
@@ -125,7 +125,7 @@ double JPetCachedFunction2D::operator()(double x, double y) const
   if ((x < fRange.first.fMin) || (x > fRange.first.fMax) || (y < fRange.second.fMin) || (y > fRange.second.fMax)) return 0;
   auto index = xyValueToIndex(x, y);
   assert(index >= 0);
-  assert(index < fValues.size());
+  assert(((unsigned int) index) < fValues.size());
   return fValues[index];
 }
 

--- a/Core/JPetCachedFunction/JPetCachedFunction.cpp
+++ b/Core/JPetCachedFunction/JPetCachedFunction.cpp
@@ -1,0 +1,138 @@
+/**
+ *  @copyright Copyright 2019 The J-PET Framework Authors. All rights reserved.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may find a copy of the License in the LICENCE file.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  @file JPetCachedFunction.cpp
+ */
+
+#include <TFormula.h>
+#include "./JPetCachedFunction.h"
+#include "JPetLoggerInclude.h"
+
+namespace  jpet_common_tools
+{
+
+JPetCachedFunction::JPetCachedFunction(const JPetCachedFunctionParams& params): fParams(params)
+{
+}
+
+JPetCachedFunction1D::JPetCachedFunction1D(const JPetCachedFunctionParams& params, const Range& range): JPetCachedFunction(params), fRange(range)
+{
+  TFormula func("myFunc", fParams.fFormula.c_str());
+  func.SetParameters(fParams.fParams.data());
+  if (fRange.fBins <= 0) {
+    ERROR("Number of bins must be greater than 0!");
+    fParams.fValidFunction = false;
+    return;
+  }
+  double step = (fRange.fMax - fRange.fMin) / fRange.fBins;
+  if (step <= 0) {
+    ERROR("Check values of XMin:" + std::to_string(fRange.fMin) << " and XMax:" << std::to_string(fRange.fMax) << " !!! getX() function will not work correctly.");
+    fParams.fValidFunction = false;
+    return;
+  }
+  fStep = step;
+  fValues.reserve(fRange.fBins);
+  double currX = fRange.fMin;
+  for (int i = 0; i < fRange.fBins; i++) {
+    fValues.push_back(func.Eval(currX));
+    currX = currX + step;
+  }
+  fParams.fValidFunction = true;
+}
+
+JPetCachedFunction2D::JPetCachedFunction2D(const JPetCachedFunctionParams& params, const Range& xRange, const Range& yRange): JPetCachedFunction(params)
+{
+  fRange = {xRange, yRange};
+  TFormula func("myFunc", fParams.fFormula.c_str());
+  func.SetParameters(fParams.fParams.data());
+  if (fRange.first.fBins <= 0) {
+    ERROR("Number of bins X must be greater than 0!");
+    fParams.fValidFunction = false;
+    return;
+  }
+  if (fRange.second.fBins <= 0) {
+    ERROR("Number of bins Y must be greater than 0!");
+    fParams.fValidFunction = false;
+    return;
+  }
+
+  double stepX = (fRange.first.fMax - fRange.first.fMin) / fRange.first.fBins;
+  double stepY = (fRange.first.fMax - fRange.first.fMin) / fRange.first.fBins;
+  if (stepX <= 0) {
+    ERROR("Check values of XMin:" + std::to_string(fRange.first.fMin) << " and XMax:" << std::to_string(fRange.first.fMax) << " !!!");
+    fParams.fValidFunction = false;
+    return;
+  }
+  if (stepY <= 0) {
+    ERROR("Check values of YMin:" + std::to_string(fRange.second.fMin) << " and YMax:" << std::to_string(fRange.second.fMax) << " !!!");
+    fParams.fValidFunction = false;
+    return;
+  }
+
+  fSteps = {stepX, stepY};
+  fValues.reserve(fRange.first.fBins * fRange.second.fBins);
+  double currX = fRange.first.fMin;
+  double currY = fRange.second.fMin;
+  for (int i = 0; i < fRange.first.fBins; i++) {
+    currX = currX + stepX;
+    for (int j = 0; j < fRange.second.fBins; j++) {
+      fValues.push_back(func.Eval(currX, currY));
+      currY = currY + stepY;
+    }
+  }
+  fParams.fValidFunction = true;
+}
+
+
+JPetCachedFunctionParams JPetCachedFunction::getParams() const
+{
+  return fParams;
+}
+
+std::vector<double> JPetCachedFunction::getValues() const
+{
+  return fValues;
+}
+
+
+double JPetCachedFunction1D::operator()(double x) const
+{
+  if ((x < fRange.fMin) || (x > fRange.fMax)) return 0;
+  int index = xValueToIndex(x);
+  assert(index >= 0);
+  assert(index < getValues().size());
+  return getValues()[index];
+}
+
+int JPetCachedFunction1D::xValueToIndex(double x) const
+{
+  assert(fStep > 0);
+  return x / fStep; /// maybe some floor or round needed?
+}
+
+
+double JPetCachedFunction2D::operator()(double x, double y) const
+{
+  if ((x < fRange.first.fMin) || (x > fRange.first.fMax) || (y < fRange.second.fMin) || (y > fRange.second.fMax)) return 0;
+  auto index = xyValueToIndex(x, y);
+  assert(index >= 0);
+  assert(index < fValues.size());
+  return fValues[index];
+}
+
+int JPetCachedFunction2D::xyValueToIndex(double x, double y) const
+{
+  assert(fSteps.first > 0 && fSteps.second > 0);
+  return (x / fSteps.first) + (y / fSteps.second) * fRange.first.fBins; /// maybe some floor or round needed?
+}
+
+}

--- a/Core/JPetCachedFunction/JPetCachedFunction.cpp
+++ b/Core/JPetCachedFunction/JPetCachedFunction.cpp
@@ -49,9 +49,8 @@ JPetCachedFunction1D::JPetCachedFunction1D(const JPetCachedFunctionParams& param
   fParams.fValidFunction = true;
 }
 
-JPetCachedFunction2D::JPetCachedFunction2D(const JPetCachedFunctionParams& params, const Range& xRange, const Range& yRange): JPetCachedFunction(params)
+JPetCachedFunction2D::JPetCachedFunction2D(const JPetCachedFunctionParams& params, const Range& xRange, const Range& yRange): JPetCachedFunction(params), fRange(xRange, yRange)
 {
-  fRange = {xRange, yRange};
   TFormula func("myFunc", fParams.fFormula.c_str());
   func.SetParameters(fParams.fParams.data());
   if (fRange.first.fBins <= 0) {

--- a/Core/JPetCachedFunction/JPetCachedFunction.cpp
+++ b/Core/JPetCachedFunction/JPetCachedFunction.cpp
@@ -109,7 +109,7 @@ double JPetCachedFunction1D::operator()(double x) const
   if ((x < fRange.fMin) || (x > fRange.fMax)) return 0;
   int index = xValueToIndex(x);
   assert(index >= 0);
-  assert(index < getValues().size());
+  assert(((unsigned int) index) < getValues().size());
   return getValues()[index];
 }
 

--- a/Core/JPetCachedFunction/JPetCachedFunction.cpp
+++ b/Core/JPetCachedFunction/JPetCachedFunction.cpp
@@ -34,7 +34,7 @@ JPetCachedFunction1D::JPetCachedFunction1D(const JPetCachedFunctionParams& param
     return;
   }
   double step = (fRange.fMax - fRange.fMin) / fRange.fBins;
-  if (step <= 0) {
+  if (step <= 0.) {
     ERROR("Check values of XMin:" + std::to_string(fRange.fMin) << " and XMax:" << std::to_string(fRange.fMax) << " !!! getX() function will not work correctly.");
     fParams.fValidFunction = false;
     return;
@@ -67,12 +67,12 @@ JPetCachedFunction2D::JPetCachedFunction2D(const JPetCachedFunctionParams& param
 
   double stepX = (fRange.first.fMax - fRange.first.fMin) / fRange.first.fBins;
   double stepY = (fRange.second.fMax - fRange.second.fMin) / fRange.second.fBins;
-  if (stepX <= 0) {
+  if (stepX <= 0.) {
     ERROR("Check values of XMin:" + std::to_string(fRange.first.fMin) << " and XMax:" << std::to_string(fRange.first.fMax) << " !!!");
     fParams.fValidFunction = false;
     return;
   }
-  if (stepY <= 0) {
+  if (stepY <= 0.) {
     ERROR("Check values of YMin:" + std::to_string(fRange.second.fMin) << " and YMax:" << std::to_string(fRange.second.fMax) << " !!!");
     fParams.fValidFunction = false;
     return;
@@ -116,8 +116,8 @@ double JPetCachedFunction1D::operator()(double x) const
 
 int JPetCachedFunction1D::xValueToIndex(double x) const
 {
-  assert(fStep > 0);
-  return x / fStep; /// maybe some floor or round needed?
+  assert(fStep > 0.);
+  return x / fStep;
 }
 
 
@@ -132,8 +132,8 @@ double JPetCachedFunction2D::operator()(double x, double y) const
 
 int JPetCachedFunction2D::xyValueToIndex(double x, double y) const
 {
-  assert(fSteps.first > 0 && fSteps.second > 0);
-  return (x / fSteps.first) + (y / fSteps.second) * fRange.first.fBins; /// maybe some floor or round needed?
+  assert(fSteps.first > 0. && fSteps.second > 0.);
+  return (x / fSteps.first) + (y / fSteps.second) * fRange.first.fBins;
 }
 
 }

--- a/Core/JPetCachedFunction/JPetCachedFunction.cpp
+++ b/Core/JPetCachedFunction/JPetCachedFunction.cpp
@@ -66,7 +66,7 @@ JPetCachedFunction2D::JPetCachedFunction2D(const JPetCachedFunctionParams& param
   }
 
   double stepX = (fRange.first.fMax - fRange.first.fMin) / fRange.first.fBins;
-  double stepY = (fRange.first.fMax - fRange.first.fMin) / fRange.first.fBins;
+  double stepY = (fRange.second.fMax - fRange.second.fMin) / fRange.second.fBins;
   if (stepX <= 0) {
     ERROR("Check values of XMin:" + std::to_string(fRange.first.fMin) << " and XMax:" << std::to_string(fRange.first.fMax) << " !!!");
     fParams.fValidFunction = false;
@@ -82,12 +82,13 @@ JPetCachedFunction2D::JPetCachedFunction2D(const JPetCachedFunctionParams& param
   fValues.reserve(fRange.first.fBins * fRange.second.fBins);
   double currX = fRange.first.fMin;
   double currY = fRange.second.fMin;
-  for (int i = 0; i < fRange.first.fBins; i++) {
-    currX = currX + stepX;
-    for (int j = 0; j < fRange.second.fBins; j++) {
+  for (int j = 0; j < fRange.second.fBins; j++) {
+    for (int i = 0; i < fRange.first.fBins; i++) {
       fValues.push_back(func.Eval(currX, currY));
-      currY = currY + stepY;
+      currX = currX + stepX;
     }
+    currX = fRange.first.fMin;
+    currY = currY + stepY;
   }
   fParams.fValidFunction = true;
 }

--- a/Core/JPetCachedFunction/JPetCachedFunction.h
+++ b/Core/JPetCachedFunction/JPetCachedFunction.h
@@ -75,6 +75,8 @@ public:
   explicit JPetCachedFunction1D(const JPetCachedFunctionParams& params, const Range& range);
 
   double operator()(double x) const;
+
+protected:
   int xValueToIndex(double x) const;
 
 private:
@@ -92,6 +94,8 @@ public:
   JPetCachedFunction2D(const JPetCachedFunctionParams& params, const Range& xRange, const Range& yRange);
 
   double operator()(double x, double y) const;
+
+protected:
   int xyValueToIndex(double x, double y) const;
 
 private:

--- a/Core/JPetCachedFunction/JPetCachedFunction.h
+++ b/Core/JPetCachedFunction/JPetCachedFunction.h
@@ -44,8 +44,10 @@ struct JPetCachedFunctionParams {
 /**
  * @brief  Class represent function of TFormula type with the cached values
  *
+ * Special class based on TFormula that precomputes and stores function values in the cache. 
+ * The classes JPetCachedFunction1D and JPetCachedFunction2D correspond to  func(x,p0,p1,...) 
+ * and func(x,y, p0,p1, ...) implementations.
  * Base class JPetCachedFunction is not ment to be created separately.
- * The two implementations 1D and 2D are given. 
  * 
  */
 class JPetCachedFunction

--- a/Core/JPetCachedFunction/JPetCachedFunction.h
+++ b/Core/JPetCachedFunction/JPetCachedFunction.h
@@ -79,7 +79,7 @@ public:
 
 private:
   Range fRange;
-  double fStep = 1; /// Step size with which the lookup table is filled.
+  double fStep = 1.; /// Step size with which the lookup table is filled.
 };
 
 /**
@@ -96,7 +96,7 @@ public:
 
 private:
   std::pair<Range, Range> fRange;
-  std::pair<double, double> fSteps = {1, 1}; /// Step size with which the lookup table is filled.
+  std::pair<double, double> fSteps = {1., 1.}; /// Step size with which the lookup table is filled.
 };
 
 }

--- a/Core/JPetCachedFunction/JPetCachedFunction.h
+++ b/Core/JPetCachedFunction/JPetCachedFunction.h
@@ -26,8 +26,8 @@ struct Range {
   Range(int bins, double min, double max): fBins(bins), fMin(min), fMax(max) {}
   Range() = default;
   int fBins = 100 ;  /// Number of times the function is sampled.
-  double fMin =  -1;
-  double fMax = -1;
+  double fMin =  -1.;
+  double fMax = -1.;
 };
 
 

--- a/Core/JPetCachedFunction/JPetCachedFunction.h
+++ b/Core/JPetCachedFunction/JPetCachedFunction.h
@@ -1,0 +1,101 @@
+/**
+ *  @copyright Copyright 2019 The J-PET Framework Authors. All rights reserved.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may find a copy of the License in the LICENCE file.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  @file JPetCachedFunction.h
+ */
+
+#ifndef JPETCACHEDFUNCTION_H
+#define JPETCACHEDFUNCTION_H
+
+#include <vector>
+#include <string>
+
+namespace  jpet_common_tools
+{
+
+struct Range {
+  Range(int bins, double min, double max): fBins(bins), fMin(min), fMax(max) {}
+  Range() = default;
+  int fBins = 100 ;  /// Number of times the function is sampled.
+  double fMin =  -1;
+  double fMax = -1;
+};
+
+
+struct JPetCachedFunctionParams {
+  JPetCachedFunctionParams(const std::string& formula, const std::vector<double>& params):
+    fFormula(formula), fParams(params)
+  {
+  }
+  std::string fFormula;  /// Function formula that must be understood by TFormula from ROOT.
+  std::vector<double> fParams; /// Parameters used by the function described by TFormula.
+  bool fValidFunction = false;
+};
+
+/**
+ * @brief  Class represent function of TFormula type with the cached values
+ *
+ * Base class JPetCachedFunction is not ment to be created separately.
+ * The two implementations 1D and 2D are given. 
+ * 
+ */
+class JPetCachedFunction
+{
+protected:
+  explicit JPetCachedFunction(const JPetCachedFunctionParams& params); 
+
+public:
+  JPetCachedFunctionParams getParams() const;
+  std::vector<double> getValues() const;
+
+protected:
+  std::vector<double> fValues; /// Lookup table containg the function values.
+  JPetCachedFunctionParams fParams;  /// Parameters describing the function.
+};
+
+
+/**
+ * @brief 1D version of JPetCachedFunction so f(x,p0,p1,...) 
+ */
+class JPetCachedFunction1D: public JPetCachedFunction
+{
+
+public:
+  explicit JPetCachedFunction1D(const JPetCachedFunctionParams& params, const Range& range);
+
+  double operator()(double x) const;
+  int xValueToIndex(double x) const;
+
+private:
+  Range fRange;
+  double fStep = 1; /// Step size with which the lookup table is filled.
+};
+
+/**
+ * @brief 2D version of JPetCachedFunction so f(x,y, p0,p1,...) 
+ */
+class JPetCachedFunction2D: public JPetCachedFunction
+{
+
+public:
+  JPetCachedFunction2D(const JPetCachedFunctionParams& params, const Range& xRange, const Range& yRange);
+
+  double operator()(double x, double y) const;
+  int xyValueToIndex(double x, double y) const;
+
+private:
+  std::pair<Range, Range> fRange;
+  std::pair<double, double> fSteps = {1, 1}; /// Step size with which the lookup table is filled.
+};
+
+}
+#endif /*  !JPETCACHEDFUNCTION_H */

--- a/Core/JPetCachedFunction/JPetCachedFunctionTest.cpp
+++ b/Core/JPetCachedFunction/JPetCachedFunctionTest.cpp
@@ -9,9 +9,9 @@ using namespace jpet_common_tools;
 /// Returns Time-over-threshold for given deposited energy
 /// the current parametrization is par1 + par2 * eDep
 /// Returned value in ps, and eDep is given in keV.
-double getToT1(double eDep, double  par1 = -91958, double par2 = 19341)
+double getToT1(double eDep, double  par1 = -91958., double par2 = 19341.)
 {
-  if (eDep < 0 ) return 0;
+  if (eDep < 0. ) return 0.;
   double value = par1 + eDep * par2;
   return value;
 }
@@ -20,48 +20,48 @@ BOOST_AUTO_TEST_SUITE(JPetCachedFunctionTestSuite)
 
 BOOST_AUTO_TEST_CASE(getTot_params)
 {
-  JPetCachedFunctionParams params("pol1", { -91958, 19341});
+  JPetCachedFunctionParams params("pol1", { -91958., 19341.});
   JPetCachedFunction1D func(params, Range(100, 0., 100.));
   BOOST_CHECK(func.getParams().fValidFunction);
   BOOST_CHECK_EQUAL(func.getParams().fParams.size(), 2);
-  BOOST_CHECK_EQUAL(func.getParams().fParams[0], -91958);
-  BOOST_CHECK_EQUAL(func.getParams().fParams[1], 19341);
+  BOOST_CHECK_EQUAL(func.getParams().fParams[0], -91958.);
+  BOOST_CHECK_EQUAL(func.getParams().fParams[1], 19341.);
   BOOST_CHECK_EQUAL(func.getValues().size(), 100);
   auto vals = func.getValues();
 }
 
 BOOST_AUTO_TEST_CASE(getTot_standardFunc)
 {
-  JPetCachedFunctionParams params("pol1", { -91958, 19341});
+  JPetCachedFunctionParams params("pol1", { -91958., 19341.});
   JPetCachedFunction1D func(params, Range( 10000, 0., 100.));
   BOOST_CHECK(func.getParams().fValidFunction);
-  BOOST_CHECK_CLOSE(func(0), getToT1(0), 0.1);
-  BOOST_CHECK_CLOSE(func(1), getToT1(1), 0.1);
-  BOOST_CHECK_CLOSE(func(10), getToT1(10), 0.1);
+  BOOST_CHECK_CLOSE(func(0.), getToT1(0.), 0.1);
+  BOOST_CHECK_CLOSE(func(1.), getToT1(1.), 0.1);
+  BOOST_CHECK_CLOSE(func(10.), getToT1(10.), 0.1);
   BOOST_CHECK_CLOSE(func(59.5), getToT1(59.5), 0.1);
   BOOST_CHECK_CLOSE(func(99.9), getToT1(99.9), 0.1);
 }
 
 BOOST_AUTO_TEST_CASE(getTot_quadratic)
 {
-  JPetCachedFunctionParams params("pol2", {1, 1, 1}); /// 1 + x + x^2
+  JPetCachedFunctionParams params("pol2", {1., 1., 1.}); /// 1 + x + x^2
   JPetCachedFunction1D func(params, Range(10000, 0., 100.));
   BOOST_CHECK(func.getParams().fValidFunction);
-  BOOST_CHECK_CLOSE(func(0), 1, 0.1);
-  BOOST_CHECK_CLOSE(func(1), 3, 0.1);
-  BOOST_CHECK_CLOSE(func(2), 7, 0.1);
-  BOOST_CHECK_CLOSE(func(3), 13, 0.1);
+  BOOST_CHECK_CLOSE(func(0), 1., 0.1);
+  BOOST_CHECK_CLOSE(func(1), 3., 0.1);
+  BOOST_CHECK_CLOSE(func(2), 7., 0.1);
+  BOOST_CHECK_CLOSE(func(3), 13., 0.1);
 }
 
 BOOST_AUTO_TEST_CASE(cached_2D)
 {
-  JPetCachedFunctionParams params("[0] + [1] * x  + [2] * y", {1, 1, 2}); /// 1 + x + 2 * y
+  JPetCachedFunctionParams params("[0] + [1] * x  + [2] * y", {1., 1., 2.}); /// 1 + x + 2 * y
   JPetCachedFunction2D func(params, Range(100, 0., 100.), Range(100, 0., 100.));
   BOOST_CHECK(func.getParams().fValidFunction);
-  BOOST_CHECK_CLOSE(func(0, 0), 1, 0.1);
-  BOOST_CHECK_CLOSE(func(1, 1), 4, 0.1);
-  BOOST_CHECK_CLOSE(func(0, 1), 3, 0.1);
-  BOOST_CHECK_CLOSE(func(1, 0), 2, 0.1);
+  BOOST_CHECK_CLOSE(func(0., 0.), 1., 0.1);
+  BOOST_CHECK_CLOSE(func(1, 1.), 4., 0.1);
+  BOOST_CHECK_CLOSE(func(0., 1.), 3., 0.1);
+  BOOST_CHECK_CLOSE(func(1., 0.), 2., 0.1);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/Core/JPetCachedFunction/JPetCachedFunctionTest.cpp
+++ b/Core/JPetCachedFunction/JPetCachedFunctionTest.cpp
@@ -53,4 +53,15 @@ BOOST_AUTO_TEST_CASE(getTot_quadratic)
   BOOST_CHECK_CLOSE(func(3), 13, 0.1);
 }
 
+BOOST_AUTO_TEST_CASE(cached_2D)
+{
+  JPetCachedFunctionParams params("[0] + [1] * x  + [2] * y", {1, 1, 2}); /// 1 + x + 2 * y
+  JPetCachedFunction2D func(params, Range(100, 0., 100.), Range(100, 0., 100.));
+  BOOST_CHECK(func.getParams().fValidFunction);
+  BOOST_CHECK_CLOSE(func(0, 0), 1, 0.1);
+  BOOST_CHECK_CLOSE(func(1, 1), 4, 0.1);
+  BOOST_CHECK_CLOSE(func(0, 1), 3, 0.1);
+  BOOST_CHECK_CLOSE(func(1, 0), 2, 0.1);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/Core/JPetCachedFunction/JPetCachedFunctionTest.cpp
+++ b/Core/JPetCachedFunction/JPetCachedFunctionTest.cpp
@@ -1,0 +1,56 @@
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE JPetCachedFunctionTest
+
+#include <boost/test/unit_test.hpp>
+#include "JPetLoggerInclude.h"
+#include "JPetCachedFunction.h"
+
+using namespace jpet_common_tools;
+/// Returns Time-over-threshold for given deposited energy
+/// the current parametrization is par1 + par2 * eDep
+/// Returned value in ps, and eDep is given in keV.
+double getToT1(double eDep, double  par1 = -91958, double par2 = 19341)
+{
+  if (eDep < 0 ) return 0;
+  double value = par1 + eDep * par2;
+  return value;
+}
+
+BOOST_AUTO_TEST_SUITE(JPetCachedFunctionTestSuite)
+
+BOOST_AUTO_TEST_CASE(getTot_params)
+{
+  JPetCachedFunctionParams params("pol1", { -91958, 19341});
+  JPetCachedFunction1D func(params, Range(100, 0., 100.));
+  BOOST_CHECK(func.getParams().fValidFunction);
+  BOOST_CHECK_EQUAL(func.getParams().fParams.size(), 2);
+  BOOST_CHECK_EQUAL(func.getParams().fParams[0], -91958);
+  BOOST_CHECK_EQUAL(func.getParams().fParams[1], 19341);
+  BOOST_CHECK_EQUAL(func.getValues().size(), 100);
+  auto vals = func.getValues();
+}
+
+BOOST_AUTO_TEST_CASE(getTot_standardFunc)
+{
+  JPetCachedFunctionParams params("pol1", { -91958, 19341});
+  JPetCachedFunction1D func(params, Range( 10000, 0., 100.));
+  BOOST_CHECK(func.getParams().fValidFunction);
+  BOOST_CHECK_CLOSE(func(0), getToT1(0), 0.1);
+  BOOST_CHECK_CLOSE(func(1), getToT1(1), 0.1);
+  BOOST_CHECK_CLOSE(func(10), getToT1(10), 0.1);
+  BOOST_CHECK_CLOSE(func(59.5), getToT1(59.5), 0.1);
+  BOOST_CHECK_CLOSE(func(99.9), getToT1(99.9), 0.1);
+}
+
+BOOST_AUTO_TEST_CASE(getTot_quadratic)
+{
+  JPetCachedFunctionParams params("pol2", {1, 1, 1}); /// 1 + x + x^2
+  JPetCachedFunction1D func(params, Range(10000, 0., 100.));
+  BOOST_CHECK(func.getParams().fValidFunction);
+  BOOST_CHECK_CLOSE(func(0), 1, 0.1);
+  BOOST_CHECK_CLOSE(func(1), 3, 0.1);
+  BOOST_CHECK_CLOSE(func(2), 7, 0.1);
+  BOOST_CHECK_CLOSE(func(3), 13, 0.1);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Add function with cache. It is a special class based on TFormula that precomputes and stores function values in the cache. The classes JPetCachedFunction1D and JPetCachedFunction2D correspond to  func(x,p0,p1,...) and func(x,y, p0,p1, ...) implementations.