### PR TITLE
JPetStatistic update

### DIFF
--- a/include/Core/JPetStatistics/JPetStatistics.h
+++ b/include/Core/JPetStatistics/JPetStatistics.h
@@ -20,12 +20,15 @@
 #include <THashTable.h>
 #include <TH1F.h>
 #include <TH2F.h>
+#include <TH3F.h>
 #include <TString.h>
 #include <TCanvas.h>
 #include <TGraph.h>
+#include <TClass.h>
 #include <TEfficiency.h>
 #include <string>
 #include <map>
+#include <set>
 
 /**
  * @brief Cointainer class for processing statistics
@@ -33,6 +36,14 @@
  * A class for storing statistics of the processing during the execution of a JPetTask.
  * Available for storing Graphs, Canvases and 1D, 2D Histograms,
  */
+class doubleCheck
+{
+public:
+  bool isChanged = false;
+  double value = 0.;
+  doubleCheck(){}
+  doubleCheck(double newValue) {value=newValue; isChanged=true;}
+};
 
 class JPetStatistics: public TObject
 {
@@ -40,16 +51,24 @@ public:
   JPetStatistics();
   JPetStatistics(const JPetStatistics& old);
   ~JPetStatistics();
+  void createObject(TObject* object);
   void createHistogram(TObject* object);
+  void createHistogramWithAxes(TObject* object, TString xAxisName="Default X axis title [unit]", TString yAxisName="Default Y axis title [unit]", TString zAxisName="Default Z axis title [unit]");
+  void createSquareHistogramWithAxes(TObject* object, TString xAxisName="Default X axis title [unit]", TString yAxisName="Default Y axis title [unit]");
   void createGraph(TObject* object);
   void createCanvas(TObject* object);
+  void fillHistogram(const char* name, double xValue, doubleCheck yValue=doubleCheck(), doubleCheck zValue=doubleCheck());
+  void fillSquareHistogram(const char* name, double xValue, doubleCheck yValue=doubleCheck());
   TEfficiency* getEffiHisto(const char* name);
   TH1F* getHisto1D(const char* name);
   TH2F* getHisto2D(const char* name);
+  TH3F* getHisto3D(const char* name);
   TGraph* getGraph(const char* name);
   TCanvas* getCanvas(const char* name);
   void createCounter(const char* name);
   double& getCounter(const char* name);
+  void writeError(const char* nameOfHistogram, const char* messageEnd );
+  
 
   template <typename T>
   T* getObject(const char* name)
@@ -68,6 +87,6 @@ public:
 protected:
   THashTable fStats;
   std::map<TString, double> fCounters;
+  std::set<std::string> fErrorCounts;
 };
-
 #endif /* !_JPET_STATISTICS_H_ */

--- a/include/Core/JPetStatistics/JPetStatistics.h
+++ b/include/Core/JPetStatistics/JPetStatistics.h
@@ -54,11 +54,9 @@ public:
   void createObject(TObject* object);
   void createHistogram(TObject* object);
   void createHistogramWithAxes(TObject* object, TString xAxisName="Default X axis title [unit]", TString yAxisName="Default Y axis title [unit]", TString zAxisName="Default Z axis title [unit]");
-  void createSquareHistogramWithAxes(TObject* object, TString xAxisName="Default X axis title [unit]", TString yAxisName="Default Y axis title [unit]");
   void createGraph(TObject* object);
   void createCanvas(TObject* object);
   void fillHistogram(const char* name, double xValue, doubleCheck yValue=doubleCheck(), doubleCheck zValue=doubleCheck());
-  void fillSquareHistogram(const char* name, double xValue, doubleCheck yValue=doubleCheck());
   TEfficiency* getEffiHisto(const char* name);
   TH1F* getHisto1D(const char* name);
   TH2F* getHisto2D(const char* name);

--- a/include/Core/JPetStatistics/JPetStatistics.h
+++ b/include/Core/JPetStatistics/JPetStatistics.h
@@ -30,12 +30,6 @@
 #include <map>
 #include <set>
 
-/**
- * @brief Cointainer class for processing statistics
- *
- * A class for storing statistics of the processing during the execution of a JPetTask.
- * Available for storing Graphs, Canvases and 1D, 2D Histograms,
- */
 class doubleCheck
 {
 public:
@@ -44,6 +38,13 @@ public:
   doubleCheck(){}
   doubleCheck(double newValue) {value=newValue; isChanged=true;}
 };
+
+/**
+ * @brief Cointainer class for processing statistics
+ *
+ * A class for storing statistics of the processing during the execution of a JPetTask.
+ * Available for storing Graphs, Canvases and 1D, 2D Histograms,
+ */
 
 class JPetStatistics: public TObject
 {
@@ -66,7 +67,6 @@ public:
   void createCounter(const char* name);
   double& getCounter(const char* name);
   void writeError(const char* nameOfHistogram, const char* messageEnd );
-  
 
   template <typename T>
   T* getObject(const char* name)
@@ -85,6 +85,5 @@ public:
 protected:
   THashTable fStats;
   std::map<TString, double> fCounters;
-  std::set<std::string> fErrorCounts;
 };
 #endif /* !_JPET_STATISTICS_H_ */

--- a/src/Core/JPetStatistics/JPetStatistics.cpp
+++ b/src/Core/JPetStatistics/JPetStatistics.cpp
@@ -55,28 +55,6 @@ void JPetStatistics::createHistogramWithAxes(TObject* object, TString xAxisName,
   fStats.Add(object);
 }
 
-void JPetStatistics::createSquareHistogramWithAxes(TObject* object, TString xAxisName, TString yAxisName) 
-{ 
-  TClass *cl = object->IsA();
-  if( cl->InheritsFrom("TH1D") )
-  {
-    TH1D* tempHisto = dynamic_cast<TH1D*>(object);
-    tempHisto->GetXaxis()->SetTitle(xAxisName);
-    tempHisto->GetYaxis()->SetTitle(yAxisName);
-  }
-  else if( cl->InheritsFrom("TH2D") )
-  {
-    TH2D* tempHisto = dynamic_cast<TH2D*>(object);
-    tempHisto->GetXaxis()->SetTitle(xAxisName);
-    tempHisto->GetYaxis()->SetTitle(yAxisName);
-  }
-  fStats.Add(object);
-  std::string objName = object->GetName();
-  objName += "_Square";
-  createCanvas( new TCanvas( objName.c_str(), objName.c_str(), 800, 800 ) );
-}
-
-
 void JPetStatistics::createGraph(TObject* object) { fStats.Add(object); }
 
 void JPetStatistics::createCanvas(TObject* object) { fStats.Add(object); }
@@ -113,51 +91,6 @@ void JPetStatistics::fillHistogram(const char* name, double xValue, doubleCheck 
     else
         writeError(name, " does not received argument for Z axis" );
   }  
-}
-
-void JPetStatistics::fillSquareHistogram(const char* name, double xValue, doubleCheck yValue)
-{
-  TObject *tempObject = getObject<TObject>(name);
-  if( !tempObject )
-  {
-    writeError(name, " does not exist" );
-    return;
-  }
-  std::string canvasName = name;
-  canvasName += "_Square";
-  TCanvas *squareCanvas = getCanvas( canvasName.c_str() );
-  if( !squareCanvas )
-  {
-    writeError(name, " has not defined square Canvas for it" );
-    return;
-  }
-  
-  TClass *cl = tempObject->IsA();
-  if( cl->InheritsFrom("TH1D") )
-  {
-    TH1D* tempHisto = dynamic_cast<TH1D*>(tempObject);
-    tempHisto->Fill(xValue);
-    if( squareCanvas )
-    {
-        squareCanvas->cd();
-        tempHisto->Draw("");
-        squareCanvas->Update();
-    }
-  }
-  else if( cl->InheritsFrom("TH2D") )
-  {
-    TH2D* tempHisto = dynamic_cast<TH2D*>(tempObject);
-    if(yValue.isChanged)
-        tempHisto->Fill(xValue, yValue.value);
-    else
-        writeError(name, " does not received argument for Y axis" );
-    if( squareCanvas )
-    {
-        squareCanvas->cd();
-        tempHisto->Draw("colz");
-        squareCanvas->Update();
-    }
-  }
 }
 
 TEfficiency* JPetStatistics::getEffiHisto(const char* name) { return getObject<TEfficiency>(name); }

--- a/src/Core/JPetStatistics/JPetStatistics.cpp
+++ b/src/Core/JPetStatistics/JPetStatistics.cpp
@@ -28,15 +28,145 @@ JPetStatistics::~JPetStatistics() { fStats.Clear("nodelete"); }
 
 void JPetStatistics::createHistogram(TObject* object) { fStats.Add(object); }
 
+void JPetStatistics::createObject(TObject* object) { fStats.Add(object); }
+
+void JPetStatistics::createHistogramWithAxes(TObject* object, TString xAxisName, TString yAxisName, TString zAxisName) 
+{ 
+  TClass *cl = object->IsA();
+  if( cl->InheritsFrom("TH1D") )
+  {
+    TH1D* tempHisto = dynamic_cast<TH1D*>(object);
+    tempHisto->GetXaxis()->SetTitle(xAxisName);
+    tempHisto->GetYaxis()->SetTitle(yAxisName);
+  }
+  else if( cl->InheritsFrom("TH2D") )
+  {
+    TH2D* tempHisto = dynamic_cast<TH2D*>(object);
+    tempHisto->GetXaxis()->SetTitle(xAxisName);
+    tempHisto->GetYaxis()->SetTitle(yAxisName);
+  }
+  else if( cl->InheritsFrom("TH3D") )
+  {
+    TH3D* tempHisto = dynamic_cast<TH3D*>(object);
+    tempHisto->GetXaxis()->SetTitle(xAxisName);
+    tempHisto->GetYaxis()->SetTitle(yAxisName);
+    tempHisto->GetZaxis()->SetTitle(zAxisName);
+  }
+  fStats.Add(object);
+}
+
+void JPetStatistics::createSquareHistogramWithAxes(TObject* object, TString xAxisName, TString yAxisName) 
+{ 
+  TClass *cl = object->IsA();
+  if( cl->InheritsFrom("TH1D") )
+  {
+    TH1D* tempHisto = dynamic_cast<TH1D*>(object);
+    tempHisto->GetXaxis()->SetTitle(xAxisName);
+    tempHisto->GetYaxis()->SetTitle(yAxisName);
+  }
+  else if( cl->InheritsFrom("TH2D") )
+  {
+    TH2D* tempHisto = dynamic_cast<TH2D*>(object);
+    tempHisto->GetXaxis()->SetTitle(xAxisName);
+    tempHisto->GetYaxis()->SetTitle(yAxisName);
+  }
+  fStats.Add(object);
+  std::string objName = object->GetName();
+  objName += "_Square";
+  createCanvas( new TCanvas( objName.c_str(), objName.c_str(), 800, 800 ) );
+}
+
+
 void JPetStatistics::createGraph(TObject* object) { fStats.Add(object); }
 
 void JPetStatistics::createCanvas(TObject* object) { fStats.Add(object); }
+
+void JPetStatistics::fillHistogram(const char* name, double xValue, doubleCheck yValue, doubleCheck zValue)
+{
+  TObject *tempObject = getObject<TObject>(name);
+  if( !tempObject )
+  {
+    writeError(name, " does not exist" );
+    return;
+  }
+  TClass *cl = tempObject->IsA();
+  if( cl->InheritsFrom("TH1D") )
+  {
+    TH1D* tempHisto = dynamic_cast<TH1D*>(tempObject);
+    tempHisto->Fill(xValue);
+  }
+  else if( cl->InheritsFrom("TH2D") )
+  {
+    TH2D* tempHisto = dynamic_cast<TH2D*>(tempObject);
+    if(yValue.isChanged)
+        tempHisto->Fill(xValue, yValue.value);
+    else
+        writeError(name, " does not received argument for Y axis" );
+  }
+  else if( cl->InheritsFrom("TH3D") )
+  {
+    TH3D* tempHisto = dynamic_cast<TH3D*>(tempObject);
+    if(zValue.isChanged)
+        tempHisto->Fill(xValue, yValue.value, zValue.value);
+    else if(yValue.isChanged)
+        writeError(name, " does not received argument for Y and Z axis" );
+    else
+        writeError(name, " does not received argument for Z axis" );
+  }  
+}
+
+void JPetStatistics::fillSquareHistogram(const char* name, double xValue, doubleCheck yValue)
+{
+  TObject *tempObject = getObject<TObject>(name);
+  if( !tempObject )
+  {
+    writeError(name, " does not exist" );
+    return;
+  }
+  std::string canvasName = name;
+  canvasName += "_Square";
+  TCanvas *squareCanvas = getCanvas( canvasName.c_str() );
+  if( !squareCanvas )
+  {
+    writeError(name, " has not defined square Canvas for it" );
+    return;
+  }
+  
+  TClass *cl = tempObject->IsA();
+  if( cl->InheritsFrom("TH1D") )
+  {
+    TH1D* tempHisto = dynamic_cast<TH1D*>(tempObject);
+    tempHisto->Fill(xValue);
+    if( squareCanvas )
+    {
+        squareCanvas->cd();
+        tempHisto->Draw("");
+        squareCanvas->Update();
+    }
+  }
+  else if( cl->InheritsFrom("TH2D") )
+  {
+    TH2D* tempHisto = dynamic_cast<TH2D*>(tempObject);
+    if(yValue.isChanged)
+        tempHisto->Fill(xValue, yValue.value);
+    else
+        writeError(name, " does not received argument for Y axis" );
+    if( squareCanvas )
+    {
+        squareCanvas->cd();
+        tempHisto->Draw("colz");
+        squareCanvas->Update();
+    }
+  }
+}
 
 TEfficiency* JPetStatistics::getEffiHisto(const char* name) { return getObject<TEfficiency>(name); }
 
 TH1F* JPetStatistics::getHisto1D(const char* name) { return getObject<TH1F>(name); }
 
 TH2F* JPetStatistics::getHisto2D(const char* name) { return getObject<TH2F>(name); }
+
+TH3F* JPetStatistics::getHisto3D(const char* name) { return getObject<TH3F>(name); }
 
 TGraph* JPetStatistics::getGraph(const char* name) { return getObject<TGraph>(name); }
 
@@ -47,3 +177,14 @@ void JPetStatistics::createCounter(const char* name) { fCounters[name] = 0.0; }
 double& JPetStatistics::getCounter(const char* name) { return fCounters[name]; }
 
 const THashTable* JPetStatistics::getStatsTable() const { return &fStats; }
+
+void JPetStatistics::writeError(const char* nameOfHistogram, const char* messageEnd )
+{
+  std::set<std::string>::iterator existenceCheck = fErrorCounts.find(std::string(nameOfHistogram));
+  if( existenceCheck == fErrorCounts.end() )
+  {
+    fErrorCounts.insert(std::string(nameOfHistogram));
+    ERROR(std::string("Histogram with name ") + std::string(nameOfHistogram) + std::string(messageEnd) );
+    std::cout << "!!![Error]!!!  -  Histogram with name " << nameOfHistogram  << " " << messageEnd << std::endl;
+  }
+}

--- a/src/Core/JPetStatistics/JPetStatistics.cpp
+++ b/src/Core/JPetStatistics/JPetStatistics.cpp
@@ -113,11 +113,5 @@ const THashTable* JPetStatistics::getStatsTable() const { return &fStats; }
 
 void JPetStatistics::writeError(const char* nameOfHistogram, const char* messageEnd )
 {
-  std::set<std::string>::iterator existenceCheck = fErrorCounts.find(std::string(nameOfHistogram));
-  if( existenceCheck == fErrorCounts.end() )
-  {
-    fErrorCounts.insert(std::string(nameOfHistogram));
-    ERROR(std::string("Histogram with name ") + std::string(nameOfHistogram) + std::string(messageEnd) );
-    std::cout << "!!![Error]!!!  -  Histogram with name " << nameOfHistogram  << " " << messageEnd << std::endl;
-  }
+  ERROR(std::string("Histogram with name ") + std::string(nameOfHistogram) + std::string(messageEnd) );
 }


### PR DESCRIPTION
    THxD histograms handling added
    TH3D histograms handling
    Defining histogram with axis names, not returning object to user to stop crashes. Returning only Errors in terminal and in log to notify user about errors
    Filling histograms not by returning histogram to the user, also to stop crashes, only notifications are written
    Square histograms defined as a square TCanvas. Histogram is filled separately, square histogram is drawn on the TCanvas with the same name as histogram, with addition "_Square". There is default option to draw 2D histos in colz style, because after saving there were some problems with using drawing options in TBrowser fro TCanvas
