### PR TITLE
Fix hld root path

### DIFF
--- a/src/Tasks/JPetUnpackTask/JPetUnpackTask.cpp
+++ b/src/Tasks/JPetUnpackTask/JPetUnpackTask.cpp
@@ -95,7 +95,7 @@ bool JPetUnpackTask::terminate(JPetParams& outParams)
     new_opts,
     JPetCommonTools::replaceDataTypeInFileName(getInputFile(fOptions), "hld")
   );
-  jpet_options_generator_tools::setOutputPath(new_opts, getOutputPath(fOptions);
+  jpet_options_generator_tools::setOutputPath(new_opts, getOutputPath(fOptions));
   outParams = JPetParams(new_opts, outParams.getParamManagerAsShared());
   INFO("UnpackTask finished.");
 

--- a/src/Tasks/JPetUnpackTask/JPetUnpackTask.cpp
+++ b/src/Tasks/JPetUnpackTask/JPetUnpackTask.cpp
@@ -95,6 +95,7 @@ bool JPetUnpackTask::terminate(JPetParams& outParams)
     new_opts,
     JPetCommonTools::replaceDataTypeInFileName(getInputFile(fOptions), "hld")
   );
+  jpet_options_generator_tools::setOutputPath(new_opts, getOutputPath(fOptions);
   outParams = JPetParams(new_opts, outParams.getParamManagerAsShared());
   INFO("UnpackTask finished.");
 


### PR DESCRIPTION
After PR #239 the UnpackTask writes the output hld.root file to the output files' location in case the '-o' option is used. However, the next task after UnpackTask still expected this file to be in the location of the originla .hld file, resulting in an error in case a combination of '-t hld' and '-o some_path' was used.