### PR TITLE
Geantparser improvements

### DIFF
--- a/include/GeantParser/JPetGeantParser/JPetGeantParser.h
+++ b/include/GeantParser/JPetGeantParser/JPetGeantParser.h
@@ -101,10 +101,10 @@ protected :
   std::vector<float> fTimeDiffDistro = {};
   unsigned int fCurrentIndexTimeShift = 0;
 
-  unsigned int getNumberOfDecaysInWindow();
+  unsigned int getNumberOfDecaysInWindow() const;
   float getNextTimeShift();
   void clearTimeDistoOfDecays();
-  bool isTimeWindowFull();
+  bool isTimeWindowFull() const;
 };
 
 #endif

--- a/include/MC/JPetMCHit/JPetMCHit.h
+++ b/include/MC/JPetMCHit/JPetMCHit.h
@@ -39,7 +39,7 @@ public:
 
   //  generated cheatsheet
   void setGenGammaMultiplicity(UInt_t i){fGenGammaMultiplicity=i;} ///< 1-prompt gamma; 2-gamma from back-to-bak; 3-gamma from oPs
-  UInt_t getGenGammaMultiplicity(){return fGenGammaMultiplicity;}
+  UInt_t getGenGammaMultiplicity() const {return fGenGammaMultiplicity;}
 
 
 private:

--- a/src/Core/JPetTaskFactory/JPetTaskFactory.cpp
+++ b/src/Core/JPetTaskFactory/JPetTaskFactory.cpp
@@ -85,7 +85,7 @@ void addDefaultTasksFromOptions(const std::map<std::string, boost::any>& options
     }
     if (fileType == FileTypeChecker::kMCGeant)
     {
-      auto taskInfo = TaskInfo("JPetGeantParser", "mcGeant", "mc.hits", 1);
+      auto taskInfo = TaskInfo("JPetGeantParser", "mcGeant", "hits", 1);
       addTaskToChain(generatorsMap, taskInfo, outChain);
     }
     auto paramBankHandlerTask = []() { return jpet_common_tools::make_unique<JPetParamBankHandlerTask>("ParamBank Filling"); };

--- a/src/Core/JPetTaskIO/JPetOutputHandler.cpp
+++ b/src/Core/JPetTaskIO/JPetOutputHandler.cpp
@@ -57,7 +57,9 @@ bool JPetOutputHandler::writeEventToFile(JPetTaskInterface* task)
     }
     else
     {
-      fWriter.write(*pOutputEntry);
+      if(pOutputEntry->getNumberOfEvents() > 0){
+        fWriter.write(*pOutputEntry);
+      }
     }
   }
   else

--- a/src/GeantParser/JPetGeantParser/JPetGeantParser.cpp
+++ b/src/GeantParser/JPetGeantParser/JPetGeantParser.cpp
@@ -150,6 +150,8 @@ void JPetGeantParser::processMCEvent(JPetGeantEventPack* evPack)
   bool isGen2g = evPack->GetEventInformation()->GetTwoGammaGen();
   bool isGen3g = evPack->GetEventInformation()->GetThreeGammaGen();
 
+  float timeShift = getNextTimeShift();
+  
   for (unsigned int i = 0; i < evPack->GetNumberOfHits(); i++)
   {
 
@@ -159,7 +161,7 @@ void JPetGeantParser::processMCEvent(JPetGeantEventPack* evPack)
     if (fMakeHisto)
       fillHistoMCGen(mcHit);
     // create reconstructed hit and add all smearings
-    JPetHit  recHit =  JPetGeantParserTools::reconstructHit(mcHit, getParamBank(), getNextTimeShift());
+    JPetHit  recHit =  JPetGeantParserTools::reconstructHit(mcHit, getParamBank(), timeShift);
 
     // add criteria for possible rejection of reconstructed events (e.g. E>50 keV)
     if (JPetGeantParserTools::isHitReconstructed(recHit, fExperimentalThreshold))
@@ -484,7 +486,7 @@ void JPetGeantParser::clearTimeDistoOfDecays()
 
 bool JPetGeantParser::isTimeWindowFull()
 {
-  if (fCurrentIndexTimeShift > getNumberOfDecaysInWindow())
+  if (fCurrentIndexTimeShift >= getNumberOfDecaysInWindow())
   {
     return true;
   }

--- a/src/GeantParser/JPetGeantParser/JPetGeantParser.cpp
+++ b/src/GeantParser/JPetGeantParser/JPetGeantParser.cpp
@@ -468,7 +468,7 @@ void JPetGeantParser::bookEfficiencyHistograms()
 
 }
 
-unsigned int JPetGeantParser::getNumberOfDecaysInWindow() { return fTimeDistroOfDecays.size(); }
+unsigned int JPetGeantParser::getNumberOfDecaysInWindow() const { return fTimeDistroOfDecays.size(); }
 
 float JPetGeantParser::getNextTimeShift()
 {
@@ -484,7 +484,7 @@ void JPetGeantParser::clearTimeDistoOfDecays()
   fTimeDistroOfDecays.clear();
 }
 
-bool JPetGeantParser::isTimeWindowFull()
+bool JPetGeantParser::isTimeWindowFull() const
 {
   if (fCurrentIndexTimeShift >= getNumberOfDecaysInWindow())
   {

--- a/src/GeantParser/JPetGeantParser/JPetGeantParserTools.cpp
+++ b/src/GeantParser/JPetGeantParser/JPetGeantParserTools.cpp
@@ -23,7 +23,7 @@ JPetMCHit JPetGeantParserTools::createJPetMCHit(JPetGeantScinHits* geantHit, con
 {
   JPetMCHit mcHit = JPetMCHit(
                       0,//UInt_t MCDecayTreeIndex,
-                      0,//UInt_t MCVtxIndex,
+                      geantHit->GetEvtID(),//UInt_t MCVtxIndex,
                       geantHit->GetEneDepos(), //  keV
                       geantHit->GetTime(),   //  ps
                       geantHit->GetHitPosition(),


### PR DESCRIPTION
1. Fix of a bug causing MCHits to be distributed in time like events [Redmine 1263]
2. Removing the ".mc" extension component from the file produced by GeantParser (to allow for seamless processing of data and MC with the same program) [Redmine 1199]
3. Storing the ID of generated event in JPetMHit objects (to allow for identification of hits originating form the same event) [Redmine 1260]
4. Avoid writing empty time windows to output files every time GeantParser processes a simulated event.