### PR TITLE
Adding method to set custom Axes for user

### DIFF
--- a/include/Core/JPetStatistics/JPetStatistics.h
+++ b/include/Core/JPetStatistics/JPetStatistics.h
@@ -52,9 +52,9 @@ public:
     
   enum AxisLabel
   {
-    xAxis,
-    yAxis,
-    zAxis,
+    kXaxis,
+    kYaxis,
+    kZaxis,
   };
 
   JPetStatistics();

--- a/include/Core/JPetStatistics/JPetStatistics.h
+++ b/include/Core/JPetStatistics/JPetStatistics.h
@@ -49,6 +49,14 @@ public:
 class JPetStatistics: public TObject
 {
 public:
+    
+  enum AxisLabel
+  {
+    xAxis,
+    yAxis,
+    zAxis,
+  };
+
   JPetStatistics();
   JPetStatistics(const JPetStatistics& old);
   ~JPetStatistics();
@@ -56,9 +64,7 @@ public:
   void createHistogram(TObject* object);
   void createHistogramWithAxes(TObject* object, TString xAxisName="Default X axis title [unit]",
                                TString yAxisName="Default Y axis title [unit]", TString zAxisName="Default Z axis title [unit]");
-  void createHistogramWithCustomAxes(TObject* object, std::vector<std::vector<std::string>> binLabels, std::vector<std::vector<unsigned>> binNumbers, 
-                                     TString xAxisName="Default X axis title [unit]", TString yAxisName="Default Y axis title [unit]", 
-                                     TString zAxisName="Default Z axis title [unit]");
+  void setHistogramBinLabel(const char* name, AxisLabel axis, std::vector<std::pair<unsigned, std::string>> binLabels);
   void createGraph(TObject* object);
   void createCanvas(TObject* object);
   void fillHistogram(const char* name, double xValue, doubleCheck yValue=doubleCheck(), doubleCheck zValue=doubleCheck());

--- a/include/Core/JPetStatistics/JPetStatistics.h
+++ b/include/Core/JPetStatistics/JPetStatistics.h
@@ -54,7 +54,11 @@ public:
   ~JPetStatistics();
   void createObject(TObject* object);
   void createHistogram(TObject* object);
-  void createHistogramWithAxes(TObject* object, TString xAxisName="Default X axis title [unit]", TString yAxisName="Default Y axis title [unit]", TString zAxisName="Default Z axis title [unit]");
+  void createHistogramWithAxes(TObject* object, TString xAxisName="Default X axis title [unit]",
+                               TString yAxisName="Default Y axis title [unit]", TString zAxisName="Default Z axis title [unit]");
+  void createHistogramWithCustomAxes(TObject* object, std::vector<std::vector<std::string>> binLabels, std::vector<std::vector<unsigned>> binNumbers, 
+                                     TString xAxisName="Default X axis title [unit]", TString yAxisName="Default Y axis title [unit]", 
+                                     TString zAxisName="Default Z axis title [unit]");
   void createGraph(TObject* object);
   void createCanvas(TObject* object);
   void fillHistogram(const char* name, double xValue, doubleCheck yValue=doubleCheck(), doubleCheck zValue=doubleCheck());

--- a/src/Core/JPetStatistics/JPetStatistics.cpp
+++ b/src/Core/JPetStatistics/JPetStatistics.cpp
@@ -70,7 +70,7 @@ void JPetStatistics::setHistogramBinLabel(const char* name, AxisLabel axis, std:
     if( binLabels.size() > 0 )
     {
       TAxis *customAxis;
-      if( axis == AxisLabel::xAxis )
+      if( axis == AxisLabel::kXaxis )
       {
         customAxis = tempHisto->GetXaxis();
         for( unsigned i=0; i<binLabels.size(); i++ )
@@ -88,9 +88,9 @@ void JPetStatistics::setHistogramBinLabel(const char* name, AxisLabel axis, std:
     if( binLabels.size() > 0 )
     {
       TAxis *customAxis;
-      if( axis != AxisLabel::zAxis )
+      if( axis != AxisLabel::kZaxis )
       {
-        customAxis = ( axis == AxisLabel::xAxis ? tempHisto->GetXaxis() : tempHisto->GetYaxis());
+        customAxis = ( axis == AxisLabel::kXaxis ? tempHisto->GetXaxis() : tempHisto->GetYaxis());
         for( unsigned i=0; i<binLabels.size(); i++ )
           customAxis->SetBinLabel(binLabels[i].first,(binLabels[i].second).c_str());
       }
@@ -106,8 +106,8 @@ void JPetStatistics::setHistogramBinLabel(const char* name, AxisLabel axis, std:
     if( binLabels.size() > 0 )
     {
       TAxis *customAxis;
-      customAxis = ( axis == AxisLabel::xAxis ? tempHisto->GetXaxis() : 
-                                        ( axis == AxisLabel::yAxis ? tempHisto->GetYaxis() : tempHisto->GetYaxis()));
+      customAxis = ( axis == AxisLabel::kXaxis ? tempHisto->GetXaxis() : 
+                                        ( axis == AxisLabel::kYaxis ? tempHisto->GetYaxis() : tempHisto->GetZaxis()));
       for( unsigned i=0; i<binLabels.size(); i++ )
         customAxis->SetBinLabel(binLabels[i].first,(binLabels[i].second).c_str());
     }

--- a/src/Core/JPetStatistics/JPetStatistics.cpp
+++ b/src/Core/JPetStatistics/JPetStatistics.cpp
@@ -55,6 +55,69 @@ void JPetStatistics::createHistogramWithAxes(TObject* object, TString xAxisName,
   fStats.Add(object);
 }
 
+void JPetStatistics::createHistogramWithCustomAxes(TObject* object, std::vector<std::vector<std::string>> binLabels, 
+                                                   std::vector<std::vector<unsigned>> binNumbers, TString xAxisName, 
+                                                   TString yAxisName, TString zAxisName)
+{
+  TClass *cl = object->IsA();
+  if( cl->InheritsFrom("TH1D") )
+  {
+    TH1D* tempHisto = dynamic_cast<TH1D*>(object);
+    tempHisto->GetXaxis()->SetTitle(xAxisName);
+    tempHisto->GetYaxis()->SetTitle(yAxisName);
+    if( binLabels.size() > 0 && binNumbers.size() > 0 )
+    {
+      for( unsigned i=0; i<binLabels[0].size() || i<binNumbers[0].size(); i++ )
+        tempHisto->GetXaxis()->SetBinLabel(binNumbers[0][i],binLabels[0][i].c_str());
+    }
+    else
+      writeError(tempHisto->GetName(), " had empty custom names of axis or bin numbers" );
+  }
+  else if( cl->InheritsFrom("TH2D") )
+  {
+    TH2D* tempHisto = dynamic_cast<TH2D*>(object);
+    tempHisto->GetXaxis()->SetTitle(xAxisName);
+    tempHisto->GetYaxis()->SetTitle(yAxisName);
+    if( binLabels.size() > 0 && binNumbers.size() > 0 )
+    {
+      for( unsigned i=0; i<binLabels[0].size() || i<binNumbers[0].size(); i++ )
+        tempHisto->GetXaxis()->SetBinLabel(binNumbers[0][i],binLabels[0][i].c_str());
+      if( binLabels.size() > 1 && binNumbers.size() > 1 )
+      {
+        for( unsigned j=0; j<binLabels[1].size() || j<binNumbers[1].size(); j++ )
+          tempHisto->GetYaxis()->SetBinLabel(binNumbers[1][j],binLabels[1][j].c_str());
+      }
+    }
+    else
+      writeError(tempHisto->GetName(), " had empty custom names of axis or bin numbers" );
+  }
+  else if( cl->InheritsFrom("TH3D") )
+  {
+    TH3D* tempHisto = dynamic_cast<TH3D*>(object);
+    tempHisto->GetXaxis()->SetTitle(xAxisName);
+    tempHisto->GetYaxis()->SetTitle(yAxisName);
+    tempHisto->GetZaxis()->SetTitle(zAxisName);
+    if( binLabels.size() > 0 && binNumbers.size() > 0 )
+    {
+      for( unsigned i=0; i<binLabels[0].size() || i<binNumbers[0].size(); i++ )
+        tempHisto->GetXaxis()->SetBinLabel(binNumbers[0][i],binLabels[0][i].c_str());
+      if( binLabels.size() > 1 && binNumbers.size() > 1 )
+      {
+        for( unsigned j=0; j<binLabels[1].size() || j<binNumbers[1].size(); j++ )
+          tempHisto->GetYaxis()->SetBinLabel(binNumbers[1][j],binLabels[1][j].c_str());
+        if( binLabels.size() > 2 && binNumbers.size() > 2 )
+        {
+          for( unsigned k=0; k<binLabels[2].size() || k<binNumbers[2].size(); k++ )
+            tempHisto->GetZaxis()->SetBinLabel(binNumbers[2][k],binLabels[2][k].c_str());
+        }
+      }
+    }
+    else
+      writeError(tempHisto->GetName(), " had empty custom names of axis or bin numbers" );
+  }
+  fStats.Add(object);  
+}
+
 void JPetStatistics::createGraph(TObject* object) { fStats.Add(object); }
 
 void JPetStatistics::createCanvas(TObject* object) { fStats.Add(object); }

--- a/src/Core/JPetStatistics/JPetStatistics.cpp
+++ b/src/Core/JPetStatistics/JPetStatistics.cpp
@@ -55,67 +55,65 @@ void JPetStatistics::createHistogramWithAxes(TObject* object, TString xAxisName,
   fStats.Add(object);
 }
 
-void JPetStatistics::createHistogramWithCustomAxes(TObject* object, std::vector<std::vector<std::string>> binLabels, 
-                                                   std::vector<std::vector<unsigned>> binNumbers, TString xAxisName, 
-                                                   TString yAxisName, TString zAxisName)
+void JPetStatistics::setHistogramBinLabel(const char* name, AxisLabel axis, std::vector<std::pair<unsigned, std::string>> binLabels)
 {
-  TClass *cl = object->IsA();
+  TObject *tempObject = getObject<TObject>(name);
+  if( !tempObject )
+  {
+    writeError(name, " does not exist" );
+    return;
+  }
+  TClass *cl = tempObject->IsA();
   if( cl->InheritsFrom("TH1D") )
   {
-    TH1D* tempHisto = dynamic_cast<TH1D*>(object);
-    tempHisto->GetXaxis()->SetTitle(xAxisName);
-    tempHisto->GetYaxis()->SetTitle(yAxisName);
-    if( binLabels.size() > 0 && binNumbers.size() > 0 )
+    TH1D* tempHisto = dynamic_cast<TH1D*>(tempObject);
+    if( binLabels.size() > 0 )
     {
-      for( unsigned i=0; i<binLabels[0].size() || i<binNumbers[0].size(); i++ )
-        tempHisto->GetXaxis()->SetBinLabel(binNumbers[0][i],binLabels[0][i].c_str());
+      TAxis *customAxis;
+      if( axis == AxisLabel::xAxis )
+      {
+        customAxis = tempHisto->GetXaxis();
+        for( unsigned i=0; i<binLabels.size(); i++ )
+          customAxis->SetBinLabel(binLabels[i].first,(binLabels[i].second).c_str());
+      }
+      else
+        writeError(name, " can not have custom Y or Z axis" );
     }
     else
-      writeError(tempHisto->GetName(), " had empty custom names of axis or bin numbers" );
+      writeError(name, " had empty custom labels of bins" );
   }
   else if( cl->InheritsFrom("TH2D") )
   {
-    TH2D* tempHisto = dynamic_cast<TH2D*>(object);
-    tempHisto->GetXaxis()->SetTitle(xAxisName);
-    tempHisto->GetYaxis()->SetTitle(yAxisName);
-    if( binLabels.size() > 0 && binNumbers.size() > 0 )
+    TH2D* tempHisto = dynamic_cast<TH2D*>(tempObject);
+    if( binLabels.size() > 0 )
     {
-      for( unsigned i=0; i<binLabels[0].size() || i<binNumbers[0].size(); i++ )
-        tempHisto->GetXaxis()->SetBinLabel(binNumbers[0][i],binLabels[0][i].c_str());
-      if( binLabels.size() > 1 && binNumbers.size() > 1 )
+      TAxis *customAxis;
+      if( axis != AxisLabel::zAxis )
       {
-        for( unsigned j=0; j<binLabels[1].size() || j<binNumbers[1].size(); j++ )
-          tempHisto->GetYaxis()->SetBinLabel(binNumbers[1][j],binLabels[1][j].c_str());
+        customAxis = ( axis == AxisLabel::xAxis ? tempHisto->GetXaxis() : tempHisto->GetYaxis());
+        for( unsigned i=0; i<binLabels.size(); i++ )
+          customAxis->SetBinLabel(binLabels[i].first,(binLabels[i].second).c_str());
       }
+      else
+        writeError(name, " can not have custom Z axis" );
     }
     else
-      writeError(tempHisto->GetName(), " had empty custom names of axis or bin numbers" );
+      writeError(name, " had empty custom labels of bins" );
   }
   else if( cl->InheritsFrom("TH3D") )
   {
-    TH3D* tempHisto = dynamic_cast<TH3D*>(object);
-    tempHisto->GetXaxis()->SetTitle(xAxisName);
-    tempHisto->GetYaxis()->SetTitle(yAxisName);
-    tempHisto->GetZaxis()->SetTitle(zAxisName);
-    if( binLabels.size() > 0 && binNumbers.size() > 0 )
+    TH3D* tempHisto = dynamic_cast<TH3D*>(tempObject);
+    if( binLabels.size() > 0 )
     {
-      for( unsigned i=0; i<binLabels[0].size() || i<binNumbers[0].size(); i++ )
-        tempHisto->GetXaxis()->SetBinLabel(binNumbers[0][i],binLabels[0][i].c_str());
-      if( binLabels.size() > 1 && binNumbers.size() > 1 )
-      {
-        for( unsigned j=0; j<binLabels[1].size() || j<binNumbers[1].size(); j++ )
-          tempHisto->GetYaxis()->SetBinLabel(binNumbers[1][j],binLabels[1][j].c_str());
-        if( binLabels.size() > 2 && binNumbers.size() > 2 )
-        {
-          for( unsigned k=0; k<binLabels[2].size() || k<binNumbers[2].size(); k++ )
-            tempHisto->GetZaxis()->SetBinLabel(binNumbers[2][k],binLabels[2][k].c_str());
-        }
-      }
+      TAxis *customAxis;
+      customAxis = ( axis == AxisLabel::xAxis ? tempHisto->GetXaxis() : 
+                                        ( axis == AxisLabel::yAxis ? tempHisto->GetYaxis() : tempHisto->GetYaxis()));
+      for( unsigned i=0; i<binLabels.size(); i++ )
+        customAxis->SetBinLabel(binLabels[i].first,(binLabels[i].second).c_str());
     }
     else
-      writeError(tempHisto->GetName(), " had empty custom names of axis or bin numbers" );
-  }
-  fStats.Add(object);  
+      writeError(name, " had empty custom labels of bins" );
+  }  
 }
 
 void JPetStatistics::createGraph(TObject* object) { fStats.Add(object); }


### PR DESCRIPTION
During the change of the examples to incorporate new methods for histogram creation I`ve noticed, that some of the histograms are created with custom names of the bins (if the signal/hit are corrupted or not, or filling histogram with number of lead/trail signals at each threshold).
Therefore I propose to add additional function to JPetStatistic in order to cover these cases with one function. I tried to made it more gentle but this version of PR is the shortest one, that I can think of.

