### PR TITLE
Use Unpacker branch develop if on develop branch itself

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -99,7 +99,16 @@ else()
   include(ExternalProject)
   message(STATUS "Unpacker2 was not found..")
   set(GITHUB_URL "https://github.com/JPETTomography/Unpacker2.git")
-  set(GIT_TAG "master")
+
+  exec_program("git"
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ARGS "branch --show-current"
+    OUTPUT_VARIABLE framework_branchname)
+  if( ${framework_branchname} STREQUAL "develop") #
+    set(GIT_TAG "develop")
+  else()
+    set(GIT_TAG "master")
+  endif()
 
   message(STATUS "Adding external project to download and compile Unpacker2 from: ${GITHUB_URL} with tag: ${GIT_TAG}")
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -104,7 +104,7 @@ else()
     ${CMAKE_CURRENT_SOURCE_DIR}
     ARGS "branch --show-current"
     OUTPUT_VARIABLE framework_branchname)
-  if( ${framework_branchname} STREQUAL "develop") #
+  if( ${framework_branchname} STREQUAL "develop")
     set(GIT_TAG "develop")
   else()
     set(GIT_TAG "master")


### PR DESCRIPTION
**This PR is required before #239, otherwise the latter will break automatic tests.**

Currently if the Unpacker location is not specified explicitly, CMake
always fetches and builds one from the master branch. Our tests rely
on this mechanism therefore always testing with master Unpacker. This
is undesirable if the API changes between them as tests will break
until all changes are in master branches. This commit makes CMake
automatically use the develop branch of Unpacker in case the framework
branch is also develop. In all other cases, master Unpacker is used as before.