### PR TITLE
Read json setups generated by j-pet-geant4

### DIFF
--- a/src/ParametersTools/JPetParamManager/JPetParamManager.cpp
+++ b/src/ParametersTools/JPetParamManager/JPetParamManager.cpp
@@ -34,6 +34,15 @@ std::shared_ptr<JPetParamManager> JPetParamManager::generateParamManager(const s
       expectMissing.insert(ParamObjectType::kDataSource);
       expectMissing.insert(ParamObjectType::kDataModule);
     }
+    if (FileTypeChecker::getInputFileType(options) == FileTypeChecker::kMCGeant) {
+      expectMissing.insert(ParamObjectType::kPM);
+      expectMissing.insert(ParamObjectType::kPMCalib);
+      expectMissing.insert(ParamObjectType::kFEB);
+      expectMissing.insert(ParamObjectType::kTRB);
+      expectMissing.insert(ParamObjectType::kTOMBChannel);
+      expectMissing.insert(ParamObjectType::kDataSource);
+      expectMissing.insert(ParamObjectType::kDataModule);
+    }
     return std::make_shared<JPetParamManager>(
       new JPetParamGetterAscii(getLocalDB(options)), expectMissing
     );

--- a/tests/ParametersTools/JPetParamManager/JPetParamManagerTest.cpp
+++ b/tests/ParametersTools/JPetParamManager/JPetParamManagerTest.cpp
@@ -49,12 +49,40 @@ BOOST_AUTO_TEST_CASE(generateParamManagerForScopeCase)
   BOOST_REQUIRE(!paramMgr->getExpectMissing().empty());
   paramMgr->fillParameterBank(1);
   BOOST_REQUIRE_EQUAL(paramMgr->getParamBank().isDummy(), false);
+  BOOST_REQUIRE_EQUAL(paramMgr->getParamBank().getTOMBChannelsSize(), 0);
+  BOOST_REQUIRE_EQUAL(paramMgr->getParamBank().getTRBsSize(), 0);
+  BOOST_REQUIRE_EQUAL(paramMgr->getParamBank().getFEBsSize(), 0);
+  BOOST_REQUIRE_EQUAL(paramMgr->getParamBank().getDataSourcesSize(), 0);
+  BOOST_REQUIRE_EQUAL(paramMgr->getParamBank().getDataModulesSize(), 0);
   BOOST_REQUIRE_EQUAL(paramMgr->getParamBank().getScintillatorsSize(), 2);
   BOOST_REQUIRE_EQUAL(paramMgr->getParamBank().getPMsSize(), 4);
+  BOOST_REQUIRE_EQUAL(paramMgr->getParamBank().getBarrelSlotsSize(), 2);
+}
+
+BOOST_AUTO_TEST_CASE(generateParamManagerForMCGeantCase)
+{
+  std::map<std::string, boost::any> opts;
+  opts["inputFileType_std::string"] = std::string("mcGeant");
+  opts["localDB_std::string"] = std::string("unitTestData/JPetParamManagerTest/test_mcGeant_setup.json");
+  opts["runId_int"] = int(95);
+  std::shared_ptr<JPetParamManager> paramMgr = JPetParamManager::generateParamManager(opts);
+  BOOST_REQUIRE(paramMgr);
+  BOOST_REQUIRE(!paramMgr->isNullObject());
+  BOOST_REQUIRE(!paramMgr->getExpectMissing().empty());
+  paramMgr->fillParameterBank(95);
+  BOOST_REQUIRE_EQUAL(paramMgr->getParamBank().isDummy(), false);
+  // These object are absent in setups generated from Geant4 package
   BOOST_REQUIRE_EQUAL(paramMgr->getParamBank().getFEBsSize(), 0);
   BOOST_REQUIRE_EQUAL(paramMgr->getParamBank().getTRBsSize(), 0);
-  BOOST_REQUIRE_EQUAL(paramMgr->getParamBank().getBarrelSlotsSize(), 2);
+  BOOST_REQUIRE_EQUAL(paramMgr->getParamBank().getPMsSize(), 0);
   BOOST_REQUIRE_EQUAL(paramMgr->getParamBank().getTOMBChannelsSize(), 0);
+  BOOST_REQUIRE_EQUAL(paramMgr->getParamBank().getDataSourcesSize(), 0);
+  BOOST_REQUIRE_EQUAL(paramMgr->getParamBank().getDataModulesSize(), 0);
+  // other objects from generated setup
+  BOOST_REQUIRE_EQUAL(paramMgr->getParamBank().getFramesSize(), 1);
+  BOOST_REQUIRE_EQUAL(paramMgr->getParamBank().getLayersSize(), 4);
+  BOOST_REQUIRE_EQUAL(paramMgr->getParamBank().getBarrelSlotsSize(), 504);
+  BOOST_REQUIRE_EQUAL(paramMgr->getParamBank().getScintillatorsSize(), 504);
 }
 
 void checkContainersSize(const JPetParamBank& bank)


### PR DESCRIPTION
Json files with detector setups for MCGeantAnalysis do not have to include low level structures, as channels or photomultipliers, because they are not the part of simulations. They are set to "expected missing" in ParamManager for mcGeant file type. 
Also updating the test (new test file is on the server).