### PR TITLE
Add root6.20 and ubuntu 18.04 to CI actions

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -26,43 +26,20 @@ jobs:
         wget http://sphinx.if.uj.edu.pl/framework/root-6-20-06-ubuntu18-jpet.tar.gz 
         tar xzf root-6-20-06-ubuntu18-jpet.tar.gz
       if: matrix.os == 'ubuntu-18.04'
-    - name: cmake (for ubuntu-16-04)
+    - name: cmake
       run: |
         source root/bin/thisroot.sh
         mkdir build
         cd build
         cmake ..
-      if: matrix.os == 'ubuntu-16.04'
-    - name: cmake (for ubuntu-18-04)
-      run: |
-        source root-system/bin/thisroot.sh
-        mkdir build
-        cd build
-        cmake ..
-      if: matrix.os == 'ubuntu-18.04'
-    - name: make (for ubuntu-16.04)
+    - name: make
       run: |
         source root/bin/thisroot.sh
         cd build
         make all tests -j4
-      if: matrix.os == 'ubuntu-16.04'
-    - name: make (for ubuntu-18.04)
-      run: |
-        source root-system/bin/thisroot.sh
-        cd build
-        make all tests -j4
-      if: matrix.os == 'ubuntu-18.04'
-    - name: run tests(for ubuntu-16.04)
+    - name: run tests
       run: |
         source root/bin/thisroot.sh
         cd build
         source bin/thisframework.sh
         ctest -j6 -C Debug -T test --output-on-failure
-      if: matrix.os == 'ubuntu-16.04'
-    - name: run tests(for ubuntu-18.04)
-      run: |
-        source root-system/bin/thisroot.sh
-        cd build
-        source bin/thisframework.sh
-        ctest -j6 -C Debug -T test --output-on-failure
-      if: matrix.os == 'ubuntu-18.04'

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-16.04]
+        os: [ubuntu-16.04, ubuntu-18.04]
    
     steps:
     - uses: actions/checkout@v2
@@ -16,24 +16,53 @@ jobs:
        sudo apt-get -qq update
        sudo apt-get install -y git libboost-all-dev libtbb-dev cmake
       
-    - name: download  ROOT 
+    - name: download  ROOT (for ubuntu 16.04)
       run: |
         wget https://root.cern/download/root_v6.12.06.Linux-ubuntu16-x86_64-gcc5.4.tar.gz
         tar xzf root_v6.12.06.Linux-ubuntu16-x86_64-gcc5.4.tar.gz
-    - name: cmake
+      if: matrix.os == 'ubuntu-16.04'
+    - name: download  ROOT (for ubuntu-18.04)
+      run: |
+        wget http://sphinx.if.uj.edu.pl/framework/root-6-20-06-ubuntu18-jpet.tar.gz 
+        tar xzf root-6-20-06-ubuntu18-jpet.tar.gz
+      if: matrix.os == 'ubuntu-18.04'
+    - name: cmake (for ubuntu-16-04)
       run: |
         source root/bin/thisroot.sh
         mkdir build
         cd build
         cmake ..
-    - name: make
+      if: matrix.os == 'ubuntu-16.04'
+    - name: cmake (for ubuntu-18-04)
+      run: |
+        source root-system/bin/thisroot.sh
+        mkdir build
+        cd build
+        cmake ..
+      if: matrix.os == 'ubuntu-18.04'
+    - name: make (for ubuntu-16.04)
       run: |
         source root/bin/thisroot.sh
         cd build
         make all tests -j4
-    - name: run tests
+      if: matrix.os == 'ubuntu-16.04'
+    - name: make (for ubuntu-18.04)
+      run: |
+        source root-system/bin/thisroot.sh
+        cd build
+        make all tests -j4
+      if: matrix.os == 'ubuntu-18.04'
+    - name: run tests(for ubuntu-16.04)
       run: |
         source root/bin/thisroot.sh
         cd build
         source bin/thisframework.sh
         ctest -j6 -C Debug -T test --output-on-failure
+      if: matrix.os == 'ubuntu-16.04'
+    - name: run tests(for ubuntu-18.04)
+      run: |
+        source root-system/bin/thisroot.sh
+        cd build
+        source bin/thisframework.sh
+        ctest -j6 -C Debug -T test --output-on-failure
+      if: matrix.os == 'ubuntu-18.04'


### PR DESCRIPTION
It is just TEMPORARY version. It is artificially long because
ROOT directory name are not the same in the prepared binaries.
It should be changed.