### PR TITLE
Add seed option in JPetGeantParser to be used in gRandom

### DIFF
--- a/include/GeantParser/JPetGeantParser/JPetGeantParser.h
+++ b/include/GeantParser/JPetGeantParser/JPetGeantParser.h
@@ -50,7 +50,6 @@ public:
   virtual bool exec() override;
   virtual bool terminate() override;
 
-  unsigned long getSeedFromgRandom() const; 
   unsigned long getSeed() const; 
 
 protected :

--- a/include/GeantParser/JPetGeantParser/JPetGeantParser.h
+++ b/include/GeantParser/JPetGeantParser/JPetGeantParser.h
@@ -50,6 +50,8 @@ public:
   virtual bool exec() override;
   virtual bool terminate() override;
 
+  unsigned long getSeedFromgRandom() const; 
+  unsigned long getSeed() const; 
 
 protected :
   JPetGeomMapping* fDetectorMap =  nullptr;
@@ -60,9 +62,8 @@ protected :
   double fMaxTime = 0.;
   double fMinTime = -50.e6; // electronic time window 50 micro seconds - true for run 3
   double fSimulatedActivity = 4.7; //< in MBq; value for run3
-
   double fExperimentalThreshold = 10; //< in keV
-
+  unsigned long fSeed = 0.;
 
   // internal variables
   const std::string kMaxTimeWindowParamKey = "GeantParser_MaxTimeWindow_double";
@@ -72,6 +73,7 @@ protected :
   const std::string kMakeEfficienciesParamKey = "GeantParser_MakeEfficiencies_bool";
   const std::string kEnergyThresholdParamKey = "GeantParser_EnergyThreshold_double";
   const std::string kProcessSingleEventinWindowParamKey = "GeantParser_ProcessSingleEventInWindow_bool";
+  const std::string kSeedParamKey = "GeantParser_Seed_int";
 
   long fExpectedNumberOfEvents = 0;
   float fTimeShift = fMinTime;

--- a/include/GeantParser/JPetGeantParser/JPetGeantParser.h
+++ b/include/GeantParser/JPetGeantParser/JPetGeantParser.h
@@ -50,7 +50,7 @@ public:
   virtual bool exec() override;
   virtual bool terminate() override;
 
-  unsigned long getSeed() const; 
+  unsigned long getOriginalSeed() const; 
 
 protected :
   JPetGeomMapping* fDetectorMap =  nullptr;

--- a/include/GeantParser/JPetGeantParser/JPetGeantParserTools.h
+++ b/include/GeantParser/JPetGeantParser/JPetGeantParserTools.h
@@ -55,6 +55,9 @@ public:
   static std::tuple<std::vector<float>,std::vector<float>> getTimeDistoOfDecays(float activityMBq, float timeWindowMin, float timeWindowMax);
   static std::pair<float, float> calculateEfficiency(ulong, ulong);
 
+  static void setSeedTogRandom(unsigned long seed);
+  static unsigned long getSeedFromgRandom();
+
 };
 
 #endif

--- a/include/GeantParser/JPetGeantParser/JPetGeantParserTools.h
+++ b/include/GeantParser/JPetGeantParser/JPetGeantParserTools.h
@@ -56,7 +56,6 @@ public:
   static std::pair<float, float> calculateEfficiency(ulong, ulong);
 
   static void setSeedTogRandom(unsigned long seed);
-  static unsigned long getSeedFromgRandom();
 
 };
 

--- a/src/GeantParser/JPetGeantParser/JPetGeantParser.cpp
+++ b/src/GeantParser/JPetGeantParser/JPetGeantParser.cpp
@@ -72,6 +72,7 @@ bool JPetGeantParser::init()
     fSeed = getOptionAsInt(fParams.getOptions(), kSeedParamKey);
   }
   JPetGeantParserTools::setSeedTogRandom(fSeed);
+  INFO("Seed value used for resolution smearing of MC simulation data:"<< boost::lexical_cast<std::string>(fSeed));
 
   if (fMakeHisto)
     bookBasicHistograms();

--- a/src/GeantParser/JPetGeantParser/JPetGeantParser.cpp
+++ b/src/GeantParser/JPetGeantParser/JPetGeantParser.cpp
@@ -71,8 +71,8 @@ bool JPetGeantParser::init()
   if (isOptionSet(fParams.getOptions(), kSeedParamKey)) {
     fSeed = getOptionAsInt(fParams.getOptions(), kSeedParamKey);
   }
-  JPetGeantParserTools::setSeedTogRandom(fSeed);
-  INFO("Seed value used for resolution smearing of MC simulation data:"<< boost::lexical_cast<std::string>(fSeed));
+  JPetGeantParserTools::setSeedTogRandom(getOriginalSeed());
+  INFO("Seed value used for resolution smearing of MC simulation data:"<< boost::lexical_cast<std::string>(getOriginalSeed()));
 
   if (fMakeHisto)
     bookBasicHistograms();
@@ -502,7 +502,7 @@ bool JPetGeantParser::isTimeWindowFull() const
   }
 }
 
-unsigned long JPetGeantParser::getSeed() const 
+unsigned long JPetGeantParser::getOriginalSeed() const 
 {
   return fSeed;
 }

--- a/src/GeantParser/JPetGeantParser/JPetGeantParser.cpp
+++ b/src/GeantParser/JPetGeantParser/JPetGeantParser.cpp
@@ -68,8 +68,8 @@ bool JPetGeantParser::init()
   {
     fProcessSingleEventinWindow = getOptionAsBool(fParams.getOptions(), kProcessSingleEventinWindowParamKey);
   }
-  if (isOptionSet(fParams.getOptions(), kSeedParamKey )) {
-    fSeed = getOptionAsInt(fParams.getOptions(), kSeedParamKey );
+  if (isOptionSet(fParams.getOptions(), kSeedParamKey)) {
+    fSeed = getOptionAsInt(fParams.getOptions(), kSeedParamKey);
   }
   JPetGeantParserTools::setSeedTogRandom(fSeed);
 

--- a/src/GeantParser/JPetGeantParser/JPetGeantParser.cpp
+++ b/src/GeantParser/JPetGeantParser/JPetGeantParser.cpp
@@ -68,6 +68,11 @@ bool JPetGeantParser::init()
   {
     fProcessSingleEventinWindow = getOptionAsBool(fParams.getOptions(), kProcessSingleEventinWindowParamKey);
   }
+  if (isOptionSet(fParams.getOptions(), kSeedParamKey )) {
+    fSeed = getOptionAsInt(fParams.getOptions(), kSeedParamKey );
+  }
+  JPetGeantParserTools::setSeedTogRandom(fSeed);
+
   if (fMakeHisto)
     bookBasicHistograms();
   if (fMakeEffiHisto)
@@ -494,4 +499,9 @@ bool JPetGeantParser::isTimeWindowFull() const
   {
     return false;
   }
+}
+
+unsigned long JPetGeantParser::getSeed() const 
+{
+  return fSeed;
 }

--- a/src/GeantParser/JPetGeantParser/JPetGeantParserTools.cpp
+++ b/src/GeantParser/JPetGeantParser/JPetGeantParserTools.cpp
@@ -120,16 +120,6 @@ std::pair<float, float> JPetGeantParserTools::calculateEfficiency(ulong n, ulong
   }
 }
 
-
-unsigned long JPetGeantParserTools::getSeedFromgRandom()
-{
-  if (!gRandom) {
-    ERROR("gRandom is not set and we cannot check the seed we return 999999 as placeholder");
-    return 999999;
-  }
-  return gRandom->GetSeed();
-}
-
 void JPetGeantParserTools::setSeedTogRandom(unsigned long seed)
 {
   if (!gRandom) {

--- a/src/GeantParser/JPetGeantParser/JPetGeantParserTools.cpp
+++ b/src/GeantParser/JPetGeantParser/JPetGeantParserTools.cpp
@@ -119,3 +119,23 @@ std::pair<float, float> JPetGeantParserTools::calculateEfficiency(ulong n, ulong
     return std::make_pair(0, 0);
   }
 }
+
+
+unsigned long JPetGeantParserTools::getSeedFromgRandom()
+{
+  if (!gRandom) {
+    ERROR("gRandom is not set and we cannot check the seed we return 999999 as placeholder");
+    return 999999;
+  }
+  return gRandom->GetSeed();
+}
+
+void JPetGeantParserTools::setSeedTogRandom(unsigned long seed)
+{
+  if (!gRandom) {
+    ERROR("gRandom is not set and we cannot set the seed");
+  } else {
+    gRandom->SetSeed(seed);     
+  }
+}
+

--- a/src/GeantParser/JPetGeantParser/JPetGeantParserTools.cpp
+++ b/src/GeantParser/JPetGeantParser/JPetGeantParserTools.cpp
@@ -138,4 +138,3 @@ void JPetGeantParserTools::setSeedTogRandom(unsigned long seed)
     gRandom->SetSeed(seed);     
   }
 }
-


### PR DESCRIPTION
The gRandom is used both for generating lifetimes and for smearing
resolutions.
As it was found by Nikodem the default seed has fixed value,
therefore in case of e.g. multiple file processing, the same sequences
of pseudorandom values would be used.
This PR introduces: 1. an option, that the user can provide in the json file
to decide about the seed value. 2.default seed value is set to 0, so the
random generator will use the seed generated from the current system
time.
The seed values are passed to ROOT gRandom.