### PR TITLE
Adding -k option for selecting Unpacker for Barrel/Modular data

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 J-PET Framework
-Copyright 2010-2020 The J-PET Framework Authors. All rights reserved.
+Copyright 2010-2021 The J-PET Framework Authors. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/include/Options/JPetOptionValidator/JPetAdditionalValidators.h
+++ b/include/Options/JPetOptionValidator/JPetAdditionalValidators.h
@@ -1,5 +1,5 @@
 /**
- *  @copyright Copyright 2018 The J-PET Framework Authors. All rights reserved.
+ *  @copyright Copyright 2021 The J-PET Framework Authors. All rights reserved.
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may find a copy of the License in the LICENCE file.
@@ -18,6 +18,6 @@
 #include <boost/any.hpp>
 #include <string>
 
-bool additionalCheckIfRunIdIsOk(std::pair<std::string, boost::any> option);
+bool additionalCheckIfRunIDIsOk(std::pair<std::string, boost::any> option);
 
 #endif /* J_PET_ADDITIONAL_VALIDATORS_H */

--- a/include/Options/JPetOptionValidator/JPetOptionValidator.h
+++ b/include/Options/JPetOptionValidator/JPetOptionValidator.h
@@ -17,9 +17,9 @@
 #define JPETOPTIONVALIDATOR_H
 
 #include <boost/any.hpp>
+#include <map>
 #include <string>
 #include <vector>
-#include <map>
 
 /**
  * @brief Class to validate the user defined options.
@@ -30,17 +30,17 @@ public:
   JPetOptionValidator();
   static std::vector<std::string> getCorrectExtensionsForTheType(std::string fileType);
   bool areCorrectOptions(const std::map<std::string, boost::any>& optionsMap, std::vector<std::string>& namesOfOptionsToBeValidated);
-  static std::map<std::string, std::vector<bool(*)(std::pair <std::string, boost::any>)>> generateValidationMap();
-  void addValidatorFunction(const std::string& name, bool(*validatorFunction)(std::pair <std::string, boost::any>));
-  static bool isNumberBoundsInRangeValid(std::pair <std::string, boost::any> option);
-  static bool isRangeOfEventsValid(std::pair <std::string, boost::any> option);
-  static bool isCorrectFileType(std::pair <std::string, boost::any> option);
+  static std::map<std::string, std::vector<bool (*)(std::pair<std::string, boost::any>)>> generateValidationMap();
+  void addValidatorFunction(const std::string& name, bool (*validatorFunction)(std::pair<std::string, boost::any>));
+  static bool isNumberBoundsInRangeValid(std::pair<std::string, boost::any> option);
+  static bool isRangeOfEventsValid(std::pair<std::string, boost::any> option);
+  static bool isCorrectFileType(std::pair<std::string, boost::any> option);
   static bool isFileTypeMatchingExtensions(std::pair<std::string, boost::any> option);
-  static bool isRunIDValid(std::pair <std::string, boost::any> option);
-  static bool isDetectorValid(std::pair <std::string, boost::any> option);
-  static bool isLocalDBValid(std::pair <std::string, boost::any> option);
-  static bool areFilesValid(std::pair <std::string, boost::any> option);
-  static bool isOutputDirectoryValid(std::pair <std::string, boost::any> option);
+  static bool isRunIDValid(std::pair<std::string, boost::any> option);
+  static bool isDetectorValid(std::pair<std::string, boost::any> option);
+  static bool isLocalDBValid(std::pair<std::string, boost::any> option);
+  static bool areFilesValid(std::pair<std::string, boost::any> option);
+  static bool isOutputDirectoryValid(std::pair<std::string, boost::any> option);
   static std::map<std::string, boost::any> addNonStandardValidators(const std::map<std::string, boost::any>& optionsMap);
 
   class ManyOptionsWrapper
@@ -48,12 +48,13 @@ public:
   public:
     ManyOptionsWrapper(std::initializer_list<boost::any>);
     std::vector<boost::any> getOptionsVector();
+
   private:
     std::vector<boost::any> optionsVector;
   };
 
 private:
-  std::map<std::string, std::vector<bool(*)(std::pair <std::string, boost::any>)>> fValidatorMap;
+  std::map<std::string, std::vector<bool (*)(std::pair<std::string, boost::any>)>> fValidatorMap;
   static void addFileTypeAndNameValidator(std::map<std::string, boost::any>&);
 };
 #endif /* !JPETOPTIONVALIDATOR_H */

--- a/include/Options/JPetOptionValidator/JPetOptionValidator.h
+++ b/include/Options/JPetOptionValidator/JPetOptionValidator.h
@@ -1,5 +1,5 @@
 /**
- *  @copyright Copyright 2018 The J-PET Framework Authors. All rights reserved.
+ *  @copyright Copyright 2021 The J-PET Framework Authors. All rights reserved.
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may find a copy of the License in the LICENCE file.
@@ -36,7 +36,8 @@ public:
   static bool isRangeOfEventsValid(std::pair <std::string, boost::any> option);
   static bool isCorrectFileType(std::pair <std::string, boost::any> option);
   static bool isFileTypeMatchingExtensions(std::pair<std::string, boost::any> option);
-  static bool isRunIdValid(std::pair <std::string, boost::any> option);
+  static bool isRunIDValid(std::pair <std::string, boost::any> option);
+  static bool isDetectorValid(std::pair <std::string, boost::any> option);
   static bool isLocalDBValid(std::pair <std::string, boost::any> option);
   static bool areFilesValid(std::pair <std::string, boost::any> option);
   static bool isOutputDirectoryValid(std::pair <std::string, boost::any> option);
@@ -52,7 +53,7 @@ public:
   };
 
 private:
-  std::map<std::string, std::vector<bool(*)(std::pair <std::string, boost::any>)> > fValidatorMap;
+  std::map<std::string, std::vector<bool(*)(std::pair <std::string, boost::any>)>> fValidatorMap;
   static void addFileTypeAndNameValidator(std::map<std::string, boost::any>&);
 };
 #endif /* !JPETOPTIONVALIDATOR_H */

--- a/include/Options/JPetOptionsGenerator/JPetAdditionalTransformations.h
+++ b/include/Options/JPetOptionsGenerator/JPetAdditionalTransformations.h
@@ -18,4 +18,4 @@
 
 using boost::any_cast;
 
-std::pair<std::string, boost::any> setAdditionalRunIdInTheMap(boost::any option);
+std::pair<std::string, boost::any> setAdditionalRunIDInTheMap(boost::any option);

--- a/include/Options/JPetOptionsTools/JPetOptionsTools.h
+++ b/include/Options/JPetOptionsTools/JPetOptionsTools.h
@@ -63,6 +63,7 @@ void printOptions(const OptsStrAny& opts);
 void printOptionsToLog(const OptsStrAny& opts, const std::string& firstLine);
 bool createConfigFileFromOptions(const OptsStrStr& options, const std::string& outFile = "");
 OptsStrAny createOptionsFromConfigFile(const std::string& inFile);
+void handleErrorMessage(const std::string& errorMessage, const std::out_of_range& outOfRangeException);
 
 class FileTypeChecker
 {
@@ -82,7 +83,6 @@ public:
   static FileType getOutputFileType(const OptsStrAny& opts);
 
 private:
-  static void handleErrorMessage(const std::string& errorMessage, const std::out_of_range& outOfRangeException);
   static FileType getFileType(const OptsStrAny& opts, const std::string& fileType);
   FileTypeChecker();
   FileTypeChecker(const FileTypeChecker&);

--- a/include/Options/JPetOptionsTools/JPetOptionsTools.h
+++ b/include/Options/JPetOptionsTools/JPetOptionsTools.h
@@ -18,8 +18,8 @@
 
 #include "JPetOptionsTools/JPetOptionsTransformators.h"
 #include <boost/any.hpp>
-#include <vector>
 #include <map>
+#include <vector>
 
 /**
  * @brief Set of helper methods to operate on options.
@@ -29,78 +29,78 @@
  */
 namespace jpet_options_tools
 {
-  using OptsStrAny = std::map<std::string, boost::any>;
-  using OptsStrStr = std::map<std::string, std::string>;
-  bool isOptionSet(const OptsStrAny& opts, const std::string& optionName);
-  boost::any getOptionValue(const OptsStrAny& opts, const std::string& optionName);
-  bool getOptionAsBool(const OptsStrAny& opts, const std::string& optionName);
-  int getOptionAsInt(const OptsStrAny& opts, const std::string& optionName);
-  float getOptionAsFloat(const OptsStrAny& opts, const std::string& optionName);
-  double getOptionAsDouble(const OptsStrAny& opts, const std::string& optionName);
-  std::string getOptionAsString(const OptsStrAny& opts, const std::string& optionName);
-  std::vector<std::string> getOptionAsVectorOfStrings(const OptsStrAny& opts, const std::string& optionName);
-  std::vector<int> getOptionAsVectorOfInts(const OptsStrAny& opts, const std::string& optionName);
-  std::vector<double> getOptionAsVectorOfDoubles(const OptsStrAny& opts, const std::string& optionName);
-  std::vector<std::string> getInputFiles(const OptsStrAny& opts);
-  std::string getInputFile(const OptsStrAny& opts);
-  std::string getScopeConfigFile(const OptsStrAny& opts);
-  std::string getScopeInputDirectory(const OptsStrAny& opts);
-  std::string getOutputFile(const OptsStrAny& opts);
-  std::string getOutputPath(const OptsStrAny& opts);
-  long long getFirstEvent(const OptsStrAny& opts);
-  long long getLastEvent(const OptsStrAny& opts);
-  long long getTotalEvents(const OptsStrAny& opts);
-  int getRunNumber(const OptsStrAny& opts);
-  bool isProgressBar(const OptsStrAny& opts);
-  bool isDirectProcessing(const OptsStrAny& opts);
-  bool isLocalDB(const OptsStrAny& opts);
-  std::string getLocalDB(const OptsStrAny& opts);
-  bool isLocalDBCreate(const OptsStrAny& opts);
-  std::string getLocalDBCreate(const OptsStrAny& opts);
-  std::string getUnpackerConfigFile(const OptsStrAny& opts);
-  std::string getConfigFileName(const OptsStrAny& optsMap);
-  void printOptions(const OptsStrAny& opts);
-  void printOptionsToLog(const OptsStrAny& opts, const std::string& firstLine);
-  bool createConfigFileFromOptions(const OptsStrStr& options, const std::string& outFile = "");
-  OptsStrAny createOptionsFromConfigFile(const std::string& inFile);
+using OptsStrAny = std::map<std::string, boost::any>;
+using OptsStrStr = std::map<std::string, std::string>;
+bool isOptionSet(const OptsStrAny& opts, const std::string& optionName);
+boost::any getOptionValue(const OptsStrAny& opts, const std::string& optionName);
+bool getOptionAsBool(const OptsStrAny& opts, const std::string& optionName);
+int getOptionAsInt(const OptsStrAny& opts, const std::string& optionName);
+float getOptionAsFloat(const OptsStrAny& opts, const std::string& optionName);
+double getOptionAsDouble(const OptsStrAny& opts, const std::string& optionName);
+std::string getOptionAsString(const OptsStrAny& opts, const std::string& optionName);
+std::vector<std::string> getOptionAsVectorOfStrings(const OptsStrAny& opts, const std::string& optionName);
+std::vector<int> getOptionAsVectorOfInts(const OptsStrAny& opts, const std::string& optionName);
+std::vector<double> getOptionAsVectorOfDoubles(const OptsStrAny& opts, const std::string& optionName);
+std::vector<std::string> getInputFiles(const OptsStrAny& opts);
+std::string getInputFile(const OptsStrAny& opts);
+std::string getScopeConfigFile(const OptsStrAny& opts);
+std::string getScopeInputDirectory(const OptsStrAny& opts);
+std::string getOutputFile(const OptsStrAny& opts);
+std::string getOutputPath(const OptsStrAny& opts);
+long long getFirstEvent(const OptsStrAny& opts);
+long long getLastEvent(const OptsStrAny& opts);
+long long getTotalEvents(const OptsStrAny& opts);
+int getRunNumber(const OptsStrAny& opts);
+bool isProgressBar(const OptsStrAny& opts);
+bool isDirectProcessing(const OptsStrAny& opts);
+bool isLocalDB(const OptsStrAny& opts);
+std::string getLocalDB(const OptsStrAny& opts);
+bool isLocalDBCreate(const OptsStrAny& opts);
+std::string getLocalDBCreate(const OptsStrAny& opts);
+std::string getUnpackerConfigFile(const OptsStrAny& opts);
+std::string getConfigFileName(const OptsStrAny& optsMap);
+void printOptions(const OptsStrAny& opts);
+void printOptionsToLog(const OptsStrAny& opts, const std::string& firstLine);
+bool createConfigFileFromOptions(const OptsStrStr& options, const std::string& outFile = "");
+OptsStrAny createOptionsFromConfigFile(const std::string& inFile);
 
-  class FileTypeChecker
+class FileTypeChecker
+{
+public:
+  enum FileType
   {
-  public:
-    enum FileType
-    {
-      kNoType,
-      kRoot,
-      kScope,
-      kHld,
-      kHldRoot,
-      kZip,
-      kMCGeant,
-      kUndefinedFileType
-    };
-    static FileType getInputFileType(const OptsStrAny& opts);
-    static FileType getOutputFileType(const OptsStrAny& opts);
-
-  private:
-    static void handleErrorMessage(const std::string& errorMessage, const std::out_of_range& outOfRangeException);
-    static FileType getFileType(const OptsStrAny& opts, const std::string& fileType);
-    FileTypeChecker();
-    FileTypeChecker(const FileTypeChecker&);
-    void operator=(const FileTypeChecker&);
-    static std::map<std::string, FileType> fStringToFileType;
+    kNoType,
+    kRoot,
+    kScope,
+    kHld,
+    kHldRoot,
+    kZip,
+    kMCGeant,
+    kUndefinedFileType
   };
+  static FileType getInputFileType(const OptsStrAny& opts);
+  static FileType getOutputFileType(const OptsStrAny& opts);
 
-  class DetectorTypeChecker
+private:
+  static void handleErrorMessage(const std::string& errorMessage, const std::out_of_range& outOfRangeException);
+  static FileType getFileType(const OptsStrAny& opts, const std::string& fileType);
+  FileTypeChecker();
+  FileTypeChecker(const FileTypeChecker&);
+  void operator=(const FileTypeChecker&);
+  static std::map<std::string, FileType> fStringToFileType;
+};
+
+class DetectorTypeChecker
+{
+public:
+  enum DetectorType
   {
-  public:
-    enum DetectorType
-    {
-      kBarrel,
-      kModular
-    };
-    static DetectorType getDetectorType(const OptsStrAny& opts);
-    static std::map<std::string, DetectorType> fStringToDetectorType;
+    kBarrel,
+    kModular
   };
+  static DetectorType getDetectorType(const OptsStrAny& opts);
+  static std::map<std::string, DetectorType> fStringToDetectorType;
+};
 
-}; // namespace jpet_options_tools
+};     // namespace jpet_options_tools
 #endif /* !JPETOPTIONSTOOLS_H */

--- a/include/Options/JPetOptionsTools/JPetOptionsTools.h
+++ b/include/Options/JPetOptionsTools/JPetOptionsTools.h
@@ -65,42 +65,35 @@ bool createConfigFileFromOptions(const OptsStrStr& options, const std::string& o
 OptsStrAny createOptionsFromConfigFile(const std::string& inFile);
 void handleErrorMessage(const std::string& errorMessage, const std::out_of_range& outOfRangeException);
 
-class FileTypeChecker
+namespace file_type_checker
 {
-public:
-  enum FileType
-  {
-    kNoType,
-    kRoot,
-    kScope,
-    kHld,
-    kHldRoot,
-    kZip,
-    kMCGeant,
-    kUndefinedFileType
-  };
-  static FileType getInputFileType(const OptsStrAny& opts);
-  static FileType getOutputFileType(const OptsStrAny& opts);
-
-private:
-  static FileType getFileType(const OptsStrAny& opts, const std::string& fileType);
-  FileTypeChecker();
-  FileTypeChecker(const FileTypeChecker&);
-  void operator=(const FileTypeChecker&);
-  static std::map<std::string, FileType> fStringToFileType;
-};
-
-class DetectorTypeChecker
+enum FileType
 {
-public:
-  enum DetectorType
-  {
-    kBarrel,
-    kModular
-  };
-  static DetectorType getDetectorType(const OptsStrAny& opts);
-  static std::map<std::string, DetectorType> fStringToDetectorType;
+  kNoType,
+  kRoot,
+  kScope,
+  kHld,
+  kHldRoot,
+  kZip,
+  kMCGeant,
+  kUndefinedFileType
 };
+FileType getFileType(const OptsStrAny& opts, const std::string& fileType);
+FileType getInputFileType(const OptsStrAny& opts);
+FileType getOutputFileType(const OptsStrAny& opts);
+} // namespace file_type_checker
 
-};     // namespace jpet_options_tools
+namespace detector_type_checker
+{
+enum DetectorType
+{
+  kBarrel,
+  kModular
+};
+DetectorType getDetectorType(const OptsStrAny& opts);
+
+} // namespace detector_type_checker
+
+}; // namespace jpet_options_tools
+
 #endif /* !JPETOPTIONSTOOLS_H */

--- a/include/Options/JPetOptionsTools/JPetOptionsTools.h
+++ b/include/Options/JPetOptionsTools/JPetOptionsTools.h
@@ -1,5 +1,5 @@
 /**
- *  @copyright Copyright 2018 The J-PET Framework Authors. All rights reserved.
+ *  @copyright Copyright 2021 The J-PET Framework Authors. All rights reserved.
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may find a copy of the License in the LICENCE file.
@@ -16,10 +16,10 @@
 #ifndef JPETOPTIONSTOOLS_H
 #define JPETOPTIONSTOOLS_H
 
-#include "./JPetOptionsTools/JPetOptionsTransformators.h"
+#include "JPetOptionsTools/JPetOptionsTransformators.h"
 #include <boost/any.hpp>
-#include <map>
 #include <vector>
+#include <map>
 
 /**
  * @brief Set of helper methods to operate on options.
@@ -29,66 +29,78 @@
  */
 namespace jpet_options_tools
 {
-using OptsStrAny = std::map<std::string, boost::any>;
-using OptsStrStr = std::map<std::string, std::string>;
-bool isOptionSet(const OptsStrAny& opts, const std::string& optionName);
-boost::any getOptionValue(const OptsStrAny& opts, const std::string& optionName);
-std::string getOptionAsString(const OptsStrAny& opts, const std::string& optionName);
-int getOptionAsInt(const OptsStrAny& opts, const std::string& optionName);
-float getOptionAsFloat(const OptsStrAny& opts, const std::string& optionName);
-double getOptionAsDouble(const OptsStrAny& opts, const std::string& optionName);
-std::vector<std::string> getOptionAsVectorOfStrings(const OptsStrAny& opts, const std::string& optionName);
-std::vector<int> getOptionAsVectorOfInts(const OptsStrAny& opts, const std::string& optionName);
-std::vector<double> getOptionAsVectorOfDoubles(const OptsStrAny& opts, const std::string& optionName);
-bool getOptionAsBool(const OptsStrAny& opts, const std::string& optionName);
-std::vector<std::string> getInputFiles(const OptsStrAny& opts);
-std::string getInputFile(const OptsStrAny& opts);
-std::string getScopeConfigFile(const OptsStrAny& opts);
-std::string getScopeInputDirectory(const OptsStrAny& opts);
-std::string getOutputFile(const OptsStrAny& opts);
-std::string getOutputPath(const OptsStrAny& opts);
-long long getFirstEvent(const OptsStrAny& opts);
-long long getLastEvent(const OptsStrAny& opts);
-long long getTotalEvents(const OptsStrAny& opts);
-int getRunNumber(const OptsStrAny& opts);
-bool isProgressBar(const OptsStrAny& opts);
-bool isDirectProcessing(const OptsStrAny& opts);
-bool isLocalDB(const OptsStrAny& opts);
-std::string getLocalDB(const OptsStrAny& opts);
-bool isLocalDBCreate(const OptsStrAny& opts);
-std::string getLocalDBCreate(const OptsStrAny& opts);
-std::string getUnpackerConfigFile(const OptsStrAny& opts);
-std::string getConfigFileName(const OptsStrAny& optsMap);
-void printOptions(const OptsStrAny& opts);
-void printOptionsToLog(const OptsStrAny& opts, const std::string& firstLine);
-bool createConfigFileFromOptions(const OptsStrStr& options, const std::string& outFile = "");
-OptsStrAny createOptionsFromConfigFile(const std::string& inFile);
+  using OptsStrAny = std::map<std::string, boost::any>;
+  using OptsStrStr = std::map<std::string, std::string>;
+  bool isOptionSet(const OptsStrAny& opts, const std::string& optionName);
+  boost::any getOptionValue(const OptsStrAny& opts, const std::string& optionName);
+  bool getOptionAsBool(const OptsStrAny& opts, const std::string& optionName);
+  int getOptionAsInt(const OptsStrAny& opts, const std::string& optionName);
+  float getOptionAsFloat(const OptsStrAny& opts, const std::string& optionName);
+  double getOptionAsDouble(const OptsStrAny& opts, const std::string& optionName);
+  std::string getOptionAsString(const OptsStrAny& opts, const std::string& optionName);
+  std::vector<std::string> getOptionAsVectorOfStrings(const OptsStrAny& opts, const std::string& optionName);
+  std::vector<int> getOptionAsVectorOfInts(const OptsStrAny& opts, const std::string& optionName);
+  std::vector<double> getOptionAsVectorOfDoubles(const OptsStrAny& opts, const std::string& optionName);
+  std::vector<std::string> getInputFiles(const OptsStrAny& opts);
+  std::string getInputFile(const OptsStrAny& opts);
+  std::string getScopeConfigFile(const OptsStrAny& opts);
+  std::string getScopeInputDirectory(const OptsStrAny& opts);
+  std::string getOutputFile(const OptsStrAny& opts);
+  std::string getOutputPath(const OptsStrAny& opts);
+  long long getFirstEvent(const OptsStrAny& opts);
+  long long getLastEvent(const OptsStrAny& opts);
+  long long getTotalEvents(const OptsStrAny& opts);
+  int getRunNumber(const OptsStrAny& opts);
+  bool isProgressBar(const OptsStrAny& opts);
+  bool isDirectProcessing(const OptsStrAny& opts);
+  bool isLocalDB(const OptsStrAny& opts);
+  std::string getLocalDB(const OptsStrAny& opts);
+  bool isLocalDBCreate(const OptsStrAny& opts);
+  std::string getLocalDBCreate(const OptsStrAny& opts);
+  std::string getUnpackerConfigFile(const OptsStrAny& opts);
+  std::string getConfigFileName(const OptsStrAny& optsMap);
+  void printOptions(const OptsStrAny& opts);
+  void printOptionsToLog(const OptsStrAny& opts, const std::string& firstLine);
+  bool createConfigFileFromOptions(const OptsStrStr& options, const std::string& outFile = "");
+  OptsStrAny createOptionsFromConfigFile(const std::string& inFile);
 
-class FileTypeChecker
-{
-public:
-  enum FileType
+  class FileTypeChecker
   {
-    kNoType,
-    kRoot,
-    kScope,
-    kHld,
-    kHldRoot,
-    kZip,
-    kMCGeant,
-    kUndefinedFileType
+  public:
+    enum FileType
+    {
+      kNoType,
+      kRoot,
+      kScope,
+      kHld,
+      kHldRoot,
+      kZip,
+      kMCGeant,
+      kUndefinedFileType
+    };
+    static FileType getInputFileType(const OptsStrAny& opts);
+    static FileType getOutputFileType(const OptsStrAny& opts);
+
+  private:
+    static void handleErrorMessage(const std::string& errorMessage, const std::out_of_range& outOfRangeException);
+    static FileType getFileType(const OptsStrAny& opts, const std::string& fileType);
+    FileTypeChecker();
+    FileTypeChecker(const FileTypeChecker&);
+    void operator=(const FileTypeChecker&);
+    static std::map<std::string, FileType> fStringToFileType;
   };
-  static FileType getInputFileType(const OptsStrAny& opts);
-  static FileType getOutputFileType(const OptsStrAny& opts);
 
-private:
-  static void handleErrorMessage(const std::string& errorMessage, const std::out_of_range& outOfRangeException);
-  static FileType getFileType(const OptsStrAny& opts, const std::string& fileType);
-  FileTypeChecker();
-  FileTypeChecker(const FileTypeChecker&);
-  void operator=(const FileTypeChecker&);
-  static std::map<std::string, FileType> fStringToFileType;
-};
+  class DetectorTypeChecker
+  {
+  public:
+    enum DetectorType
+    {
+      kBarrel,
+      kModular
+    };
+    static DetectorType getDetectorType(const OptsStrAny& opts);
+    static std::map<std::string, DetectorType> fStringToDetectorType;
+  };
 
-} // namespace jpet_options_tools
+}; // namespace jpet_options_tools
 #endif /* !JPETOPTIONSTOOLS_H */

--- a/include/Tasks/JPetUnpackTask/JPetUnpackTask.h
+++ b/include/Tasks/JPetUnpackTask/JPetUnpackTask.h
@@ -38,17 +38,13 @@ protected:
   const std::string kTDCnonlinearityCalibKey = "Unpacker_TDCnonlinearityCalib_std::string";
   const std::string kTOTOffsetCalibKey = "Unpacker_TOToffsetCalib_std::string";
   const std::string kEndpointsParamKey = "Unpacker_EndpointsNumber_int";
-  std::string fTDCnonlinearityCalibFile = std::string("");
-  std::string fTOTOffsetCalibFile = std::string("");
-  std::string fXMLConfFile = std::string("");
-  std::string fInputFile = std::string("");
-  std::string fInputFilePath = std::string("");
-  std::string fOutputFilePath = std::string("");
-
+  std::string fTDCnonlinearityCalibFile;
+  std::string fTOTOffsetCalibFile;
+  std::string fXMLConfFile;
+  std::string fInputFile;
+  std::string fInputFilePath;
+  std::string fOutputFilePath;
   int fEventsToProcess = 100000000;
-
-  Unpacker2D* fUnpacker2D = nullptr;
-  Unpacker2* fUnpacker2 = nullptr;
   OptsStrAny fOptions;
 };
 

--- a/include/Tasks/JPetUnpackTask/JPetUnpackTask.h
+++ b/include/Tasks/JPetUnpackTask/JPetUnpackTask.h
@@ -1,5 +1,5 @@
 /**
- *  @copyright Copyright 2019 The J-PET Framework Authors. All rights reserved.
+ *  @copyright Copyright 2021 The J-PET Framework Authors. All rights reserved.
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may find a copy of the License in the LICENCE file.
@@ -17,9 +17,11 @@
 #define JPETUNPACKTASK_H
 
 #include "JPetTask/JPetTask.h"
-#include <boost/any.hpp>
+#include "Unpacker2D.h"
 #include "Unpacker2.h"
-#include <map>
+
+class Unpacker2D;
+class Unpacker2;
 
 class JPetUnpackTask: public JPetTask
 {
@@ -38,15 +40,21 @@ public:
 protected:
   const std::string kTDCnonlinearityCalibKey = "Unpacker_TDCnonlinearityCalib_std::string";
   const std::string kTOTOffsetCalibKey = "Unpacker_TOToffsetCalib_std::string";
-  std::string fOutputFilePath = std::string("");
-  std::string fInputFilePath = std::string("");
+  const std::string kEndpointsParamKey = "Unpacker_EndpointsNumber_int";
+  std::string fTDCnonlinearityCalibFile;
+  std::string fTOTOffsetCalibFile;
+  std::string fXMLConfFile;
+
   std::string fInputFile = std::string("");
-  std::string fTDCnonlinearityCalibFile = std::string("");
-  std::string fTOTOffsetCalibFile = std::string("") = std::string("");
-  std::string fXMLConfFile = std::string("");
-  int fEventsToProcess = 1000000000;
+  std::string fInputFilePath = std::string("");
+  std::string fOutputFilePath = std::string("");
+
+  int fEventsToProcess = 100000000;
+
+  Unpacker2D* fUnpacker2D = nullptr;
   Unpacker2* fUnpacker2 = nullptr;
   OptsStrAny fOptions;
+
 };
 
 #endif /* !JPETUNPACKTASK_H */

--- a/include/Tasks/JPetUnpackTask/JPetUnpackTask.h
+++ b/include/Tasks/JPetUnpackTask/JPetUnpackTask.h
@@ -17,13 +17,13 @@
 #define JPETUNPACKTASK_H
 
 #include "JPetTask/JPetTask.h"
-#include "Unpacker2D.h"
 #include "Unpacker2.h"
+#include "Unpacker2D.h"
 
 class Unpacker2D;
 class Unpacker2;
 
-class JPetUnpackTask: public JPetTask
+class JPetUnpackTask : public JPetTask
 {
 public:
   using OptsStrAny = std::map<std::string, boost::any>;
@@ -31,20 +31,16 @@ public:
   bool init(const JPetParams& inOptions) override;
   bool run(const JPetDataInterface& inData) override;
   bool terminate(JPetParams& outOptions) override;
-  static bool validateFiles(
-    std::string fileNameWithPath, std::string xmlConfig,
-    std::string totCalib, bool totCalibSet,
-    std::string tdcCalib, bool tdcCalibSet
-  );
+  static bool validateFiles(std::string fileNameWithPath, std::string xmlConfig, std::string totCalib, bool totCalibSet, std::string tdcCalib,
+                            bool tdcCalibSet);
 
 protected:
   const std::string kTDCnonlinearityCalibKey = "Unpacker_TDCnonlinearityCalib_std::string";
   const std::string kTOTOffsetCalibKey = "Unpacker_TOToffsetCalib_std::string";
   const std::string kEndpointsParamKey = "Unpacker_EndpointsNumber_int";
-  std::string fTDCnonlinearityCalibFile;
-  std::string fTOTOffsetCalibFile;
-  std::string fXMLConfFile;
-
+  std::string fTDCnonlinearityCalibFile = std::string("");
+  std::string fTOTOffsetCalibFile = std::string("");
+  std::string fXMLConfFile = std::string("");
   std::string fInputFile = std::string("");
   std::string fInputFilePath = std::string("");
   std::string fOutputFilePath = std::string("");
@@ -54,7 +50,6 @@ protected:
   Unpacker2D* fUnpacker2D = nullptr;
   Unpacker2* fUnpacker2 = nullptr;
   OptsStrAny fOptions;
-
 };
 
 #endif /* !JPETUNPACKTASK_H */

--- a/src/Core/JPetCmdParser/JPetCmdParser.cpp
+++ b/src/Core/JPetCmdParser/JPetCmdParser.cpp
@@ -1,5 +1,5 @@
 /**
- *  @copyright Copyright 2018 The J-PET Framework Authors. All rights reserved.
+ *  @copyright Copyright 2021 The J-PET Framework Authors. All rights reserved.
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may find a copy of the License in the LICENCE file.
@@ -23,20 +23,21 @@
  */
 JPetCmdParser::JPetCmdParser() : fOptionsDescriptions("Allowed options")
 {
-  fOptionsDescriptions.add_options()
-  ("help,h", "Displays this help message.")
-  ("type,t", po::value<std::string>()->required(), "Type of file: hld, zip, mcGeant, root or scope.")
-  ("file,f", po::value<std::vector<std::string>>()->required()->multitoken(), "File(s) to open.")
-  ("outputPath,o", po::value<std::string>(), "Location to which the outputFiles will be saved.")
-  ("range,r", po::value<std::vector<int>>()->multitoken()->default_value({-1, -1}, ""), "Range of events to process e.g. -r 1 1000 .")
-  ("unpackerConfigFile,p", po::value<std::string>(), "xml file with TRB settings used by the unpacker program.")
-  ("unpackerCalibFile,c", po::value<std::string>(), "ROOT file with TRB calibration used by the unpacker program.")
-  ("runID,i", po::value<int>(), "Run ID.")
-  ("detector,k", po::value<std::string>()->default_value("barrel"), "Detector type: barrel (default) or modular")
-  ("progressBar,b", po::bool_switch()->default_value(false), "Progress bar.")
-  ("localDB,l", po::value<std::string>(), "The file to use as the parameter database.")
-  ("localDBCreate,L", po::value<std::string>(), "File name to which the parameter database will be saved.")("userCfg,u", po::value<std::string>(), "Json file with optional user parameters.")
-  ("directProcessing,d", po::bool_switch(), "Process directly to the output of last module without creating intermediate files (faster and less storage needed).");
+  fOptionsDescriptions.add_options()("help,h", "Displays this help message.")("type,t", po::value<std::string>()->required(),
+                                                                              "Type of file: hld, zip, mcGeant, root or scope.")(
+      "file,f", po::value<std::vector<std::string>>()->required()->multitoken(),
+      "File(s) to open.")("outputPath,o", po::value<std::string>(), "Location to which the outputFiles will be saved.")(
+      "range,r", po::value<std::vector<int>>()->multitoken()->default_value({-1, -1}, ""), "Range of events to process e.g. -r 1 1000 .")(
+      "unpackerConfigFile,p", po::value<std::string>(), "xml file with TRB settings used by the unpacker program.")(
+      "unpackerCalibFile,c", po::value<std::string>(), "ROOT file with TRB calibration used by the unpacker program.")(
+      "runID,i", po::value<int>(), "Run ID.")("detector,k", po::value<std::string>()->default_value("barrel"),
+                                              "Detector type: barrel (default) or modular")(
+      "progressBar,b", po::bool_switch()->default_value(false), "Progress bar.")("localDB,l", po::value<std::string>(),
+                                                                                 "The file to use as the parameter database.")(
+      "localDBCreate,L", po::value<std::string>(),
+      "File name to which the parameter database will be saved.")("userCfg,u", po::value<std::string>(), "Json file with optional user parameters.")(
+      "directProcessing,d", po::bool_switch(),
+      "Process directly to the output of last module without creating intermediate files (faster and less storage needed).");
 }
 
 /**

--- a/src/Core/JPetCmdParser/JPetCmdParser.cpp
+++ b/src/Core/JPetCmdParser/JPetCmdParser.cpp
@@ -23,18 +23,20 @@
  */
 JPetCmdParser::JPetCmdParser() : fOptionsDescriptions("Allowed options")
 {
-  fOptionsDescriptions.add_options()("help,h", "Displays this help message.")("type,t", po::value<std::string>()->required(),
-                                                                              "Type of file: hld, zip, mcGeant, root or scope.")(
-      "file,f", po::value<std::vector<std::string>>()->required()->multitoken(),
-      "File(s) to open.")("outputPath,o", po::value<std::string>(), "Location to which the outputFiles will be saved.")(
-      "range,r", po::value<std::vector<int>>()->multitoken()->default_value({-1, -1}, ""), "Range of events to process e.g. -r 1 1000 .")(
-      "unpackerConfigFile,p", po::value<std::string>(), "xml file with TRB settings used by the unpacker program.")(
-      "unpackerCalibFile,c", po::value<std::string>(), "ROOT file with TRB calibration used by the unpacker program.")(
-      "runId,i", po::value<int>(), "Run id.")("progressBar,b", po::bool_switch()->default_value(false),
-                                              "Progress bar.")("localDB,l", po::value<std::string>(), "The file to use as the parameter database.")(
-      "localDBCreate,L", po::value<std::string>(),
-      "File name to which the parameter database will be saved.")("userCfg,u", po::value<std::string>(), "Json file with optional user parameters.")(
-      "directProcessing,d", po::bool_switch(), "Process directly to the output of last module without creating intermediate files (faster and less storage needed).");
+  fOptionsDescriptions.add_options()
+  ("help,h", "Displays this help message.")
+  ("type,t", po::value<std::string>()->required(), "Type of file: hld, zip, mcGeant, root or scope.")
+  ("file,f", po::value<std::vector<std::string>>()->required()->multitoken(), "File(s) to open.")
+  ("outputPath,o", po::value<std::string>(), "Location to which the outputFiles will be saved.")
+  ("range,r", po::value<std::vector<int>>()->multitoken()->default_value({-1, -1}, ""), "Range of events to process e.g. -r 1 1000 .")
+  ("unpackerConfigFile,p", po::value<std::string>(), "xml file with TRB settings used by the unpacker program.")
+  ("unpackerCalibFile,c", po::value<std::string>(), "ROOT file with TRB calibration used by the unpacker program.")
+  ("runID,i", po::value<int>(), "Run ID.")
+  ("detector,k", po::value<std::string>()->default_value("barrel"), "Detector type: barrel (default) or modular")
+  ("progressBar,b", po::bool_switch()->default_value(false), "Progress bar.")
+  ("localDB,l", po::value<std::string>(), "The file to use as the parameter database.")
+  ("localDBCreate,L", po::value<std::string>(), "File name to which the parameter database will be saved.")("userCfg,u", po::value<std::string>(), "Json file with optional user parameters.")
+  ("directProcessing,d", po::bool_switch(), "Process directly to the output of last module without creating intermediate files (faster and less storage needed).");
 }
 
 /**

--- a/src/Core/JPetTaskFactory/JPetTaskFactory.cpp
+++ b/src/Core/JPetTaskFactory/JPetTaskFactory.cpp
@@ -1,5 +1,5 @@
 /**
- *  @copyright Copyright 2019 The J-PET Framework Authors. All rights reserved.
+ *  @copyright Copyright 2021 The J-PET Framework Authors. All rights reserved.
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may find a copy of the License in the LICENCE file.
@@ -32,9 +32,8 @@ namespace jpet_task_factory
 
 JPetTaskFactory::JPetTaskFactory(){};
 
-std::vector<TaskGenerator> JPetTaskFactory::createTaskGeneratorChain(
-  const std::map<std::string, boost::any>& options
-) const {
+std::vector<TaskGenerator> JPetTaskFactory::createTaskGeneratorChain(const std::map<std::string, boost::any>& options) const
+{
 
   if (jpet_options_tools::isDirectProcessing(options))
   {
@@ -44,13 +43,14 @@ std::vector<TaskGenerator> JPetTaskFactory::createTaskGeneratorChain(
   return generateTaskGeneratorChain(fTasksToUse, fTasksDictionary, options);
 }
 
-bool JPetTaskFactory::addTaskInfo(
-  const std::string& name, const std::string& inputFileType,
-  const std::string& outputFileType, int numIter
-) {
-  if (fTasksDictionary.find(name) != fTasksDictionary.end()) {
+bool JPetTaskFactory::addTaskInfo(const std::string& name, const std::string& inputFileType, const std::string& outputFileType, int numIter)
+{
+  if (fTasksDictionary.find(name) != fTasksDictionary.end())
+  {
     fTasksToUse.push_back(TaskInfo(name, inputFileType, outputFileType, numIter));
-  } else {
+  }
+  else
+  {
     ERROR("Task with the name " + std::string(name) + " is not registered!");
     return false;
   }
@@ -59,10 +59,7 @@ bool JPetTaskFactory::addTaskInfo(
 
 std::vector<TaskInfo> JPetTaskFactory::getTasksToUse() const { return fTasksToUse; }
 
-std::map<std::string, TaskGenerator> JPetTaskFactory::getTasksDictionary() const
-{
-  return fTasksDictionary;
-}
+std::map<std::string, TaskGenerator> JPetTaskFactory::getTasksDictionary() const { return fTasksDictionary; }
 
 void JPetTaskFactory::clear()
 {
@@ -70,24 +67,22 @@ void JPetTaskFactory::clear()
   fTasksToUse.clear();
 }
 
-TaskGeneratorChain generateTaskGeneratorChain(
-  const std::vector<TaskInfo>& taskInfoVect,
-  const std::map<std::string, TaskGenerator>& generatorsMap,
-  const std::map<std::string, boost::any>& options
-) {
+TaskGeneratorChain generateTaskGeneratorChain(const std::vector<TaskInfo>& taskInfoVect, const std::map<std::string, TaskGenerator>& generatorsMap,
+                                              const std::map<std::string, boost::any>& options)
+{
   TaskGeneratorChain chain;
   addDefaultTasksFromOptions(options, generatorsMap, chain);
-  for (const auto& taskInfo : taskInfoVect) {
+  for (const auto& taskInfo : taskInfoVect)
+  {
     addTaskToChain(generatorsMap, taskInfo, chain);
   }
   return chain;
 }
 
-  TaskGeneratorChain generateDirectTaskGeneratorChain(
-                                                      const std::vector<TaskInfo>& taskInfoVect,
-                                                      const std::map<std::string, TaskGenerator>& generatorsMap,
-                                                      const std::map<std::string, boost::any>& options)
-  {
+TaskGeneratorChain generateDirectTaskGeneratorChain(const std::vector<TaskInfo>& taskInfoVect,
+                                                    const std::map<std::string, TaskGenerator>& generatorsMap,
+                                                    const std::map<std::string, boost::any>& options)
+{
   TaskGeneratorChain chain;
   addDefaultTasksFromOptions(options, generatorsMap, chain);
 
@@ -95,18 +90,21 @@ TaskGeneratorChain generateTaskGeneratorChain(
   auto outT = taskInfoVect.back().outputFileType;
   std::string name = "Direct Task Chain";
 
-  chain.push_back(
-  [name, inT, outT, generatorsMap, taskInfoVect]() {
+  chain.push_back([name, inT, outT, generatorsMap, taskInfoVect]() {
     auto task = jpet_common_tools::make_unique<JPetTaskStreamIO>(name.c_str(), inT.c_str(), outT.c_str());
 
-    for (const auto& taskInfo : taskInfoVect) {
+    for (const auto& taskInfo : taskInfoVect)
+    {
       auto task_name = taskInfo.name;
 
-      if (generatorsMap.find(task_name) != generatorsMap.end()) {
+      if (generatorsMap.find(task_name) != generatorsMap.end())
+      {
         TaskGenerator userTaskGen = generatorsMap.at(task_name);
 
         task->addSubTask(std::unique_ptr<JPetTaskInterface>(userTaskGen()));
-      } else {
+      }
+      else
+      {
         ERROR(Form("The requested task %s is not registered! The output chain might be broken!", name.c_str()));
         return task;
       }
@@ -116,109 +114,99 @@ TaskGeneratorChain generateTaskGeneratorChain(
 
   return chain;
 }
-  
-void addDefaultTasksFromOptions(
-  const std::map<std::string, boost::any>& options,
-  const std::map<std::string, TaskGenerator>& generatorsMap,
-  TaskGeneratorChain& outChain
-) {
+
+void addDefaultTasksFromOptions(const std::map<std::string, boost::any>& options, const std::map<std::string, TaskGenerator>& generatorsMap,
+                                TaskGeneratorChain& outChain)
+{
   using namespace jpet_options_tools;
   auto addDefaultTasksFromOptions = [&](const std::map<std::string, boost::any>& options) {
-
-    auto fileType = FileTypeChecker::getInputFileType(options);
-    if (fileType == FileTypeChecker::kUndefinedFileType) {
+    auto fileType = file_type_checker::getInputFileType(options);
+    if (fileType == file_type_checker::kUndefinedFileType)
+    {
       ERROR(Form("Unknown file type provided for file: %s", getInputFile(options).c_str()));
       return;
     }
 
     // Create Scope task if indicated by the filetype
-    if (fileType == FileTypeChecker::kScope) {
-      auto scopeTask = []() {
-        return std::make_unique<JPetScopeLoader>(
-          std::unique_ptr<JPetScopeTask>(new JPetScopeTask("JPetScopeReader"))
-        );
-      };
+    if (fileType == file_type_checker::kScope)
+    {
+      auto scopeTask = []() { return std::make_unique<JPetScopeLoader>(std::unique_ptr<JPetScopeTask>(new JPetScopeTask("JPetScopeReader"))); };
       outChain.insert(outChain.begin(), scopeTask);
     }
 
     // Create Geant Parser task if indicated by filetype
-    if (fileType == FileTypeChecker::kMCGeant) {
+    if (fileType == file_type_checker::kMCGeant)
+    {
       auto mcInfo = TaskInfo("JPetGeantParser", "mcGeant", "hits", 1);
       addTaskToChain(generatorsMap, mcInfo, outChain);
     }
 
     // Create task to unzip file if indicated by the filetype
-    if (fileType == FileTypeChecker::kZip) {
-      auto unzip = []() {
-        return std::make_unique<JPetUnzipTask>("JPetUnzipTask");
-      };
+    if (fileType == file_type_checker::kZip)
+    {
+      auto unzip = []() { return std::make_unique<JPetUnzipTask>("JPetUnzipTask"); };
       outChain.insert(outChain.end(), unzip);
     }
 
     // Create Unpack task if indicated by the filetype
-    if (fileType == FileTypeChecker::kHld || fileType == FileTypeChecker::kZip) {
-      auto unpack = []() {
-        return std::make_unique<JPetUnpackTask>("JPetUnpackTask");
-      };
+    if (fileType == file_type_checker::kHld || fileType == file_type_checker::kZip)
+    {
+      auto unpack = []() { return std::make_unique<JPetUnpackTask>("JPetUnpackTask"); };
       outChain.insert(outChain.end(), unpack);
     }
 
     // Create task for Param Bank
-    auto paramBankTask = []() {
-      return std::make_unique<JPetParamBankHandlerTask>("ParamBank Filling");
-    };
+    auto paramBankTask = []() { return std::make_unique<JPetParamBankHandlerTask>("ParamBank Filling"); };
     outChain.insert(outChain.begin(), paramBankTask);
-
   };
   addDefaultTasksFromOptions(options);
 }
 
-void addTaskToChain(
-  const std::map<std::string, TaskGenerator>& generatorsMap,
-  const TaskInfo& info, TaskGeneratorChain& outChain
-) {
+void addTaskToChain(const std::map<std::string, TaskGenerator>& generatorsMap, const TaskInfo& info, TaskGeneratorChain& outChain)
+{
   auto name = info.name;
   auto inT = info.inputFileType;
   auto outT = info.outputFileType;
   auto numOfIterations = info.numOfIterations;
 
-  if (generatorsMap.find(name) != generatorsMap.end()) {
+  if (generatorsMap.find(name) != generatorsMap.end())
+  {
     TaskGenerator userTaskGen = generatorsMap.at(name);
-    if (numOfIterations == 1) {
+    if (numOfIterations == 1)
+    {
       outChain.push_back([name, inT, outT, userTaskGen]() {
         auto task = std::make_unique<JPetTaskIOLoopPerSubTask>(name.c_str(), inT.c_str(), outT.c_str());
         task->addSubTask(std::unique_ptr<JPetTaskInterface>(userTaskGen()));
         return task;
       });
-    } else {
-      if (numOfIterations < 0) {
+    }
+    else
+    {
+      if (numOfIterations < 0)
+      {
         outChain.push_back([name, inT, outT, userTaskGen]() {
           auto task = std::make_unique<JPetTaskIOLoopPerSubTask>(name.c_str(), inT.c_str(), outT.c_str());
           task->addSubTask(std::unique_ptr<JPetTaskInterface>(userTaskGen()));
-          auto looperTask = std::make_unique<JPetTaskLooper>(
-            name.c_str(), std::move(task), JPetTaskLooper::getStopOnOptionPredicate(kStopIterationOptionName)
-          );
+          auto looperTask =
+              std::make_unique<JPetTaskLooper>(name.c_str(), std::move(task), JPetTaskLooper::getStopOnOptionPredicate(kStopIterationOptionName));
           return looperTask;
         });
-      } else {
+      }
+      else
+      {
         outChain.push_back([name, inT, outT, numOfIterations, userTaskGen]() {
           auto task = std::make_unique<JPetTaskIOLoopPerSubTask>(name.c_str(), inT.c_str(), outT.c_str());
           task->addSubTask(std::unique_ptr<JPetTaskInterface>(userTaskGen()));
-          auto looperTask = std::make_unique<JPetTaskLooper>(
-            name.c_str(), std::move(task),
-            JPetTaskLooper::getMaxIterationPredicate(numOfIterations)
-          );
+          auto looperTask =
+              std::make_unique<JPetTaskLooper>(name.c_str(), std::move(task), JPetTaskLooper::getMaxIterationPredicate(numOfIterations));
           return looperTask;
         });
       }
     }
-  } else {
-    ERROR(
-      Form(
-        "The requested task %s is not registered! The output chain might be broken!",
-        name.c_str()
-      )
-    );
+  }
+  else
+  {
+    ERROR(Form("The requested task %s is not registered! The output chain might be broken!", name.c_str()));
     return;
   }
 }

--- a/src/Core/JPetTaskIO/JPetInputHandler.cpp
+++ b/src/Core/JPetTaskIO/JPetInputHandler.cpp
@@ -1,5 +1,5 @@
 /**
- *  @copyright Copyright 2018 The J-PET Framework Authors. All rights reserved.
+ *  @copyright Copyright 2021 The J-PET Framework Authors. All rights reserved.
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may find a copy of the License in the LICENCE file.
@@ -28,8 +28,8 @@ bool JPetInputHandler::openInput(const char* inputFilename, const JPetParams& pa
   {
     /// For all types of files which has not hld format we assume
     /// that we can read paramBank from the file.
-    if (FileTypeChecker::getInputFileType(options) != FileTypeChecker::kHldRoot &&
-        FileTypeChecker::getInputFileType(options) != FileTypeChecker::kMCGeant)
+    if (file_type_checker::getInputFileType(options) != file_type_checker::kHldRoot &&
+        file_type_checker::getInputFileType(options) != file_type_checker::kMCGeant)
     {
       auto paramManager = params.getParamManager();
       assert(paramManager);

--- a/src/Core/JPetTaskIO/JPetTaskIO.cpp
+++ b/src/Core/JPetTaskIO/JPetTaskIO.cpp
@@ -1,5 +1,5 @@
 /**
- *  @copyright Copyright 2018 The J-PET Framework Authors. All rights reserved.
+ *  @copyright Copyright 2021 The J-PET Framework Authors. All rights reserved.
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may find a copy of the License in the LICENCE file.
@@ -198,8 +198,8 @@ bool JPetTaskIO::createOutputObjects(const char* outputFilename)
   using namespace jpet_options_tools;
   auto options = fParams.getOptions();
 
-  if (FileTypeChecker::getInputFileType(options) == FileTypeChecker::kHldRoot ||
-      FileTypeChecker::getInputFileType(options) == FileTypeChecker::kMCGeant)
+  if (file_type_checker::getInputFileType(options) == file_type_checker::kHldRoot ||
+      file_type_checker::getInputFileType(options) == file_type_checker::kMCGeant)
   {
 
     fHeader = new JPetTreeHeader(getRunNumber(options));

--- a/src/Core/JPetTaskIO/JPetTaskIOTools.cpp
+++ b/src/Core/JPetTaskIO/JPetTaskIOTools.cpp
@@ -1,5 +1,5 @@
 /**
- *  @copyright Copyright 2018 The J-PET Framework Authors. All rights reserved.
+ *  @copyright Copyright 2021 The J-PET Framework Authors. All rights reserved.
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may find a copy of the License in the LICENCE file.
@@ -111,8 +111,8 @@ std::tuple<bool, std::string, std::string, bool> setInputAndOutputFile(const Opt
 OptsStrAny setOutputOptions(const JPetParams& oldParams, bool resetOutputPath, const std::string& fullOutPath)
 {
   OptsStrAny new_opts = oldParams.getOptions();
-  if (FileTypeChecker::getInputFileType(oldParams.getOptions()) == FileTypeChecker::kHldRoot ||
-      FileTypeChecker::getInputFileType(oldParams.getOptions()) == FileTypeChecker::kMCGeant)
+  if (file_type_checker::getInputFileType(oldParams.getOptions()) == file_type_checker::kHldRoot ||
+      file_type_checker::getInputFileType(oldParams.getOptions()) == file_type_checker::kMCGeant)
   {
     jpet_options_generator_tools::setOutputFileType(new_opts, "root");
   }

--- a/src/Options/JPetOptionValidator/JPetAdditionalValidators.cpp
+++ b/src/Options/JPetOptionValidator/JPetAdditionalValidators.cpp
@@ -1,5 +1,5 @@
 /**
- *  @copyright Copyright 2018 The J-PET Framework Authors. All rights reserved.
+ *  @copyright Copyright 2021 The J-PET Framework Authors. All rights reserved.
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may find a copy of the License in the LICENCE file.
@@ -20,10 +20,9 @@
 using boost::any_cast;
 
 // cppcheck-suppress unusedFunction
-bool additionalCheckIfRunIdIsOk(std::pair<std::string, boost::any> option)
+bool additionalCheckIfRunIDIsOk(std::pair<std::string, boost::any> option)
 {
-  if (any_cast<int>(option.second) != 10)
-  {
+  if (any_cast<int>(option.second) != 10) {
     return false;
   }
   return true;

--- a/src/Options/JPetOptionValidator/JPetAdditionalValidators.cpp
+++ b/src/Options/JPetOptionValidator/JPetAdditionalValidators.cpp
@@ -22,7 +22,8 @@ using boost::any_cast;
 // cppcheck-suppress unusedFunction
 bool additionalCheckIfRunIDIsOk(std::pair<std::string, boost::any> option)
 {
-  if (any_cast<int>(option.second) != 10) {
+  if (any_cast<int>(option.second) != 10)
+  {
     return false;
   }
   return true;

--- a/src/Options/JPetOptionValidator/JPetOptionValidator.cpp
+++ b/src/Options/JPetOptionValidator/JPetOptionValidator.cpp
@@ -14,26 +14,26 @@
  */
 
 #include "JPetOptionValidator/JPetOptionValidator.h"
-#include "JPetOptionsTools/JPetOptionsTools.h"
 #include "JPetCommonTools/JPetCommonTools.h"
 #include "JPetLoggerInclude.h"
+#include "JPetOptionsTools/JPetOptionsTools.h"
 
 using boost::any_cast;
 
-JPetOptionValidator::JPetOptionValidator()
-{
-  fValidatorMap = generateValidationMap();
-}
+JPetOptionValidator::JPetOptionValidator() { fValidatorMap = generateValidationMap(); }
 
-bool JPetOptionValidator::areCorrectOptions(
-  const std::map<std::string, boost::any>& optionsMap,
-  std::vector<std::string>& namesOfOptionsToBeValidated
-) {
+bool JPetOptionValidator::areCorrectOptions(const std::map<std::string, boost::any>& optionsMap,
+                                            std::vector<std::string>& namesOfOptionsToBeValidated)
+{
   auto newOptionsMap = addNonStandardValidators(optionsMap);
-  for (auto& checkGroup : fValidatorMap) {
-    if (std::find(namesOfOptionsToBeValidated.begin(), namesOfOptionsToBeValidated.end(), checkGroup.first ) != namesOfOptionsToBeValidated.end()) {
-      for (auto& checkFunc : checkGroup.second) {
-        if ((!checkFunc(std::make_pair(checkGroup.first, newOptionsMap.at(checkGroup.first))))) {
+  for (auto& checkGroup : fValidatorMap)
+  {
+    if (std::find(namesOfOptionsToBeValidated.begin(), namesOfOptionsToBeValidated.end(), checkGroup.first) != namesOfOptionsToBeValidated.end())
+    {
+      for (auto& checkFunc : checkGroup.second)
+      {
+        if ((!checkFunc(std::make_pair(checkGroup.first, newOptionsMap.at(checkGroup.first)))))
+        {
           ERROR("VALIDATION ERROR FOR " + checkGroup.first);
           return false;
         }
@@ -55,19 +55,18 @@ void JPetOptionValidator::addFileTypeAndNameValidator(std::map<std::string, boos
   using namespace jpet_options_tools;
   std::string type_key = "type_std::string";
   std::string filename_key = "file_std::vector<std::string>";
-  if (!isOptionSet(optionsMap,  type_key) || !isOptionSet(optionsMap,  filename_key)) {
+  if (!isOptionSet(optionsMap, type_key) || !isOptionSet(optionsMap, filename_key))
+  {
     WARNING("file type or file name option not present! No validator added!");
     return;
   }
-  optionsMap["type_std::string, file_std::vector<std::string>"]
-    = JPetOptionValidator::ManyOptionsWrapper(
-      {getOptionAsString(optionsMap, type_key), getOptionAsVectorOfStrings(optionsMap, filename_key)}
-    );
+  optionsMap["type_std::string, file_std::vector<std::string>"] =
+      JPetOptionValidator::ManyOptionsWrapper({getOptionAsString(optionsMap, type_key), getOptionAsVectorOfStrings(optionsMap, filename_key)});
 }
 
-std::map<std::string, std::vector<bool(*)(std::pair <std::string, boost::any>)>> JPetOptionValidator::generateValidationMap()
+std::map<std::string, std::vector<bool (*)(std::pair<std::string, boost::any>)>> JPetOptionValidator::generateValidationMap()
 {
-  std::map<std::string, std::vector<bool(*)(std::pair <std::string, boost::any>)>> validationMap;
+  std::map<std::string, std::vector<bool (*)(std::pair<std::string, boost::any>)>> validationMap;
   validationMap["range_std::vector<int>"].push_back(&isNumberBoundsInRangeValid);
   validationMap["range_std::vector<int>"].push_back(&isRangeOfEventsValid);
   validationMap["type_std::string"].push_back(&isCorrectFileType);
@@ -87,7 +86,8 @@ void JPetOptionValidator::addValidatorFunction(const std::string& name, bool (*v
 
 bool JPetOptionValidator::isNumberBoundsInRangeValid(std::pair<std::string, boost::any> option)
 {
-  if (any_cast<std::vector<int>>(option.second).size() != 2) {
+  if (any_cast<std::vector<int>>(option.second).size() != 2)
+  {
     ERROR("Wrong number of bounds in range: " + std::to_string(any_cast<std::vector<int>>(option.second).size()));
     return false;
   }
@@ -96,7 +96,8 @@ bool JPetOptionValidator::isNumberBoundsInRangeValid(std::pair<std::string, boos
 
 bool JPetOptionValidator::isRangeOfEventsValid(std::pair<std::string, boost::any> option)
 {
-  if (any_cast<std::vector<int>>(option.second).at(0) > any_cast<std::vector<int>>(option.second).at(1)) {
+  if (any_cast<std::vector<int>>(option.second).at(0) > any_cast<std::vector<int>>(option.second).at(1))
+  {
     ERROR("Wrong number of bounds in range: " + std::to_string(any_cast<std::vector<int>>(option.second).size()));
     return false;
   }
@@ -106,9 +107,12 @@ bool JPetOptionValidator::isRangeOfEventsValid(std::pair<std::string, boost::any
 bool JPetOptionValidator::isCorrectFileType(std::pair<std::string, boost::any> option)
 {
   std::string type = any_cast<std::string>(option.second);
-  if (type == "hld" || type == "root" || type == "scope" || type == "zip" || type == "mcGeant") {
+  if (type == "hld" || type == "root" || type == "scope" || type == "zip" || type == "mcGeant")
+  {
     return true;
-  } else {
+  }
+  else
+  {
     ERROR("Wrong type of file:" + type);
     return false;
   }
@@ -121,12 +125,11 @@ bool JPetOptionValidator::isFileTypeMatchingExtensions(std::pair<std::string, bo
   std::string fileType = any_cast<std::string>(optionsVector[0]);
   std::vector<std::string> fileNames = any_cast<std::vector<std::string>>(optionsVector[1]);
   std::vector<std::string> correctFileExtensions = getCorrectExtensionsForTheType(fileType);
-  for (const std::string& fileName : fileNames) {
-    if (std::find(
-        correctFileExtensions.begin(),
-        correctFileExtensions.end(),
-        JPetCommonTools::exctractFileNameSuffix(fileName)
-      ) == correctFileExtensions.end()) {
+  for (const std::string& fileName : fileNames)
+  {
+    if (std::find(correctFileExtensions.begin(), correctFileExtensions.end(), JPetCommonTools::exctractFileNameSuffix(fileName)) ==
+        correctFileExtensions.end())
+    {
       ERROR("Wrong extension of file: " + fileName);
       return false;
     }
@@ -136,44 +139,52 @@ bool JPetOptionValidator::isFileTypeMatchingExtensions(std::pair<std::string, bo
 
 std::vector<std::string> JPetOptionValidator::getCorrectExtensionsForTheType(std::string fileType)
 {
-  if (fileType == "scope") {
+  if (fileType == "scope")
+  {
     return {".json"};
-  } else if (fileType == "zip") {
+  }
+  else if (fileType == "zip")
+  {
     return {".gz", ".xz", ".bz2", ".zip"};
-  } else if (fileType == "mcGeant") {
+  }
+  else if (fileType == "mcGeant")
+  {
     return {".root"};
-  } else {
+  }
+  else
+  {
     return {"." + fileType};
   }
 }
 
 bool JPetOptionValidator::isRunIDValid(std::pair<std::string, boost::any> option)
 {
-  if (any_cast<int>(option.second) <= 0) {
+  if (any_cast<int>(option.second) <= 0)
+  {
     ERROR("Run id must be a number larger than 0.");
     return false;
   }
   return true;
 }
 
-bool JPetOptionValidator::isDetectorValid(std::pair <std::string, boost::any> option)
+bool JPetOptionValidator::isDetectorValid(std::pair<std::string, boost::any> option)
 {
-  if (
-    any_cast<std::string>(option.second) == "bar"
-    || any_cast<std::string>(option.second) == "barrel"
-    || any_cast<std::string>(option.second) == "mod"
-    || any_cast<std::string>(option.second) == "modular"
-  ) {
+  if (any_cast<std::string>(option.second) == "bar" || any_cast<std::string>(option.second) == "barrel" ||
+      any_cast<std::string>(option.second) == "mod" || any_cast<std::string>(option.second) == "modular")
+  {
     return true;
-  } else {
+  }
+  else
+  {
     ERROR("Provided detector type not found. Use '-k barrel' or '-k modular'");
     return false;
   }
 }
 
-bool JPetOptionValidator::isLocalDBValid(std::pair <std::string, boost::any> option)
+bool JPetOptionValidator::isLocalDBValid(std::pair<std::string, boost::any> option)
 {
-  if ( !JPetCommonTools::ifFileExisting(any_cast<std::string>(option.second)) ) {
+  if (!JPetCommonTools::ifFileExisting(any_cast<std::string>(option.second)))
+  {
     ERROR("File doed not exist.");
     return false;
   }
@@ -204,12 +215,6 @@ bool JPetOptionValidator::isOutputDirectoryValid(std::pair<std::string, boost::a
   return true;
 }
 
-JPetOptionValidator::ManyOptionsWrapper::ManyOptionsWrapper(std::initializer_list<boost::any> options)
-{
-  optionsVector = options;
-}
+JPetOptionValidator::ManyOptionsWrapper::ManyOptionsWrapper(std::initializer_list<boost::any> options) { optionsVector = options; }
 
-std::vector<boost::any> JPetOptionValidator::ManyOptionsWrapper::getOptionsVector()
-{
-  return optionsVector;
-}
+std::vector<boost::any> JPetOptionValidator::ManyOptionsWrapper::getOptionsVector() { return optionsVector; }

--- a/src/Options/JPetOptionValidator/JPetOptionValidator.cpp
+++ b/src/Options/JPetOptionValidator/JPetOptionValidator.cpp
@@ -1,5 +1,5 @@
 /**
- *  @copyright Copyright 2018 The J-PET Framework Authors. All rights reserved.
+ *  @copyright Copyright 2021 The J-PET Framework Authors. All rights reserved.
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may find a copy of the License in the LICENCE file.
@@ -14,26 +14,26 @@
  */
 
 #include "JPetOptionValidator/JPetOptionValidator.h"
-#include "./JPetLoggerInclude.h"
-#include "JPetCommonTools/JPetCommonTools.h"
 #include "JPetOptionsTools/JPetOptionsTools.h"
+#include "JPetCommonTools/JPetCommonTools.h"
+#include "JPetLoggerInclude.h"
 
 using boost::any_cast;
 
-JPetOptionValidator::JPetOptionValidator() { fValidatorMap = generateValidationMap(); }
-
-bool JPetOptionValidator::areCorrectOptions(const std::map<std::string, boost::any>& optionsMap,
-                                            std::vector<std::string>& namesOfOptionsToBeValidated)
+JPetOptionValidator::JPetOptionValidator()
 {
+  fValidatorMap = generateValidationMap();
+}
+
+bool JPetOptionValidator::areCorrectOptions(
+  const std::map<std::string, boost::any>& optionsMap,
+  std::vector<std::string>& namesOfOptionsToBeValidated
+) {
   auto newOptionsMap = addNonStandardValidators(optionsMap);
-  for (auto& checkGroup : fValidatorMap)
-  {
-    if (std::find(namesOfOptionsToBeValidated.begin(), namesOfOptionsToBeValidated.end(), checkGroup.first) != namesOfOptionsToBeValidated.end())
-    {
-      for (auto& checkFunc : checkGroup.second)
-      {
-        if ((!checkFunc(std::make_pair(checkGroup.first, newOptionsMap.at(checkGroup.first)))))
-        {
+  for (auto& checkGroup : fValidatorMap) {
+    if (std::find(namesOfOptionsToBeValidated.begin(), namesOfOptionsToBeValidated.end(), checkGroup.first ) != namesOfOptionsToBeValidated.end()) {
+      for (auto& checkFunc : checkGroup.second) {
+        if ((!checkFunc(std::make_pair(checkGroup.first, newOptionsMap.at(checkGroup.first))))) {
           ERROR("VALIDATION ERROR FOR " + checkGroup.first);
           return false;
         }
@@ -55,24 +55,26 @@ void JPetOptionValidator::addFileTypeAndNameValidator(std::map<std::string, boos
   using namespace jpet_options_tools;
   std::string type_key = "type_std::string";
   std::string filename_key = "file_std::vector<std::string>";
-  if (!isOptionSet(optionsMap, type_key) || !isOptionSet(optionsMap, filename_key))
-  {
+  if (!isOptionSet(optionsMap,  type_key) || !isOptionSet(optionsMap,  filename_key)) {
     WARNING("file type or file name option not present! No validator added!");
     return;
   }
-  optionsMap["type_std::string, file_std::vector<std::string>"] =
-      JPetOptionValidator::ManyOptionsWrapper({getOptionAsString(optionsMap, type_key), getOptionAsVectorOfStrings(optionsMap, filename_key)});
+  optionsMap["type_std::string, file_std::vector<std::string>"]
+    = JPetOptionValidator::ManyOptionsWrapper(
+      {getOptionAsString(optionsMap, type_key), getOptionAsVectorOfStrings(optionsMap, filename_key)}
+    );
 }
 
-std::map<std::string, std::vector<bool (*)(std::pair<std::string, boost::any>)>> JPetOptionValidator::generateValidationMap()
+std::map<std::string, std::vector<bool(*)(std::pair <std::string, boost::any>)>> JPetOptionValidator::generateValidationMap()
 {
-  std::map<std::string, std::vector<bool (*)(std::pair<std::string, boost::any>)>> validationMap;
+  std::map<std::string, std::vector<bool(*)(std::pair <std::string, boost::any>)>> validationMap;
   validationMap["range_std::vector<int>"].push_back(&isNumberBoundsInRangeValid);
   validationMap["range_std::vector<int>"].push_back(&isRangeOfEventsValid);
   validationMap["type_std::string"].push_back(&isCorrectFileType);
   validationMap["file_std::vector<std::string>"].push_back(&areFilesValid);
   validationMap["type_std::string, file_std::vector<std::string>"].push_back(&isFileTypeMatchingExtensions);
-  validationMap["runId_int"].push_back(&isRunIdValid);
+  validationMap["runID_int"].push_back(&isRunIDValid);
+  validationMap["detectorType_std::string"].push_back(&isDetectorValid);
   validationMap["localDB_std::string"].push_back(&isLocalDBValid);
   validationMap["outputPath_std::string"].push_back(&isOutputDirectoryValid);
   return validationMap;
@@ -85,8 +87,7 @@ void JPetOptionValidator::addValidatorFunction(const std::string& name, bool (*v
 
 bool JPetOptionValidator::isNumberBoundsInRangeValid(std::pair<std::string, boost::any> option)
 {
-  if (any_cast<std::vector<int>>(option.second).size() != 2)
-  {
+  if (any_cast<std::vector<int>>(option.second).size() != 2) {
     ERROR("Wrong number of bounds in range: " + std::to_string(any_cast<std::vector<int>>(option.second).size()));
     return false;
   }
@@ -95,8 +96,7 @@ bool JPetOptionValidator::isNumberBoundsInRangeValid(std::pair<std::string, boos
 
 bool JPetOptionValidator::isRangeOfEventsValid(std::pair<std::string, boost::any> option)
 {
-  if (any_cast<std::vector<int>>(option.second).at(0) > any_cast<std::vector<int>>(option.second).at(1))
-  {
+  if (any_cast<std::vector<int>>(option.second).at(0) > any_cast<std::vector<int>>(option.second).at(1)) {
     ERROR("Wrong number of bounds in range: " + std::to_string(any_cast<std::vector<int>>(option.second).size()));
     return false;
   }
@@ -106,12 +106,9 @@ bool JPetOptionValidator::isRangeOfEventsValid(std::pair<std::string, boost::any
 bool JPetOptionValidator::isCorrectFileType(std::pair<std::string, boost::any> option)
 {
   std::string type = any_cast<std::string>(option.second);
-  if (type == "hld" || type == "root" || type == "scope" || type == "zip" || type == "mcGeant")
-  {
+  if (type == "hld" || type == "root" || type == "scope" || type == "zip" || type == "mcGeant") {
     return true;
-  }
-  else
-  {
+  } else {
     ERROR("Wrong type of file:" + type);
     return false;
   }
@@ -124,11 +121,12 @@ bool JPetOptionValidator::isFileTypeMatchingExtensions(std::pair<std::string, bo
   std::string fileType = any_cast<std::string>(optionsVector[0]);
   std::vector<std::string> fileNames = any_cast<std::vector<std::string>>(optionsVector[1]);
   std::vector<std::string> correctFileExtensions = getCorrectExtensionsForTheType(fileType);
-  for (const std::string& fileName : fileNames)
-  {
-    if (std::find(correctFileExtensions.begin(), correctFileExtensions.end(), JPetCommonTools::exctractFileNameSuffix(fileName)) ==
-        correctFileExtensions.end())
-    {
+  for (const std::string& fileName : fileNames) {
+    if (std::find(
+        correctFileExtensions.begin(),
+        correctFileExtensions.end(),
+        JPetCommonTools::exctractFileNameSuffix(fileName)
+      ) == correctFileExtensions.end()) {
       ERROR("Wrong extension of file: " + fileName);
       return false;
     }
@@ -138,38 +136,44 @@ bool JPetOptionValidator::isFileTypeMatchingExtensions(std::pair<std::string, bo
 
 std::vector<std::string> JPetOptionValidator::getCorrectExtensionsForTheType(std::string fileType)
 {
-  if (fileType == "scope")
-  {
+  if (fileType == "scope") {
     return {".json"};
-  }
-  else if (fileType == "zip")
-  {
+  } else if (fileType == "zip") {
     return {".gz", ".xz", ".bz2", ".zip"};
-  }
-  else if (fileType == "mcGeant")
-  {
+  } else if (fileType == "mcGeant") {
     return {".root"};
-  }
-  else
-  {
+  } else {
     return {"." + fileType};
   }
 }
 
-bool JPetOptionValidator::isRunIdValid(std::pair<std::string, boost::any> option)
+bool JPetOptionValidator::isRunIDValid(std::pair<std::string, boost::any> option)
 {
-  if (any_cast<int>(option.second) <= 0)
-  {
+  if (any_cast<int>(option.second) <= 0) {
     ERROR("Run id must be a number larger than 0.");
     return false;
   }
   return true;
 }
 
-bool JPetOptionValidator::isLocalDBValid(std::pair<std::string, boost::any> option)
+bool JPetOptionValidator::isDetectorValid(std::pair <std::string, boost::any> option)
 {
-  if (!JPetCommonTools::ifFileExisting(any_cast<std::string>(option.second)))
-  {
+  if (
+    any_cast<std::string>(option.second) == "bar"
+    || any_cast<std::string>(option.second) == "barrel"
+    || any_cast<std::string>(option.second) == "mod"
+    || any_cast<std::string>(option.second) == "modular"
+  ) {
+    return true;
+  } else {
+    ERROR("Provided detector type not found. Use '-k barrel' or '-k modular'");
+    return false;
+  }
+}
+
+bool JPetOptionValidator::isLocalDBValid(std::pair <std::string, boost::any> option)
+{
+  if ( !JPetCommonTools::ifFileExisting(any_cast<std::string>(option.second)) ) {
     ERROR("File doed not exist.");
     return false;
   }
@@ -200,6 +204,12 @@ bool JPetOptionValidator::isOutputDirectoryValid(std::pair<std::string, boost::a
   return true;
 }
 
-JPetOptionValidator::ManyOptionsWrapper::ManyOptionsWrapper(std::initializer_list<boost::any> options) { optionsVector = options; }
+JPetOptionValidator::ManyOptionsWrapper::ManyOptionsWrapper(std::initializer_list<boost::any> options)
+{
+  optionsVector = options;
+}
 
-std::vector<boost::any> JPetOptionValidator::ManyOptionsWrapper::getOptionsVector() { return optionsVector; }
+std::vector<boost::any> JPetOptionValidator::ManyOptionsWrapper::getOptionsVector()
+{
+  return optionsVector;
+}

--- a/src/Options/JPetOptionsGenerator/JPetAdditionalTransformations.cpp
+++ b/src/Options/JPetOptionsGenerator/JPetAdditionalTransformations.cpp
@@ -1,5 +1,5 @@
 /**
- *  @copyright Copyright 2018 The J-PET Framework Authors. All rights reserved.
+ *  @copyright Copyright 2021 The J-PET Framework Authors. All rights reserved.
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may find a copy of the License in the LICENCE file.
@@ -20,7 +20,7 @@
 using boost::any_cast;
 
 // cppcheck-suppress unusedFunction
-std::pair<std::string, boost::any> setAdditionalRunIdInTheMap(boost::any option)
+std::pair<std::string, boost::any> setAdditionalRunIDInTheMap(boost::any option)
 {
   int run = any_cast<int>(option);
   return std::make_pair("additionalRunID_int", run);

--- a/src/Options/JPetOptionsGenerator/JPetOptionsGeneratorTools.cpp
+++ b/src/Options/JPetOptionsGenerator/JPetOptionsGeneratorTools.cpp
@@ -1,5 +1,5 @@
 /**
- *  @copyright Copyright 2018 The J-PET Framework Authors. All rights reserved.
+ *  @copyright Copyright 2021 The J-PET Framework Authors. All rights reserved.
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may find a copy of the License in the LICENCE file.
@@ -20,44 +20,47 @@ using namespace jpet_options_tools;
 
 namespace jpet_options_generator_tools
 {
-std::map<std::string, boost::any> kDefaultOptions = {{"inputFile_std::string", std::string("")},
-                                                     {"inputFileType_std::string", std::string("")},
-                                                     {"scopeConfigFile_std::string", std::string("")},
-                                                     {"scopeInputDirectory_std::string", std::string("")},
-                                                     {"outputPath_std::string", std::string("")},
-                                                     {"outputFile_std::string", std::string("test.root")},
-                                                     {"outputFileType_std::string", std::string("root")},
-                                                     {"firstEvent_int", -1},
-                                                     {"lastEvent_int", -1},
-                                                     {"progressBar_bool", false},
-                                                     {"directProcessing_bool", false},
-                                                     {"runId_int", -1},
-                                                     {"unpackerConfigFile_std::string", std::string("conf_trb3.xml")},
-                                                     {"unpackerCalibFile_std::string", std::string("")}};
+std::map<std::string, boost::any> kDefaultOptions = {
+  {"inputFile_std::string", std::string("")},
+  {"inputFileType_std::string", std::string("")},
+  {"scopeConfigFile_std::string", std::string("")},
+  {"scopeInputDirectory_std::string", std::string("")},
+  {"outputPath_std::string", std::string("")},
+  {"outputFile_std::string", std::string("test.root")},
+  {"outputFileType_std::string", std::string("root")},
+  {"firstEvent_int", -1},
+  {"lastEvent_int", -1},
+  {"progressBar_bool", false},
+  {"directProcessing_bool", false},
+  {"runID_int", -1},
+  {"detectorType_std::string", std::string("barrel")},
+  {"unpackerConfigFile_std::string", std::string("conf_trb3.xml")},
+  {"unpackerCalibFile_std::string", std::string("")}
+};
 
-std::map<std::string, std::string> kOptCmdLineNameToExtendedName = {{"type", "type_std::string"},
-                                                                    {"file", "file_std::vector<std::string>"},
-                                                                    {"outputPath", "outputPath_std::string"},
-                                                                    {"range", "range_std::vector<int>"},
-                                                                    {"unpackerConfigFile", "unpackerConfigFile_std::string"},
-                                                                    {"unpackerCalibFile", "unpackerCalibFile_std::string"},
-                                                                    {"runId", "runId_int"},
-                                                                    {"directProcessing", "directProcessing_bool"},
-                                                                    {"progressBar", "progressBar_bool"},
-                                                                    {"localDB", "localDB_std::string"},
-                                                                    {"localDBCreate", "localDBCreate_std::string"},
-                                                                    {"userCfg", "userCfg_std::string"}};
+std::map<std::string, std::string> kOptCmdLineNameToExtendedName = {
+  {"type", "type_std::string"},
+  {"file", "file_std::vector<std::string>"},
+  {"outputPath", "outputPath_std::string"},
+  {"range", "range_std::vector<int>"},
+  {"unpackerConfigFile", "unpackerConfigFile_std::string"},
+  {"unpackerCalibFile", "unpackerCalibFile_std::string"},
+  {"runID", "runID_int"},
+  {"directProcessing", "directProcessing_bool"},
+  {"detector", "detectorType_std::string"},
+  {"progressBar", "progressBar_bool"},
+  {"localDB", "localDB_std::string"},
+  {"localDBCreate", "localDBCreate_std::string"},
+  {"userCfg", "userCfg_std::string"}
+};
 
 std::map<std::string, boost::any> transformOptions(const TransformersMap& transformationMap, const std::map<std::string, boost::any>& oldOptionsMap)
 {
   std::map<std::string, boost::any> newOptionsMap(oldOptionsMap);
-  for (auto& transformGroup : transformationMap)
-  {
+  for (auto& transformGroup : transformationMap) {
     auto key = transformGroup.first;
-    if (newOptionsMap.find(key) != newOptionsMap.end())
-    {
-      for (auto& transformFunc : transformGroup.second)
-      {
+    if (newOptionsMap.find(key) != newOptionsMap.end()) {
+      for (auto& transformFunc : transformGroup.second) {
         auto newOpt = transformFunc(newOptionsMap.at(key));
         newOptionsMap[newOpt.first] = newOpt.second;
       }
@@ -126,7 +129,7 @@ std::map<std::string, boost::any> addMissingDefaultOptions(const std::map<std::s
 }
 
 /**
- * The keys usedin this method correspond to the keys defined in the CmdArgMap
+ * The keys used in this method correspond to the keys defined in the CmdArgMap
  */
 std::map<std::string, std::vector<Transformer>> generateTransformationMap(OptsStrAny& options)
 {
@@ -168,7 +171,10 @@ OptsStrAny addTypeSuffixes(const std::map<std::string, boost::any>& oldMap)
 
 std::map<std::string, boost::any> getDefaultOptions() { return kDefaultOptions; }
 
-void addTransformFunction(TransformersMap& map, const std::string& name, Transformer transformFunction) { map[name].push_back(transformFunction); }
+void addTransformFunction(TransformersMap& map, const std::string& name, Transformer transformFunction)
+{
+  map[name].push_back(transformFunction);
+}
 
 /**
  * Adding an option to already existing ones. If the key already exists the element

--- a/src/Options/JPetOptionsGenerator/JPetOptionsGeneratorTools.cpp
+++ b/src/Options/JPetOptionsGenerator/JPetOptionsGeneratorTools.cpp
@@ -20,47 +20,46 @@ using namespace jpet_options_tools;
 
 namespace jpet_options_generator_tools
 {
-std::map<std::string, boost::any> kDefaultOptions = {
-  {"inputFile_std::string", std::string("")},
-  {"inputFileType_std::string", std::string("")},
-  {"scopeConfigFile_std::string", std::string("")},
-  {"scopeInputDirectory_std::string", std::string("")},
-  {"outputPath_std::string", std::string("")},
-  {"outputFile_std::string", std::string("test.root")},
-  {"outputFileType_std::string", std::string("root")},
-  {"firstEvent_int", -1},
-  {"lastEvent_int", -1},
-  {"progressBar_bool", false},
-  {"directProcessing_bool", false},
-  {"runID_int", -1},
-  {"detectorType_std::string", std::string("barrel")},
-  {"unpackerConfigFile_std::string", std::string("conf_trb3.xml")},
-  {"unpackerCalibFile_std::string", std::string("")}
-};
+std::map<std::string, boost::any> kDefaultOptions = {{"inputFile_std::string", std::string("")},
+                                                     {"inputFileType_std::string", std::string("")},
+                                                     {"scopeConfigFile_std::string", std::string("")},
+                                                     {"scopeInputDirectory_std::string", std::string("")},
+                                                     {"outputPath_std::string", std::string("")},
+                                                     {"outputFile_std::string", std::string("test.root")},
+                                                     {"outputFileType_std::string", std::string("root")},
+                                                     {"firstEvent_int", -1},
+                                                     {"lastEvent_int", -1},
+                                                     {"progressBar_bool", false},
+                                                     {"directProcessing_bool", false},
+                                                     {"runID_int", -1},
+                                                     {"detectorType_std::string", std::string("barrel")},
+                                                     {"unpackerConfigFile_std::string", std::string("conf_trb3.xml")},
+                                                     {"unpackerCalibFile_std::string", std::string("")}};
 
-std::map<std::string, std::string> kOptCmdLineNameToExtendedName = {
-  {"type", "type_std::string"},
-  {"file", "file_std::vector<std::string>"},
-  {"outputPath", "outputPath_std::string"},
-  {"range", "range_std::vector<int>"},
-  {"unpackerConfigFile", "unpackerConfigFile_std::string"},
-  {"unpackerCalibFile", "unpackerCalibFile_std::string"},
-  {"runID", "runID_int"},
-  {"directProcessing", "directProcessing_bool"},
-  {"detector", "detectorType_std::string"},
-  {"progressBar", "progressBar_bool"},
-  {"localDB", "localDB_std::string"},
-  {"localDBCreate", "localDBCreate_std::string"},
-  {"userCfg", "userCfg_std::string"}
-};
+std::map<std::string, std::string> kOptCmdLineNameToExtendedName = {{"type", "type_std::string"},
+                                                                    {"file", "file_std::vector<std::string>"},
+                                                                    {"outputPath", "outputPath_std::string"},
+                                                                    {"range", "range_std::vector<int>"},
+                                                                    {"unpackerConfigFile", "unpackerConfigFile_std::string"},
+                                                                    {"unpackerCalibFile", "unpackerCalibFile_std::string"},
+                                                                    {"runID", "runID_int"},
+                                                                    {"directProcessing", "directProcessing_bool"},
+                                                                    {"detector", "detectorType_std::string"},
+                                                                    {"progressBar", "progressBar_bool"},
+                                                                    {"localDB", "localDB_std::string"},
+                                                                    {"localDBCreate", "localDBCreate_std::string"},
+                                                                    {"userCfg", "userCfg_std::string"}};
 
 std::map<std::string, boost::any> transformOptions(const TransformersMap& transformationMap, const std::map<std::string, boost::any>& oldOptionsMap)
 {
   std::map<std::string, boost::any> newOptionsMap(oldOptionsMap);
-  for (auto& transformGroup : transformationMap) {
+  for (auto& transformGroup : transformationMap)
+  {
     auto key = transformGroup.first;
-    if (newOptionsMap.find(key) != newOptionsMap.end()) {
-      for (auto& transformFunc : transformGroup.second) {
+    if (newOptionsMap.find(key) != newOptionsMap.end())
+    {
+      for (auto& transformFunc : transformGroup.second)
+      {
         auto newOpt = transformFunc(newOptionsMap.at(key));
         newOptionsMap[newOpt.first] = newOpt.second;
       }
@@ -171,10 +170,7 @@ OptsStrAny addTypeSuffixes(const std::map<std::string, boost::any>& oldMap)
 
 std::map<std::string, boost::any> getDefaultOptions() { return kDefaultOptions; }
 
-void addTransformFunction(TransformersMap& map, const std::string& name, Transformer transformFunction)
-{
-  map[name].push_back(transformFunction);
-}
+void addTransformFunction(TransformersMap& map, const std::string& name, Transformer transformFunction) { map[name].push_back(transformFunction); }
 
 /**
  * Adding an option to already existing ones. If the key already exists the element

--- a/src/Options/JPetOptionsTools/JPetOptionsTools.cpp
+++ b/src/Options/JPetOptionsTools/JPetOptionsTools.cpp
@@ -1,5 +1,5 @@
 /**
- *  @copyright Copyright 2018 The J-PET Framework Authors. All rights reserved.
+ *  @copyright Copyright 2021 The J-PET Framework Authors. All rights reserved.
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may find a copy of the License in the LICENCE file.
@@ -201,7 +201,7 @@ long long getTotalEvents(const std::map<std::string, boost::any>& opts)
   return diff;
 }
 
-int getRunNumber(const std::map<std::string, boost::any>& opts) { return any_cast<int>(opts.at("runId_int")); }
+int getRunNumber(const std::map<std::string, boost::any>& opts) { return any_cast<int>(opts.at("runID_int")); }
 
 bool isProgressBar(const std::map<std::string, boost::any>& opts) {
   if (opts.find("progressBar_bool") != opts.end())
@@ -423,6 +423,36 @@ FileTypeChecker::FileType FileTypeChecker::getFileType(const std::map<std::strin
     handleErrorMessage(errorMessage, outOfRangeOptionException);
   }
   return FileType::kUndefinedFileType;
+}
+
+/**
+ * Map contains allowed strings for "-k" command line option and indicates what type
+ * of detector is to be used.
+ */
+std::map<std::string, DetectorTypeChecker::DetectorType> DetectorTypeChecker::fStringToDetectorType =
+{
+  {"bar", kBarrel}, {"barrel", kBarrel}, {"mod", kModular}, {"modular", kModular}
+};
+
+/**
+ * Method returns the detector type based on the provided options:
+ * if the "-k" option for the is worng or not used, then by default
+ * the detector type is the Big Barrel - kBarrel.
+ */
+DetectorTypeChecker::DetectorType DetectorTypeChecker::getDetectorType(
+  const std::map<std::string, boost::any>& opts
+) {
+  try {
+    auto option = any_cast<std::string>(opts.at("detectorType_std::string"));
+    try {
+      return fStringToDetectorType.at(option);
+    } catch (const std::out_of_range& outOfRangeDetectorTypeException) { }
+  } catch (const std::out_of_range& outOfRangeOptionException) {
+    std::string errorMessage = "Out of range error in DetectorTypeChecker container ";
+    std::cerr << errorMessage << outOfRangeOptionException.what() << '\n';
+    ERROR(errorMessage);
+  }
+  return DetectorType::kBarrel;
 }
 
 } // namespace jpet_options_tools

--- a/src/Options/JPetOptionsTools/JPetOptionsTools.cpp
+++ b/src/Options/JPetOptionsTools/JPetOptionsTools.cpp
@@ -203,7 +203,8 @@ long long getTotalEvents(const std::map<std::string, boost::any>& opts)
 
 int getRunNumber(const std::map<std::string, boost::any>& opts) { return any_cast<int>(opts.at("runID_int")); }
 
-bool isProgressBar(const std::map<std::string, boost::any>& opts) {
+bool isProgressBar(const std::map<std::string, boost::any>& opts)
+{
   if (opts.find("progressBar_bool") != opts.end())
   {
     return any_cast<bool>(opts.at("progressBar_bool"));
@@ -211,7 +212,8 @@ bool isProgressBar(const std::map<std::string, boost::any>& opts) {
   return false;
 }
 
-bool isDirectProcessing(const std::map<std::string, boost::any>& opts){
+bool isDirectProcessing(const std::map<std::string, boost::any>& opts)
+{
   if (opts.find("directProcessing_bool") != opts.end())
   {
     return any_cast<bool>(opts.at("directProcessing_bool"));
@@ -415,11 +417,13 @@ FileTypeChecker::FileType FileTypeChecker::getFileType(const std::map<std::strin
     }
     catch (const std::out_of_range& outOfRangeFileTypeException)
     {
+      std::string errorMessage = "Provided file type option was not found - out of range in getFileType() ";
+      handleErrorMessage(errorMessage, outOfRangeOptionException);
     }
   }
   catch (const std::out_of_range& outOfRangeOptionException)
   {
-    std::string errorMessage = "Out of range error in Options container ";
+    std::string errorMessage = "Provided option was not found - out of range error in options container ";
     handleErrorMessage(errorMessage, outOfRangeOptionException);
   }
   return FileType::kUndefinedFileType;
@@ -429,28 +433,33 @@ FileTypeChecker::FileType FileTypeChecker::getFileType(const std::map<std::strin
  * Map contains allowed strings for "-k" command line option and indicates what type
  * of detector is to be used.
  */
-std::map<std::string, DetectorTypeChecker::DetectorType> DetectorTypeChecker::fStringToDetectorType =
-{
-  {"bar", kBarrel}, {"barrel", kBarrel}, {"mod", kModular}, {"modular", kModular}
-};
+std::map<std::string, DetectorTypeChecker::DetectorType> DetectorTypeChecker::fStringToDetectorType = {
+    {"bar", kBarrel}, {"barrel", kBarrel}, {"mod", kModular}, {"modular", kModular}};
 
 /**
  * Method returns the detector type based on the provided options:
  * if the "-k" option for the is worng or not used, then by default
  * the detector type is the Big Barrel - kBarrel.
  */
-DetectorTypeChecker::DetectorType DetectorTypeChecker::getDetectorType(
-  const std::map<std::string, boost::any>& opts
-) {
-  try {
+DetectorTypeChecker::DetectorType DetectorTypeChecker::getDetectorType(const std::map<std::string, boost::any>& opts)
+{
+  try
+  {
     auto option = any_cast<std::string>(opts.at("detectorType_std::string"));
-    try {
+    try
+    {
       return fStringToDetectorType.at(option);
-    } catch (const std::out_of_range& outOfRangeDetectorTypeException) { }
-  } catch (const std::out_of_range& outOfRangeOptionException) {
-    std::string errorMessage = "Out of range error in DetectorTypeChecker container ";
-    std::cerr << errorMessage << outOfRangeOptionException.what() << '\n';
-    ERROR(errorMessage);
+    }
+    catch (const std::out_of_range& outOfRangeDetectorTypeException)
+    {
+      std::string errorMessage = "Provided detector type option was not found - out of range in getDetectorType() ";
+      handleErrorMessage(errorMessage, outOfRangeOptionException);
+    }
+  }
+  catch (const std::out_of_range& outOfRangeOptionException)
+  {
+    std::string errorMessage = "Provided option was not found - out of range error in options container ";
+    handleErrorMessage(errorMessage, outOfRangeOptionException);
   }
   return DetectorType::kBarrel;
 }

--- a/src/Options/JPetOptionsTools/JPetOptionsTools.cpp
+++ b/src/Options/JPetOptionsTools/JPetOptionsTools.cpp
@@ -390,6 +390,12 @@ std::map<std::string, boost::any> createOptionsFromConfigFile(const std::string&
   return mapOptions;
 }
 
+void handleErrorMessage(const std::string& errorMessage, const std::out_of_range& outOfRangeException)
+{
+  std::cerr << errorMessage << outOfRangeException.what() << '\n';
+  ERROR(errorMessage);
+}
+
 FileTypeChecker::FileType FileTypeChecker::getInputFileType(const std::map<std::string, boost::any>& opts)
 {
   return getFileType(opts, "inputFileType_std::string");
@@ -398,12 +404,6 @@ FileTypeChecker::FileType FileTypeChecker::getInputFileType(const std::map<std::
 FileTypeChecker::FileType FileTypeChecker::getOutputFileType(const std::map<std::string, boost::any>& opts)
 {
   return getFileType(opts, "outputFileType_std::string");
-}
-
-void FileTypeChecker::handleErrorMessage(const std::string& errorMessage, const std::out_of_range& outOfRangeException)
-{
-  std::cerr << errorMessage << outOfRangeException.what() << '\n';
-  ERROR(errorMessage);
 }
 
 FileTypeChecker::FileType FileTypeChecker::getFileType(const std::map<std::string, boost::any>& opts, const std::string& fileTypeName)
@@ -418,7 +418,7 @@ FileTypeChecker::FileType FileTypeChecker::getFileType(const std::map<std::strin
     catch (const std::out_of_range& outOfRangeFileTypeException)
     {
       std::string errorMessage = "Provided file type option was not found - out of range in getFileType() ";
-      handleErrorMessage(errorMessage, outOfRangeOptionException);
+      handleErrorMessage(errorMessage, outOfRangeFileTypeException);
     }
   }
   catch (const std::out_of_range& outOfRangeOptionException)
@@ -453,7 +453,7 @@ DetectorTypeChecker::DetectorType DetectorTypeChecker::getDetectorType(const std
     catch (const std::out_of_range& outOfRangeDetectorTypeException)
     {
       std::string errorMessage = "Provided detector type option was not found - out of range in getDetectorType() ";
-      handleErrorMessage(errorMessage, outOfRangeOptionException);
+      handleErrorMessage(errorMessage, outOfRangeDetectorTypeException);
     }
   }
   catch (const std::out_of_range& outOfRangeOptionException)

--- a/src/Options/JPetOptionsTools/JPetOptionsTools.cpp
+++ b/src/Options/JPetOptionsTools/JPetOptionsTools.cpp
@@ -27,10 +27,6 @@ using boost::any_cast;
 
 namespace jpet_options_tools
 {
-
-std::map<std::string, FileTypeChecker::FileType> FileTypeChecker::fStringToFileType = {
-    {"", kNoType}, {"root", kRoot}, {"mcGeant", kMCGeant}, {"scope", kScope}, {"hld", kHld}, {"hldRoot", kHldRoot}, {"zip", kZip}};
-
 bool isOptionSet(const OptsStrAny& opts, const std::string& optionName) { return static_cast<bool>(opts.count(optionName)); }
 
 boost::any getOptionValue(const OptsStrAny& opts, const std::string& optionName) { return opts.at(optionName); }
@@ -396,24 +392,17 @@ void handleErrorMessage(const std::string& errorMessage, const std::out_of_range
   ERROR(errorMessage);
 }
 
-FileTypeChecker::FileType FileTypeChecker::getInputFileType(const std::map<std::string, boost::any>& opts)
+file_type_checker::FileType file_type_checker::getFileType(const std::map<std::string, boost::any>& opts, const std::string& fileTypeName)
 {
-  return getFileType(opts, "inputFileType_std::string");
-}
+  std::map<std::string, file_type_checker::FileType> fileTypeMap = {{"", kNoType}, {"root", kRoot},       {"mcGeant", kMCGeant}, {"scope", kScope},
+                                                                    {"hld", kHld}, {"hldRoot", kHldRoot}, {"zip", kZip}};
 
-FileTypeChecker::FileType FileTypeChecker::getOutputFileType(const std::map<std::string, boost::any>& opts)
-{
-  return getFileType(opts, "outputFileType_std::string");
-}
-
-FileTypeChecker::FileType FileTypeChecker::getFileType(const std::map<std::string, boost::any>& opts, const std::string& fileTypeName)
-{
   try
   {
     auto option = any_cast<std::string>(opts.at(fileTypeName));
     try
     {
-      return fStringToFileType.at(option);
+      return fileTypeMap.at(option);
     }
     catch (const std::out_of_range& outOfRangeFileTypeException)
     {
@@ -426,29 +415,35 @@ FileTypeChecker::FileType FileTypeChecker::getFileType(const std::map<std::strin
     std::string errorMessage = "Provided option was not found - out of range error in options container ";
     handleErrorMessage(errorMessage, outOfRangeOptionException);
   }
-  return FileType::kUndefinedFileType;
+  return file_type_checker::FileType::kUndefinedFileType;
 }
 
-/**
- * Map contains allowed strings for "-k" command line option and indicates what type
- * of detector is to be used.
- */
-std::map<std::string, DetectorTypeChecker::DetectorType> DetectorTypeChecker::fStringToDetectorType = {
-    {"bar", kBarrel}, {"barrel", kBarrel}, {"mod", kModular}, {"modular", kModular}};
+file_type_checker::FileType file_type_checker::getInputFileType(const std::map<std::string, boost::any>& opts)
+{
+  return file_type_checker::getFileType(opts, "inputFileType_std::string");
+}
+
+file_type_checker::FileType file_type_checker::getOutputFileType(const std::map<std::string, boost::any>& opts)
+{
+  return file_type_checker::getFileType(opts, "outputFileType_std::string");
+}
 
 /**
  * Method returns the detector type based on the provided options:
  * if the "-k" option for the is worng or not used, then by default
  * the detector type is the Big Barrel - kBarrel.
  */
-DetectorTypeChecker::DetectorType DetectorTypeChecker::getDetectorType(const std::map<std::string, boost::any>& opts)
+detector_type_checker::DetectorType detector_type_checker::getDetectorType(const std::map<std::string, boost::any>& opts)
 {
+  std::map<std::string, detector_type_checker::DetectorType> detectorTypeMap = {
+      {"bar", kBarrel}, {"barrel", kBarrel}, {"mod", kModular}, {"modular", kModular}};
+
   try
   {
     auto option = any_cast<std::string>(opts.at("detectorType_std::string"));
     try
     {
-      return fStringToDetectorType.at(option);
+      return detectorTypeMap.at(option);
     }
     catch (const std::out_of_range& outOfRangeDetectorTypeException)
     {
@@ -461,7 +456,7 @@ DetectorTypeChecker::DetectorType DetectorTypeChecker::getDetectorType(const std
     std::string errorMessage = "Provided option was not found - out of range error in options container ";
     handleErrorMessage(errorMessage, outOfRangeOptionException);
   }
-  return DetectorType::kBarrel;
+  return detector_type_checker::DetectorType::kBarrel;
 }
 
 } // namespace jpet_options_tools

--- a/src/ParametersTools/JPetParamManager/JPetParamManager.cpp
+++ b/src/ParametersTools/JPetParamManager/JPetParamManager.cpp
@@ -1,5 +1,5 @@
 /**
- *  @copyright Copyright 2020 The J-PET Framework Authors. All rights reserved.
+ *  @copyright Copyright 2021 The J-PET Framework Authors. All rights reserved.
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may find a copy of the License in the LICENCE file.
@@ -23,9 +23,11 @@
 std::shared_ptr<JPetParamManager> JPetParamManager::generateParamManager(const std::map<std::string, boost::any>& options)
 {
   using namespace jpet_options_tools;
-  if (isLocalDB(options)) {
+  if (isLocalDB(options))
+  {
     std::set<ParamObjectType> expectMissing;
-    if (FileTypeChecker::getInputFileType(options) == FileTypeChecker::kScope) {
+    if (file_type_checker::getInputFileType(options) == file_type_checker::kScope)
+    {
       expectMissing.insert(ParamObjectType::kTRB);
       expectMissing.insert(ParamObjectType::kFEB);
       expectMissing.insert(ParamObjectType::kFrame);
@@ -34,7 +36,8 @@ std::shared_ptr<JPetParamManager> JPetParamManager::generateParamManager(const s
       expectMissing.insert(ParamObjectType::kDataSource);
       expectMissing.insert(ParamObjectType::kDataModule);
     }
-    if (FileTypeChecker::getInputFileType(options) == FileTypeChecker::kMCGeant) {
+    if (file_type_checker::getInputFileType(options) == file_type_checker::kMCGeant)
+    {
       expectMissing.insert(ParamObjectType::kPM);
       expectMissing.insert(ParamObjectType::kPMCalib);
       expectMissing.insert(ParamObjectType::kFEB);
@@ -43,10 +46,10 @@ std::shared_ptr<JPetParamManager> JPetParamManager::generateParamManager(const s
       expectMissing.insert(ParamObjectType::kDataSource);
       expectMissing.insert(ParamObjectType::kDataModule);
     }
-    return std::make_shared<JPetParamManager>(
-      new JPetParamGetterAscii(getLocalDB(options)), expectMissing
-    );
-  } else {
+    return std::make_shared<JPetParamManager>(new JPetParamGetterAscii(getLocalDB(options)), expectMissing);
+  }
+  else
+  {
     ERROR("No local database file found.");
     return std::make_shared<JPetParamManager>();
   }
@@ -160,32 +163,25 @@ JPetTOMBChannelFactory& JPetParamManager::getTOMBChannelFactory(const int runID)
   return fTOMBChannelFactories.at(runID);
 }
 
-std::map<int, JPetDataSource*>& JPetParamManager::getDataSources(const int runID) {
-  return getDataSourceFactory(runID).getDataSources();
-}
+std::map<int, JPetDataSource*>& JPetParamManager::getDataSources(const int runID) { return getDataSourceFactory(runID).getDataSources(); }
 
 JPetDataSourceFactory& JPetParamManager::getDataSourceFactory(const int runID)
 {
-  if (fDataSourceFactories.count(runID) == 0) {
-    fDataSourceFactories.emplace(
-      std::piecewise_construct, std::forward_as_tuple(runID),
-      std::forward_as_tuple(*fParamGetter, runID)
-    );
+  if (fDataSourceFactories.count(runID) == 0)
+  {
+    fDataSourceFactories.emplace(std::piecewise_construct, std::forward_as_tuple(runID), std::forward_as_tuple(*fParamGetter, runID));
   }
   return fDataSourceFactories.at(runID);
 }
 
-std::map<int, JPetDataModule*>& JPetParamManager::getDataModules(const int runID) {
-  return getDataModuleFactory(runID).getDataModules();
-}
+std::map<int, JPetDataModule*>& JPetParamManager::getDataModules(const int runID) { return getDataModuleFactory(runID).getDataModules(); }
 
 JPetDataModuleFactory& JPetParamManager::getDataModuleFactory(const int runID)
 {
-  if (fDataModuleFactories.count(runID) == 0) {
-    fDataModuleFactories.emplace(
-      std::piecewise_construct, std::forward_as_tuple(runID),
-      std::forward_as_tuple(*fParamGetter, runID, getDataSourceFactory(runID))
-    );
+  if (fDataModuleFactories.count(runID) == 0)
+  {
+    fDataModuleFactories.emplace(std::piecewise_construct, std::forward_as_tuple(runID),
+                                 std::forward_as_tuple(*fParamGetter, runID, getDataSourceFactory(runID)));
   }
   return fDataModuleFactories.at(runID);
 }
@@ -279,21 +275,22 @@ void JPetParamManager::fillParameterBank(const int run)
     }
   }
 
-
-  if (!fExpectMissing.count(ParamObjectType::kDataSource)) {
-    for (auto& dataSourceElement : getDataSources(run)) {
+  if (!fExpectMissing.count(ParamObjectType::kDataSource))
+  {
+    for (auto& dataSourceElement : getDataSources(run))
+    {
       auto& dataSource = *dataSourceElement.second;
       fBank->addDataSource(dataSource);
     }
   }
 
-  if (!fExpectMissing.count(ParamObjectType::kDataModule)) {
-    for (auto& dataModuleElement : getDataModules(run)) {
+  if (!fExpectMissing.count(ParamObjectType::kDataModule))
+  {
+    for (auto& dataModuleElement : getDataModules(run))
+    {
       auto& dataModule = *dataModuleElement.second;
       fBank->addDataModule(dataModule);
-      fBank->getDataModule(dataModule.getID()).setDataSource(
-        fBank->getDataSource(dataModule.getDataSource().getID())
-      );
+      fBank->getDataModule(dataModule.getID()).setDataSource(fBank->getDataSource(dataModule.getDataSource().getID()));
     }
   }
 }

--- a/src/Tasks/JPetParamBankHandlerTask/JPetParamBankHandlerTask.cpp
+++ b/src/Tasks/JPetParamBankHandlerTask/JPetParamBankHandlerTask.cpp
@@ -1,5 +1,5 @@
 /**
- *  @copyright Copyright 2018 The J-PET Framework Authors. All rights reserved.
+ *  @copyright Copyright 2021 The J-PET Framework Authors. All rights reserved.
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may find a copy of the License in the LICENCE file.
@@ -32,35 +32,37 @@ JPetParamBankHandlerTask::JPetParamBankHandlerTask(const char* name) : JPetTask(
 bool JPetParamBankHandlerTask::init(const JPetParams& params)
 {
   using namespace jpet_options_tools;
+  using namespace file_type_checker;
+
   auto options = params.getOptions();
-  switch (FileTypeChecker::getInputFileType(options))
+  switch (file_type_checker::getInputFileType(options))
   {
-  case FileTypeChecker::FileType::kHld:
-  case FileTypeChecker::FileType::kHldRoot:
+  case FileType::kHld:
+  case FileType::kHldRoot:
     return generateParamBankFromConfig(params);
     break;
-  case FileTypeChecker::FileType::kRoot:
+  case FileType::kRoot:
     return generateParamBankFromRootFile(params);
     break;
-  case FileTypeChecker::FileType::kScope:
+  case FileType::kScope:
     return generateParamBankFromConfig(params);
     break;
-  case FileTypeChecker::FileType::kMCGeant:
+  case FileType::kMCGeant:
     return generateParamBankFromConfig(params);
     break;
   default:
-    std::map<FileTypeChecker::FileType, std::string> fileTypeToString = {{FileTypeChecker::kNoType, ""},         {FileTypeChecker::kRoot, "root"},
-                                                                         {FileTypeChecker::kScope, "scope"},     {FileTypeChecker::kHld, "hld"},
-                                                                         {FileTypeChecker::kHldRoot, "hldRoot"}, {FileTypeChecker::kZip, "zip"}};
-    WARNING("Unrecognized file format: " + fileTypeToString[FileTypeChecker::getInputFileType(options)] +
-            " but trying to generate ParamBank from file...");
+    std::map<FileType, std::string> fileTypeToString = {{kNoType, ""}, {kRoot, "root"},       {kScope, "scope"},
+                                                        {kHld, "hld"}, {kHldRoot, "hldRoot"}, {kZip, "zip"}};
+    WARNING("Unrecognized file format: " + fileTypeToString[getInputFileType(options)] + " but trying to generate ParamBank from file...");
     if (generateParamBankFromRootFile(params))
+    {
       return true;
+    }
     else
     {
       if (getRunNumber(options) != -1 && isLocalDB(options))
       {
-        WARNING("Error while tring generate ParamBank from file: " + fileTypeToString[FileTypeChecker::getInputFileType(options)] +
+        WARNING("Error while tring generate ParamBank from file: " + fileTypeToString[getInputFileType(options)] +
                 " but run number and localDB is set, trying to generate ParamBank from it...");
         return generateParamBankFromConfig(params);
       }

--- a/src/Tasks/JPetUnpackTask/JPetUnpackTask.cpp
+++ b/src/Tasks/JPetUnpackTask/JPetUnpackTask.cpp
@@ -49,8 +49,9 @@ bool JPetUnpackTask::init(const JPetParams& inParams)
     fEventsToProcess = getTotalEvents(fOptions);
   }
 
-  bool totCalibSet = false, tdcCalibSet = false;
-  if (totCalibSet = isOptionSet(fOptions, kTOTOffsetCalibKey))
+  bool totCalibSet = isOptionSet(fOptions, kTOTOffsetCalibKey);
+  bool tdcCalibSet = isOptionSet(fOptions, kTDCnonlinearityCalibKey);
+  if (totCalibSet)
   {
     fTOTOffsetCalibFile = getOptionAsString(fOptions, kTOTOffsetCalibKey);
   }
@@ -58,7 +59,7 @@ bool JPetUnpackTask::init(const JPetParams& inParams)
   {
     WARNING("No TOT offset calibration file set int the user options!");
   }
-  if (tdcCalibSet = isOptionSet(fOptions, kTDCnonlinearityCalibKey))
+  if (tdcCalibSet)
   {
     fTDCnonlinearityCalibFile = getOptionAsString(fOptions, kTDCnonlinearityCalibKey);
   }

--- a/src/Tasks/JPetUnpackTask/JPetUnpackTask.cpp
+++ b/src/Tasks/JPetUnpackTask/JPetUnpackTask.cpp
@@ -13,10 +13,10 @@
  *  @file JPetUnpackTask.cpp
  */
 
+#include "JPetUnpackTask/JPetUnpackTask.h"
+#include "JPetCommonTools/JPetCommonTools.h"
 #include "JPetOptionsGenerator/JPetOptionsGeneratorTools.h"
 #include "JPetOptionsTools/JPetOptionsTools.h"
-#include "JPetCommonTools/JPetCommonTools.h"
-#include "JPetUnpackTask/JPetUnpackTask.h"
 #include "JPetParams/JPetParams.h"
 #include <fstream>
 
@@ -31,69 +31,71 @@ bool JPetUnpackTask::init(const JPetParams& inParams)
   fOptions = inParams.getOptions();
 
   fInputFile = JPetCommonTools::extractFileNameFromFullPath(getInputFile(fOptions));
-  fInputFilePath = JPetCommonTools::appendSlashToPathIfAbsent(
-    JPetCommonTools::extractPathFromFile(getInputFile(fOptions))
-  );
+  fInputFilePath = JPetCommonTools::appendSlashToPathIfAbsent(JPetCommonTools::extractPathFromFile(getInputFile(fOptions)));
 
-  if (getOutputPath(fOptions) != "") {
+  if (getOutputPath(fOptions) != "")
+  {
     fOutputFilePath = JPetCommonTools::appendSlashToPathIfAbsent(getOutputPath(fOptions));
-  } else {
+  }
+  else
+  {
     fOutputFilePath = fInputFilePath;
   }
 
   fXMLConfFile = getUnpackerConfigFile(fOptions);
 
-  if (getTotalEvents(fOptions) > 0) {
+  if (getTotalEvents(fOptions) > 0)
+  {
     fEventsToProcess = getTotalEvents(fOptions);
   }
 
   bool totCalibSet = false, tdcCalibSet = false;
-  if (totCalibSet = isOptionSet(fOptions, kTOTOffsetCalibKey)) {
+  if (totCalibSet = isOptionSet(fOptions, kTOTOffsetCalibKey))
+  {
     fTOTOffsetCalibFile = getOptionAsString(fOptions, kTOTOffsetCalibKey);
-  } else {
+  }
+  else
+  {
     WARNING("No TOT offset calibration file set int the user options!");
   }
-  if (tdcCalibSet = isOptionSet(fOptions, kTDCnonlinearityCalibKey)) {
+  if (tdcCalibSet = isOptionSet(fOptions, kTDCnonlinearityCalibKey))
+  {
     fTDCnonlinearityCalibFile = getOptionAsString(fOptions, kTDCnonlinearityCalibKey);
-  } else {
+  }
+  else
+  {
     WARNING("No TDC nonlinearity file set int the user options!");
   }
 
-  return validateFiles(
-    fInputFilePath+fInputFile, fXMLConfFile, 
-    fTOTOffsetCalibFile, totCalibSet, fTDCnonlinearityCalibFile, tdcCalibSet
-  );
+  return validateFiles(fInputFilePath + fInputFile, fXMLConfFile, fTOTOffsetCalibFile, totCalibSet, fTDCnonlinearityCalibFile, tdcCalibSet);
 }
 
 bool JPetUnpackTask::run(const JPetDataInterface&)
 {
-  if (DetectorTypeChecker::getDetectorType(fOptions) == DetectorTypeChecker::DetectorType::kBarrel) {
+  if (DetectorTypeChecker::getDetectorType(fOptions) == DetectorTypeChecker::DetectorType::kBarrel)
+  {
 
     int refChannelOffset = 65;
     fUnpacker2 = new Unpacker2();
 
     INFO(Form("Using Unpacker2 to process first %i events", fEventsToProcess));
 
-    fUnpacker2->UnpackSingleStep(
-      fInputFile, fInputFilePath, fOutputFilePath,
-      fXMLConfFile, fEventsToProcess, refChannelOffset,
-      fTOTOffsetCalibFile, fTDCnonlinearityCalibFile
-    );
-
-  } else if (DetectorTypeChecker::getDetectorType(fOptions) == DetectorTypeChecker::DetectorType::kModular) {
+    fUnpacker2->UnpackSingleStep(fInputFile, fInputFilePath, fOutputFilePath, fXMLConfFile, fEventsToProcess, refChannelOffset, fTOTOffsetCalibFile,
+                                 fTDCnonlinearityCalibFile);
+  }
+  else if (DetectorTypeChecker::getDetectorType(fOptions) == DetectorTypeChecker::DetectorType::kModular)
+  {
 
     int refChannelOffset = 105;
     fUnpacker2D = new Unpacker2D();
 
     INFO(Form("Using Unpacker2D to process first %i events", fEventsToProcess));
 
-    fUnpacker2D->UnpackSingleStep(
-      fInputFile, fInputFilePath, fOutputFilePath,
-      fXMLConfFile, fEventsToProcess, refChannelOffset,
-      fTDCnonlinearityCalibFile
-    );
-
-  } else {
+    fUnpacker2D->UnpackSingleStep(fInputFile, fInputFilePath, fOutputFilePath, fXMLConfFile, fEventsToProcess, refChannelOffset,
+                                  fTDCnonlinearityCalibFile);
+  }
+  else
+  {
     return false;
   }
   return true;
@@ -101,21 +103,20 @@ bool JPetUnpackTask::run(const JPetDataInterface&)
 
 bool JPetUnpackTask::terminate(JPetParams& outParams)
 {
-  if (fUnpacker2) {
+  if (fUnpacker2)
+  {
     delete fUnpacker2;
     fUnpacker2 = 0;
   }
-  if (fUnpacker2D) {
+  if (fUnpacker2D)
+  {
     delete fUnpacker2D;
     fUnpacker2D = 0;
   }
 
   OptsStrAny new_opts;
   jpet_options_generator_tools::setOutputFileType(new_opts, "hldRoot");
-  jpet_options_generator_tools::setOutputFile(
-    new_opts,
-    JPetCommonTools::replaceDataTypeInFileName(getInputFile(fOptions), "hld")
-  );
+  jpet_options_generator_tools::setOutputFile(new_opts, JPetCommonTools::replaceDataTypeInFileName(getInputFile(fOptions), "hld"));
   jpet_options_generator_tools::setOutputPath(new_opts, getOutputPath(fOptions));
   outParams = JPetParams(new_opts, outParams.getParamManagerAsShared());
   INFO("UnpackTask finished.");
@@ -123,29 +124,33 @@ bool JPetUnpackTask::terminate(JPetParams& outParams)
   return true;
 }
 
-bool JPetUnpackTask::validateFiles(
-  string fileNameWithPath, string xmlConfig,
-  string totCalib, bool totCalibSet, string tdcCalib, bool tdcCalibSet
-){
-  if(!boost::filesystem::exists(fileNameWithPath)) {
+bool JPetUnpackTask::validateFiles(string fileNameWithPath, string xmlConfig, string totCalib, bool totCalibSet, string tdcCalib, bool tdcCalibSet)
+{
+  if (!boost::filesystem::exists(fileNameWithPath))
+  {
     ERROR(Form("No input HLD file found: %s", fileNameWithPath.c_str()));
     return false;
   }
 
-  if (!boost::filesystem::exists(xmlConfig)) {
+  if (!boost::filesystem::exists(xmlConfig))
+  {
     ERROR(Form("No XML configuration file found: %s", xmlConfig.c_str()));
     return false;
   }
 
-  if(totCalibSet) {
-    if(!boost::filesystem::exists(totCalib)){
+  if (totCalibSet)
+  {
+    if (!boost::filesystem::exists(totCalib))
+    {
       ERROR(Form("No TOT offset calibration file found: %s", totCalib.c_str()));
       return false;
     }
   }
 
-  if(tdcCalibSet){
-    if(!boost::filesystem::exists(tdcCalib)){
+  if (tdcCalibSet)
+  {
+    if (!boost::filesystem::exists(tdcCalib))
+    {
       ERROR(Form("No TDC nonlinearity file found: %s", tdcCalib.c_str()));
       return false;
     }

--- a/src/Tasks/JPetUnpackTask/JPetUnpackTask.cpp
+++ b/src/Tasks/JPetUnpackTask/JPetUnpackTask.cpp
@@ -77,23 +77,23 @@ bool JPetUnpackTask::run(const JPetDataInterface&)
   {
 
     int refChannelOffset = 65;
-    fUnpacker2 = new Unpacker2();
+    Unpacker2 unpacker2;
 
     INFO(Form("Using Unpacker2 to process first %i events", fEventsToProcess));
 
-    fUnpacker2->UnpackSingleStep(fInputFile, fInputFilePath, fOutputFilePath, fXMLConfFile, fEventsToProcess, refChannelOffset, fTOTOffsetCalibFile,
-                                 fTDCnonlinearityCalibFile);
+    unpacker2.UnpackSingleStep(fInputFile, fInputFilePath, fOutputFilePath, fXMLConfFile, fEventsToProcess, refChannelOffset, fTOTOffsetCalibFile,
+                               fTDCnonlinearityCalibFile);
   }
   else if (DetectorTypeChecker::getDetectorType(fOptions) == DetectorTypeChecker::DetectorType::kModular)
   {
 
     int refChannelOffset = 105;
-    fUnpacker2D = new Unpacker2D();
+    Unpacker2D unpacker2D;
 
     INFO(Form("Using Unpacker2D to process first %i events", fEventsToProcess));
 
-    fUnpacker2D->UnpackSingleStep(fInputFile, fInputFilePath, fOutputFilePath, fXMLConfFile, fEventsToProcess, refChannelOffset,
-                                  fTDCnonlinearityCalibFile);
+    unpacker2D.UnpackSingleStep(fInputFile, fInputFilePath, fOutputFilePath, fXMLConfFile, fEventsToProcess, refChannelOffset,
+                                fTDCnonlinearityCalibFile);
   }
   else
   {
@@ -104,17 +104,6 @@ bool JPetUnpackTask::run(const JPetDataInterface&)
 
 bool JPetUnpackTask::terminate(JPetParams& outParams)
 {
-  if (fUnpacker2)
-  {
-    delete fUnpacker2;
-    fUnpacker2 = 0;
-  }
-  if (fUnpacker2D)
-  {
-    delete fUnpacker2D;
-    fUnpacker2D = 0;
-  }
-
   OptsStrAny new_opts;
   jpet_options_generator_tools::setOutputFileType(new_opts, "hldRoot");
   jpet_options_generator_tools::setOutputFile(new_opts, JPetCommonTools::replaceDataTypeInFileName(getInputFile(fOptions), "hld"));

--- a/src/Tasks/JPetUnpackTask/JPetUnpackTask.cpp
+++ b/src/Tasks/JPetUnpackTask/JPetUnpackTask.cpp
@@ -73,7 +73,7 @@ bool JPetUnpackTask::init(const JPetParams& inParams)
 
 bool JPetUnpackTask::run(const JPetDataInterface&)
 {
-  if (DetectorTypeChecker::getDetectorType(fOptions) == DetectorTypeChecker::DetectorType::kBarrel)
+  if (detector_type_checker::getDetectorType(fOptions) == detector_type_checker::DetectorType::kBarrel)
   {
 
     int refChannelOffset = 65;
@@ -84,7 +84,7 @@ bool JPetUnpackTask::run(const JPetDataInterface&)
     unpacker2.UnpackSingleStep(fInputFile, fInputFilePath, fOutputFilePath, fXMLConfFile, fEventsToProcess, refChannelOffset, fTOTOffsetCalibFile,
                                fTDCnonlinearityCalibFile);
   }
-  else if (DetectorTypeChecker::getDetectorType(fOptions) == DetectorTypeChecker::DetectorType::kModular)
+  else if (detector_type_checker::getDetectorType(fOptions) == detector_type_checker::DetectorType::kModular)
   {
 
     int refChannelOffset = 105;

--- a/tests/Core/JPetCmdParser/JPetCmdParserTest.cpp
+++ b/tests/Core/JPetCmdParser/JPetCmdParserTest.cpp
@@ -28,7 +28,7 @@ using namespace std;
 BOOST_AUTO_TEST_SUITE(FirstSuite)
 BOOST_AUTO_TEST_CASE(testCmd)
 {
-  auto cmdLine = "main.x -t hld -f unitTestData/JPetCmdParserTest/testfile.hld -i 10";
+  auto cmdLine = "main.x -t hld -f unitTestData/JPetCmdParserTest/testfile.hld -i 10 -k barrel";
   auto args_char = JPetCommonTools::createArgs(cmdLine);
   auto argc = args_char.size();
   auto argv = args_char.data();
@@ -36,17 +36,19 @@ BOOST_AUTO_TEST_CASE(testCmd)
   auto result = parser.parseCmdLineArgs(argc, const_cast<const char**>(argv));
   BOOST_REQUIRE(result.find("type") != result.end());
   BOOST_REQUIRE_EQUAL(any_cast<std::string>(result.at("type").value()), "hld");
-  BOOST_REQUIRE(result.find("runId") != result.end());
-  BOOST_REQUIRE_EQUAL(any_cast<int>(result.at("runId").value()), 10);
+  BOOST_REQUIRE(result.find("runID") != result.end());
+  BOOST_REQUIRE_EQUAL(any_cast<int>(result.at("runID").value()), 10);
+  BOOST_REQUIRE(result.find("detector") != result.end());
+  BOOST_REQUIRE_EQUAL(any_cast<std::string>(result.at("detector").value()), "barrel");
   BOOST_REQUIRE(result.find("file") != result.end());
-  auto vectOfFiles = any_cast<std::vector<std::string>>(result.at("file").value());
+  auto vectOfFiles =  any_cast<std::vector<std::string>>(result.at("file").value());
   BOOST_REQUIRE_EQUAL(vectOfFiles.size(), 1u);
   BOOST_REQUIRE_EQUAL(vectOfFiles.at(0), "unitTestData/JPetCmdParserTest/testfile.hld");
 }
 
 BOOST_AUTO_TEST_CASE(testCmd2)
 {
-  auto cmdLine = "main.x -t hld -f unitTestData/JPetCmdParserTest/testfile.hld unitTestData/JPetCmdParserTest/testfile2.hld -i 10";
+  auto cmdLine = "main.x -t hld -f unitTestData/JPetCmdParserTest/testfile.hld unitTestData/JPetCmdParserTest/testfile2.hld -i 10 -k modular";
   auto args_char = JPetCommonTools::createArgs(cmdLine);
   auto argc = args_char.size();
   auto argv = args_char.data();
@@ -54,10 +56,12 @@ BOOST_AUTO_TEST_CASE(testCmd2)
   auto result = parser.parseCmdLineArgs(argc, const_cast<const char**>(argv));
   BOOST_REQUIRE(result.find("type") != result.end());
   BOOST_REQUIRE_EQUAL(any_cast<std::string>(result.at("type").value()), "hld");
-  BOOST_REQUIRE(result.find("runId") != result.end());
-  BOOST_REQUIRE_EQUAL(any_cast<int>(result.at("runId").value()), 10);
+  BOOST_REQUIRE(result.find("runID") != result.end());
+  BOOST_REQUIRE_EQUAL(any_cast<int>(result.at("runID").value()), 10);
+  BOOST_REQUIRE(result.find("detector") != result.end());
+  BOOST_REQUIRE_EQUAL(any_cast<std::string>(result.at("detector").value()), "modular");
   BOOST_REQUIRE(result.find("file") != result.end());
-  auto vectOfFiles = any_cast<std::vector<std::string>>(result.at("file").value());
+  auto vectOfFiles =  any_cast<std::vector<std::string>>(result.at("file").value());
   BOOST_REQUIRE_EQUAL(vectOfFiles.size(), 2u);
   BOOST_REQUIRE_EQUAL(vectOfFiles.at(0), "unitTestData/JPetCmdParserTest/testfile.hld");
   BOOST_REQUIRE_EQUAL(vectOfFiles.at(1), "unitTestData/JPetCmdParserTest/testfile2.hld");
@@ -110,7 +114,7 @@ BOOST_AUTO_TEST_CASE(testCmd4)
   BOOST_REQUIRE(result.find("unpackerCalibFile") != result.end());
   BOOST_REQUIRE_EQUAL(any_cast<std::string>(result.at("unpackerCalibFile").value()), "unitTestData/JPetUnpackerTest/calib.root");
 
-  BOOST_REQUIRE_EQUAL(any_cast<int>(result.at("runId").value()), 231);
+  BOOST_REQUIRE_EQUAL(any_cast<int>(result.at("runID").value()), 231);
   BOOST_REQUIRE(result.find("file") != result.end());
 
   BOOST_REQUIRE(result.find("localDBCreate") != result.end());

--- a/tests/Core/JPetCmdParser/JPetCmdParserTest.cpp
+++ b/tests/Core/JPetCmdParser/JPetCmdParserTest.cpp
@@ -41,7 +41,7 @@ BOOST_AUTO_TEST_CASE(testCmd)
   BOOST_REQUIRE(result.find("detector") != result.end());
   BOOST_REQUIRE_EQUAL(any_cast<std::string>(result.at("detector").value()), "barrel");
   BOOST_REQUIRE(result.find("file") != result.end());
-  auto vectOfFiles =  any_cast<std::vector<std::string>>(result.at("file").value());
+  auto vectOfFiles = any_cast<std::vector<std::string>>(result.at("file").value());
   BOOST_REQUIRE_EQUAL(vectOfFiles.size(), 1u);
   BOOST_REQUIRE_EQUAL(vectOfFiles.at(0), "unitTestData/JPetCmdParserTest/testfile.hld");
 }
@@ -61,7 +61,7 @@ BOOST_AUTO_TEST_CASE(testCmd2)
   BOOST_REQUIRE(result.find("detector") != result.end());
   BOOST_REQUIRE_EQUAL(any_cast<std::string>(result.at("detector").value()), "modular");
   BOOST_REQUIRE(result.find("file") != result.end());
-  auto vectOfFiles =  any_cast<std::vector<std::string>>(result.at("file").value());
+  auto vectOfFiles = any_cast<std::vector<std::string>>(result.at("file").value());
   BOOST_REQUIRE_EQUAL(vectOfFiles.size(), 2u);
   BOOST_REQUIRE_EQUAL(vectOfFiles.at(0), "unitTestData/JPetCmdParserTest/testfile.hld");
   BOOST_REQUIRE_EQUAL(vectOfFiles.at(1), "unitTestData/JPetCmdParserTest/testfile2.hld");

--- a/tests/Options/JPetOptionValidator/JPetOptionValidatorTest.cpp
+++ b/tests/Options/JPetOptionValidator/JPetOptionValidatorTest.cpp
@@ -62,8 +62,7 @@ BOOST_AUTO_TEST_CASE(wrongOptions)
       {"localDB_std::string", std::string("ble/ble/ble.hld")},
       {"outputPath_std::string", std::string("ble/ble/ble")},
       {"runID_int", -1},
-      {"detectorType_std::string", std::string("squirrel")}
-  };
+      {"detectorType_std::string", std::string("squirrel")}};
   BOOST_REQUIRE_EQUAL(JPetOptionValidator::isRangeOfEventsValid(std::make_pair("range_std::vector<int>", options.at("range_std::vector<int>"))),
                       false);
   BOOST_REQUIRE_EQUAL(
@@ -72,7 +71,8 @@ BOOST_AUTO_TEST_CASE(wrongOptions)
                       false);
   BOOST_REQUIRE_EQUAL(JPetOptionValidator::isLocalDBValid(std::make_pair("localDB_std::string", options.at("localDB_std::string"))), false);
   BOOST_REQUIRE_EQUAL(JPetOptionValidator::isRunIDValid(std::make_pair("runID_int", options.at("runID_int"))), false);
-  BOOST_REQUIRE_EQUAL(JPetOptionValidator::isDetectorValid(std::make_pair("detectorType_std::string", options.at("detectorType_std::string"))), false);
+  BOOST_REQUIRE_EQUAL(JPetOptionValidator::isDetectorValid(std::make_pair("detectorType_std::string", options.at("detectorType_std::string"))),
+                      false);
   BOOST_REQUIRE_EQUAL(
       JPetOptionValidator::areFilesValid(std::make_pair("file_std::vector<std::string>", options.at("file_std::vector<std::string>"))), false);
   BOOST_REQUIRE_EQUAL(JPetOptionValidator::isCorrectFileType(std::make_pair("type_std::string", options.at("type_std::string"))), false);
@@ -89,15 +89,13 @@ BOOST_AUTO_TEST_CASE(areCorrectAllOptionsWork)
 {
   std::vector<int> range = {1, 2};
   std::vector<std::string> files = {"unitTestData/JPetCmdParserTest/data.hld", "unitTestData/JPetCmdParserTest/data.hld"};
-  std::map<std::string, boost::any> options = {
-      {"range_std::vector<int>", range},
-      {"type_std::string", std::string("hld")},
-      {"file_std::vector<std::string>", files},
-      {"localDB_std::string", std::string("unitTestData/JPetCmdParserTest/data.hld")},
-      {"outputPath_std::string", std::string("unitTestData/JPetCmdParserTest")},
-      {"runID_int", 3},
-      {"detectorType_std::string", std::string("barrel")}
-  };
+  std::map<std::string, boost::any> options = {{"range_std::vector<int>", range},
+                                               {"type_std::string", std::string("hld")},
+                                               {"file_std::vector<std::string>", files},
+                                               {"localDB_std::string", std::string("unitTestData/JPetCmdParserTest/data.hld")},
+                                               {"outputPath_std::string", std::string("unitTestData/JPetCmdParserTest")},
+                                               {"runID_int", 3},
+                                               {"detectorType_std::string", std::string("barrel")}};
   JPetOptionValidator validator;
   std::vector<std::string> v;
   for (auto& opt : options)

--- a/tests/Options/JPetOptionValidator/JPetOptionValidatorTest.cpp
+++ b/tests/Options/JPetOptionValidator/JPetOptionValidatorTest.cpp
@@ -1,5 +1,5 @@
 /**
- *  @copyright Copyright 2018 The J-PET Framework Authors. All rights reserved.
+ *  @copyright Copyright 2021 The J-PET Framework Authors. All rights reserved.
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may find a copy of the License in the LICENCE file.
@@ -36,12 +36,12 @@ BOOST_AUTO_TEST_CASE(correctOptions)
       {"type_std::string, file_std::vector<std::string>", JPetOptionValidator::ManyOptionsWrapper({std::string("hld"), files})},
       {"localDB_std::string", std::string("unitTestData/JPetCmdParserTest/data.hld")},
       {"outputPath_std::string", std::string("unitTestData/JPetCmdParserTest")},
-      {"runId_int", 3},
+      {"runID_int", 3},
   };
 
   BOOST_REQUIRE(JPetOptionValidator::isOutputDirectoryValid(std::make_pair("outputPath_std::string", options.at("outputPath_std::string"))));
   BOOST_REQUIRE(JPetOptionValidator::isLocalDBValid(std::make_pair("localDB_std::string", options.at("localDB_std::string"))));
-  BOOST_REQUIRE(JPetOptionValidator::isRunIdValid(std::make_pair("runId_int", options.at("runId_int"))));
+  BOOST_REQUIRE(JPetOptionValidator::isRunIDValid(std::make_pair("runID_int", options.at("runID_int"))));
   BOOST_REQUIRE(JPetOptionValidator::areFilesValid(std::make_pair("file_std::vector<std::string>", options.at("file_std::vector<std::string>"))));
   BOOST_REQUIRE(JPetOptionValidator::isCorrectFileType(std::make_pair("type_std::string", options.at("type_std::string"))));
   BOOST_REQUIRE(JPetOptionValidator::isFileTypeMatchingExtensions(
@@ -61,7 +61,8 @@ BOOST_AUTO_TEST_CASE(wrongOptions)
       {"type_std::string, file_std::vector<std::string>", JPetOptionValidator::ManyOptionsWrapper({std::string("tdt"), wrongFiles})},
       {"localDB_std::string", std::string("ble/ble/ble.hld")},
       {"outputPath_std::string", std::string("ble/ble/ble")},
-      {"runId_int", -1},
+      {"runID_int", -1},
+      {"detectorType_std::string", std::string("squirrel")}
   };
   BOOST_REQUIRE_EQUAL(JPetOptionValidator::isRangeOfEventsValid(std::make_pair("range_std::vector<int>", options.at("range_std::vector<int>"))),
                       false);
@@ -70,7 +71,8 @@ BOOST_AUTO_TEST_CASE(wrongOptions)
   BOOST_REQUIRE_EQUAL(JPetOptionValidator::isOutputDirectoryValid(std::make_pair("outputPath_std::string", options.at("outputPath_std::string"))),
                       false);
   BOOST_REQUIRE_EQUAL(JPetOptionValidator::isLocalDBValid(std::make_pair("localDB_std::string", options.at("localDB_std::string"))), false);
-  BOOST_REQUIRE_EQUAL(JPetOptionValidator::isRunIdValid(std::make_pair("runId_int", options.at("runId_int"))), false);
+  BOOST_REQUIRE_EQUAL(JPetOptionValidator::isRunIDValid(std::make_pair("runID_int", options.at("runID_int"))), false);
+  BOOST_REQUIRE_EQUAL(JPetOptionValidator::isDetectorValid(std::make_pair("detectorType_std::string", options.at("detectorType_std::string"))), false);
   BOOST_REQUIRE_EQUAL(
       JPetOptionValidator::areFilesValid(std::make_pair("file_std::vector<std::string>", options.at("file_std::vector<std::string>"))), false);
   BOOST_REQUIRE_EQUAL(JPetOptionValidator::isCorrectFileType(std::make_pair("type_std::string", options.at("type_std::string"))), false);
@@ -93,7 +95,8 @@ BOOST_AUTO_TEST_CASE(areCorrectAllOptionsWork)
       {"file_std::vector<std::string>", files},
       {"localDB_std::string", std::string("unitTestData/JPetCmdParserTest/data.hld")},
       {"outputPath_std::string", std::string("unitTestData/JPetCmdParserTest")},
-      {"runId_int", 3},
+      {"runID_int", 3},
+      {"detectorType_std::string", std::string("barrel")}
   };
   JPetOptionValidator validator;
   std::vector<std::string> v;
@@ -113,7 +116,7 @@ BOOST_AUTO_TEST_CASE(areCorrectSomeOptionsWork)
       {"range_std::vector<int>", range},
       {"type_std::string", std::string("hld")},
       {"localDB_std::string", std::string("unitTestData/JPetCmdParserTest/data.hld")},
-      {"runId_int", 3},
+      {"runID_int", 3},
   };
 
   JPetOptionValidator validator;

--- a/tests/Options/JPetOptionsGenerator/JPetOptionsGeneratorTest.cpp
+++ b/tests/Options/JPetOptionsGenerator/JPetOptionsGeneratorTest.cpp
@@ -1,5 +1,5 @@
 /**
- *  @copyright Copyright 2018 The J-PET Framework Authors. All rights reserved.
+ *  @copyright Copyright 2021 The J-PET Framework Authors. All rights reserved.
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may find a copy of the License in the LICENCE file.
@@ -71,7 +71,7 @@ BOOST_AUTO_TEST_CASE(generateOptions_oneFileOneTask)
   auto opts = it->second;
   BOOST_REQUIRE_EQUAL(getRunNumber(opts), 231);
   BOOST_REQUIRE_EQUAL(getInputFile(opts), "unitTestData/JPetOptionsGeneratorTest/infile.root");
-  BOOST_REQUIRE_EQUAL(FileTypeChecker::getInputFileType(opts), FileTypeChecker::kRoot);
+  BOOST_REQUIRE_EQUAL(file_type_checker::getInputFileType(opts), file_type_checker::FileType::kRoot);
 }
 
 BOOST_AUTO_TEST_CASE(generateOptions_oneFileTwoTasks)
@@ -99,7 +99,7 @@ BOOST_AUTO_TEST_CASE(generateOptions_TwoFilesOneTasks)
   auto opts = it->second;
   BOOST_REQUIRE_EQUAL(getRunNumber(opts), 231);
   BOOST_REQUIRE_EQUAL(getInputFile(opts), "unitTestData/JPetOptionsGeneratorTest/infile.root");
-  BOOST_REQUIRE_EQUAL(FileTypeChecker::getInputFileType(opts), FileTypeChecker::kRoot);
+  BOOST_REQUIRE_EQUAL(file_type_checker::getInputFileType(opts), file_type_checker::FileType::kRoot);
   BOOST_REQUIRE_EQUAL(getFirstEvent(opts), -1);
   BOOST_REQUIRE_EQUAL(getLastEvent(opts), -1);
   BOOST_REQUIRE(!isProgressBar(opts));
@@ -110,7 +110,7 @@ BOOST_AUTO_TEST_CASE(generateOptions_TwoFilesOneTasks)
   opts = it->second;
   BOOST_REQUIRE_EQUAL(getRunNumber(opts), 231);
   BOOST_REQUIRE_EQUAL(getInputFile(opts), "unitTestData/JPetOptionsGeneratorTest/infile2.root");
-  BOOST_REQUIRE_EQUAL(FileTypeChecker::getInputFileType(opts), FileTypeChecker::kRoot);
+  BOOST_REQUIRE_EQUAL(file_type_checker::getInputFileType(opts), file_type_checker::FileType::kRoot);
   BOOST_REQUIRE_EQUAL(getFirstEvent(opts), -1);
   BOOST_REQUIRE_EQUAL(getLastEvent(opts), -1);
   BOOST_REQUIRE(!isProgressBar(opts));
@@ -132,7 +132,7 @@ BOOST_AUTO_TEST_CASE(generateOptions_oneFileTwoTasksWithOutput)
   auto opts = it->second;
   BOOST_REQUIRE_EQUAL(getRunNumber(opts), 231);
   BOOST_REQUIRE_EQUAL(getInputFile(opts), "unitTestData/JPetOptionsGeneratorTest/infile.root");
-  BOOST_REQUIRE_EQUAL(FileTypeChecker::getInputFileType(opts), FileTypeChecker::kRoot);
+  BOOST_REQUIRE_EQUAL(file_type_checker::getInputFileType(opts), file_type_checker::FileType::kRoot);
   BOOST_REQUIRE_EQUAL(getOutputPath(opts), "unitTestData/JPetCmdParserTest/");
   BOOST_REQUIRE_EQUAL(getFirstEvent(opts), 2);
   BOOST_REQUIRE_EQUAL(getLastEvent(opts), 100);
@@ -158,7 +158,7 @@ BOOST_AUTO_TEST_CASE(generateOptions_TestWithUserOptions)
   BOOST_REQUIRE_EQUAL(getRunNumber(opts), 231);
   BOOST_REQUIRE_EQUAL(getInputFiles(opts).size(), 1);
   BOOST_REQUIRE_EQUAL(getInputFiles(opts).at(0), "unitTestData/JPetOptionsGeneratorTest/infile.root");
-  BOOST_REQUIRE_EQUAL(FileTypeChecker::getInputFileType(opts), FileTypeChecker::kRoot);
+  BOOST_REQUIRE_EQUAL(file_type_checker::getInputFileType(opts), file_type_checker::FileType::kRoot);
   BOOST_REQUIRE_EQUAL(getFirstEvent(opts), -1);
   BOOST_REQUIRE_EQUAL(getLastEvent(opts), -1);
   BOOST_REQUIRE(!isProgressBar(opts));
@@ -189,7 +189,7 @@ BOOST_AUTO_TEST_CASE(ScopeOptions)
   BOOST_REQUIRE_EQUAL(getInputFile(opts), "unitTestData/JPetScopeLoaderTest/test_file_test_0");
   BOOST_REQUIRE_EQUAL(getScopeConfigFile(opts), "unitTestData/JPetScopeLoaderTest/test_file.json");
   BOOST_REQUIRE_EQUAL(getScopeInputDirectory(opts), "unitTestData/JPetScopeLoaderTest/scope_files/0");
-  BOOST_REQUIRE_EQUAL(FileTypeChecker::getInputFileType(opts), FileTypeChecker::kScope);
+  BOOST_REQUIRE_EQUAL(file_type_checker::getInputFileType(opts), file_type_checker::FileType::kScope);
   BOOST_REQUIRE_EQUAL(getFirstEvent(opts), -1);
   BOOST_REQUIRE_EQUAL(getLastEvent(opts), -1);
   BOOST_REQUIRE(!isProgressBar(opts));
@@ -214,7 +214,7 @@ BOOST_AUTO_TEST_CASE(generateAndValidateOptions_Test)
   BOOST_REQUIRE_EQUAL(getRunNumber(result), 231);
   BOOST_REQUIRE_EQUAL(getInputFiles(result).size(), 1);
   BOOST_REQUIRE_EQUAL(getInputFiles(result).at(0), "unitTestData/JPetOptionsGeneratorTest/infile.root");
-  BOOST_REQUIRE_EQUAL(FileTypeChecker::getInputFileType(result), FileTypeChecker::kRoot);
+  BOOST_REQUIRE_EQUAL(file_type_checker::getInputFileType(result), file_type_checker::FileType::kRoot);
   BOOST_REQUIRE_EQUAL(getFirstEvent(result), -1);
   BOOST_REQUIRE_EQUAL(getLastEvent(result), -1);
   BOOST_REQUIRE(!isProgressBar(result));
@@ -233,7 +233,7 @@ BOOST_AUTO_TEST_CASE(generateAndValidateOptions_TestWithUserOptions)
   BOOST_REQUIRE_EQUAL(getRunNumber(result), 231);
   BOOST_REQUIRE_EQUAL(getInputFiles(result).size(), 1);
   BOOST_REQUIRE_EQUAL(getInputFiles(result).at(0), "unitTestData/JPetOptionsGeneratorTest/infile.root");
-  BOOST_REQUIRE_EQUAL(FileTypeChecker::getInputFileType(result), FileTypeChecker::kRoot);
+  BOOST_REQUIRE_EQUAL(file_type_checker::getInputFileType(result), file_type_checker::FileType::kRoot);
   BOOST_REQUIRE_EQUAL(getFirstEvent(result), -1);
   BOOST_REQUIRE_EQUAL(getLastEvent(result), -1);
   BOOST_REQUIRE(!isProgressBar(result));
@@ -251,9 +251,10 @@ BOOST_AUTO_TEST_CASE(generateAndValidateOptions_TestWithUserOptions)
 BOOST_AUTO_TEST_CASE(generateAndValidateOptions_TestBooleanOptions_Unset)
 {
   JPetOptionsGenerator generator;
-  auto commandLine = "main.x -i 231 -f unitTestData/JPetOptionsGeneratorTest/infile.root -t root" ;
-  auto inArgs =  getCmdLineArgs(commandLine);
-  auto result = generator.generateAndValidateOptions(inArgs); BOOST_REQUIRE(!result.empty());
+  auto commandLine = "main.x -i 231 -f unitTestData/JPetOptionsGeneratorTest/infile.root -t root";
+  auto inArgs = getCmdLineArgs(commandLine);
+  auto result = generator.generateAndValidateOptions(inArgs);
+  BOOST_REQUIRE(!result.empty());
   BOOST_REQUIRE_EQUAL(isProgressBar(result), false);
   BOOST_REQUIRE_EQUAL(isDirectProcessing(result), false);
 }
@@ -261,8 +262,8 @@ BOOST_AUTO_TEST_CASE(generateAndValidateOptions_TestBooleanOptions_Unset)
 BOOST_AUTO_TEST_CASE(generateAndValidateOptions_TestBooleanOptions_Set)
 {
   JPetOptionsGenerator generator;
-  auto commandLine = "main.x -i 231 -f unitTestData/JPetOptionsGeneratorTest/infile.root -t root -b -d" ;
-  auto inArgs =  getCmdLineArgs(commandLine);
+  auto commandLine = "main.x -i 231 -f unitTestData/JPetOptionsGeneratorTest/infile.root -t root -b -d";
+  auto inArgs = getCmdLineArgs(commandLine);
   auto result = generator.generateAndValidateOptions(inArgs);
   BOOST_REQUIRE(!result.empty());
   BOOST_REQUIRE_EQUAL(isProgressBar(result), true);
@@ -289,7 +290,7 @@ BOOST_FIXTURE_TEST_CASE(generateAndValidateOptions_roothld, MyFixture)
   BOOST_REQUIRE_EQUAL(getRunNumber(result), -1);
   BOOST_REQUIRE_EQUAL(getInputFiles(result).size(), 1);
   BOOST_REQUIRE_EQUAL(getInputFiles(result).at(0), "dabc_17025151847.hld.root");
-  BOOST_REQUIRE_EQUAL(FileTypeChecker::getInputFileType(result), FileTypeChecker::kHldRoot);
+  BOOST_REQUIRE_EQUAL(file_type_checker::getInputFileType(result), file_type_checker::FileType::kHldRoot);
   BOOST_REQUIRE_EQUAL(getFirstEvent(result), -1);
   BOOST_REQUIRE_EQUAL(getLastEvent(result), -1);
   BOOST_REQUIRE(!isProgressBar(result));

--- a/tests/Options/JPetOptionsGenerator/JPetOptionsGeneratorToolsTest.cpp
+++ b/tests/Options/JPetOptionsGenerator/JPetOptionsGeneratorToolsTest.cpp
@@ -169,7 +169,7 @@ BOOST_AUTO_TEST_CASE(generateOptionsForTask_hldRoot_after_hld)
   std::map<std::string, boost::any> controlSettings = {{"outputFileType_std::string", std::string("hldRoot")}};
   auto resultsOpt = generateOptionsForTask(inOpts, controlSettings);
   BOOST_REQUIRE(isOptionSet(resultsOpt, "inputFileType_std::string"));
-  BOOST_REQUIRE_EQUAL(FileTypeChecker::getInputFileType(resultsOpt), FileTypeChecker::kHldRoot);
+  BOOST_REQUIRE_EQUAL(file_type_checker::getInputFileType(resultsOpt), file_type_checker::FileType::kHldRoot);
 }
 
 BOOST_AUTO_TEST_CASE(generateOptionsForTask_root_after_hldRoot)
@@ -179,7 +179,7 @@ BOOST_AUTO_TEST_CASE(generateOptionsForTask_root_after_hldRoot)
   std::map<std::string, boost::any> controlSettings = {{"outputFileType_std::string", std::string("root")}};
   auto resultsOpt = generateOptionsForTask(inOpts, controlSettings);
   BOOST_REQUIRE(isOptionSet(resultsOpt, "inputFileType_std::string"));
-  BOOST_REQUIRE_EQUAL(FileTypeChecker::getInputFileType(resultsOpt), FileTypeChecker::kRoot);
+  BOOST_REQUIRE_EQUAL(file_type_checker::getInputFileType(resultsOpt), file_type_checker::FileType::kRoot);
   BOOST_REQUIRE(isOptionSet(resultsOpt, "firstEvent_int"));
   BOOST_REQUIRE(isOptionSet(resultsOpt, "lastEvent_int"));
   BOOST_REQUIRE_EQUAL(getOptionAsInt(resultsOpt, "firstEvent_int"), 2);
@@ -193,7 +193,7 @@ BOOST_AUTO_TEST_CASE(generateOptionsForTask_root_after_Root)
   std::map<std::string, boost::any> controlSettings = {{"outputFileType_std::string", std::string("root")}};
   auto resultsOpt = generateOptionsForTask(inOpts, controlSettings);
   BOOST_REQUIRE(isOptionSet(resultsOpt, "inputFileType_std::string"));
-  BOOST_REQUIRE_EQUAL(FileTypeChecker::getInputFileType(resultsOpt), FileTypeChecker::kRoot);
+  BOOST_REQUIRE_EQUAL(file_type_checker::getInputFileType(resultsOpt), file_type_checker::FileType::kRoot);
   BOOST_REQUIRE(isOptionSet(resultsOpt, "firstEvent_int"));
   BOOST_REQUIRE(isOptionSet(resultsOpt, "lastEvent_int"));
   BOOST_REQUIRE_EQUAL(getOptionAsInt(resultsOpt, "firstEvent_int"), 2);

--- a/tests/Options/JPetOptionsGenerator/JPetOptionsGeneratorToolsTest.cpp
+++ b/tests/Options/JPetOptionsGenerator/JPetOptionsGeneratorToolsTest.cpp
@@ -35,20 +35,19 @@ OptsStrAny getOptions(const std::string& commandLine)
   auto argc = args_char.size();
   auto argv = args_char.data();
   po::options_description description("Allowed options");
-  description.add_options()
-  ("help,h", "Displays this help message.")
-  ("type,t", po::value<std::string>()->required(), "Type of file: hld, zip, root or scope.")
-  ("file,f", po::value< std::vector<std::string> >()->required()->multitoken(), "File(s) to open.")
-  ("outputPath,o", po::value<std::string>(), "Location to which the outputFiles will be saved.")
-  ("range,r", po::value< std::vector<int> >()->multitoken()->default_value({ -1, -1}, ""), "Range of events to process e.g. -r 1 1000 .")
-  ("unpackerConfigFile,p", po::value<std::string>(), "xml file with TRB settings used by the unpacker program.")
-  ("unpackerCalibFile,c", po::value<std::string>(), "ROOT file with TRB calibration used by the unpacker program.")
-  ("runID,i", po::value<int>(), "Run ID.")
-  ("detector,k", po::value<std::string>()->default_value("barrel"), "Detector type: barrel (default) ot modular")
-  ("progressBar,b", po::bool_switch()->default_value(false), "Progress bar.")
-  ("localDB,l", po::value<std::string>(), "The file to use as the parameter database.")
-  ("localDBCreate,L", po::value<std::string>(), "File name to which the parameter database will be saved.")
-  ("userCfg,u", po::value<std::string>(), "Json file with optional user parameters.");
+  description.add_options()("help,h", "Displays this help message.")("type,t", po::value<std::string>()->required(),
+                                                                     "Type of file: hld, zip, root or scope.")(
+      "file,f", po::value<std::vector<std::string>>()->required()->multitoken(),
+      "File(s) to open.")("outputPath,o", po::value<std::string>(), "Location to which the outputFiles will be saved.")(
+      "range,r", po::value<std::vector<int>>()->multitoken()->default_value({-1, -1}, ""), "Range of events to process e.g. -r 1 1000 .")(
+      "unpackerConfigFile,p", po::value<std::string>(), "xml file with TRB settings used by the unpacker program.")(
+      "unpackerCalibFile,c", po::value<std::string>(), "ROOT file with TRB calibration used by the unpacker program.")(
+      "runID,i", po::value<int>(), "Run ID.")("detector,k", po::value<std::string>()->default_value("barrel"),
+                                              "Detector type: barrel (default) ot modular")(
+      "progressBar,b", po::bool_switch()->default_value(false), "Progress bar.")("localDB,l", po::value<std::string>(),
+                                                                                 "The file to use as the parameter database.")(
+      "localDBCreate,L", po::value<std::string>(),
+      "File name to which the parameter database will be saved.")("userCfg,u", po::value<std::string>(), "Json file with optional user parameters.");
   po::variables_map variablesMap;
   po::store(po::parse_command_line(argc, argv, description), variablesMap);
   po::notify(variablesMap);
@@ -122,17 +121,15 @@ BOOST_AUTO_TEST_CASE(checkIfFunctionToAddOptionsFromCfgFileWork)
   auto argc = args_char.size();
   auto argv = args_char.data();
   po::options_description description("Allowed options");
-  description.add_options()
-  ("file_std::vector<std::string>,f", po::value<std::vector<std::string>>(), "File(s) to open")
-  ("type_std::string,t", po::value<std::string>(), "type of file: hld, zip, root or scope")
-  ("range_std::vector<int>,r", po::value<std::vector<int>>(), "Range of events to process.")
-  ("param_std::string,p", po::value<std::string>(), "File with TRB numbers.")
-  ("runID_int,i", po::value<int>(), "Run id.")
-  ("detector,k", po::value<std::string>()->default_value("barrel"), "Detector type: barrel (default) ot modular")
-  ("progressBar_bool,b", po::bool_switch()->default_value(false), "Progress bar.")
-  ("localDB_std::string,l", po::value<std::string>(), "The file to use as the parameter database.")
-  ("localDBCreate_std::string,L", po::value<std::string>(), "Where to save the parameter database.")
-  ("userCfg_std::string,u", po::value<std::string>(), "Json file with optional user parameters.");
+  description.add_options()("file_std::vector<std::string>,f", po::value<std::vector<std::string>>(),
+                            "File(s) to open")("type_std::string,t", po::value<std::string>(), "type of file: hld, zip, root or scope")(
+      "range_std::vector<int>,r", po::value<std::vector<int>>(), "Range of events to process.")(
+      "param_std::string,p", po::value<std::string>(), "File with TRB numbers.")("runID_int,i", po::value<int>(), "Run id.")(
+      "detector,k", po::value<std::string>()->default_value("barrel"),
+      "Detector type: barrel (default) ot modular")("progressBar_bool,b", po::bool_switch()->default_value(false), "Progress bar.")(
+      "localDB_std::string,l", po::value<std::string>(),
+      "The file to use as the parameter database.")("localDBCreate_std::string,L", po::value<std::string>(), "Where to save the parameter database.")(
+      "userCfg_std::string,u", po::value<std::string>(), "Json file with optional user parameters.");
   po::variables_map variablesMap;
   po::store(po::parse_command_line(argc, argv, description), variablesMap);
   po::notify(variablesMap);

--- a/tests/Options/JPetOptionsGenerator/JPetOptionsGeneratorToolsTest.cpp
+++ b/tests/Options/JPetOptionsGenerator/JPetOptionsGeneratorToolsTest.cpp
@@ -1,5 +1,5 @@
 /**
- *  @copyright Copyright 2018 The J-PET Framework Authors. All rights reserved.
+ *  @copyright Copyright 2021 The J-PET Framework Authors. All rights reserved.
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may find a copy of the License in the LICENCE file.
@@ -35,17 +35,20 @@ OptsStrAny getOptions(const std::string& commandLine)
   auto argc = args_char.size();
   auto argv = args_char.data();
   po::options_description description("Allowed options");
-  description.add_options()("help,h", "Displays this help message.")("type,t", po::value<std::string>()->required(),
-                                                                     "Type of file: hld, zip, root or scope.")(
-      "file,f", po::value<std::vector<std::string>>()->required()->multitoken(),
-      "File(s) to open.")("outputPath,o", po::value<std::string>(), "Location to which the outputFiles will be saved.")(
-      "range,r", po::value<std::vector<int>>()->multitoken()->default_value({-1, -1}, ""), "Range of events to process e.g. -r 1 1000 .")(
-      "unpackerConfigFile,p", po::value<std::string>(), "xml file with TRB settings used by the unpacker program.")(
-      "unpackerCalibFile,c", po::value<std::string>(), "ROOT file with TRB calibration used by the unpacker program.")(
-      "runId,i", po::value<int>(), "Run id.")("progressBar,b", po::bool_switch()->default_value(false),
-                                              "Progress bar.")("localDB,l", po::value<std::string>(), "The file to use as the parameter database.")(
-      "localDBCreate,L", po::value<std::string>(),
-      "File name to which the parameter database will be saved.")("userCfg,u", po::value<std::string>(), "Json file with optional user parameters.");
+  description.add_options()
+  ("help,h", "Displays this help message.")
+  ("type,t", po::value<std::string>()->required(), "Type of file: hld, zip, root or scope.")
+  ("file,f", po::value< std::vector<std::string> >()->required()->multitoken(), "File(s) to open.")
+  ("outputPath,o", po::value<std::string>(), "Location to which the outputFiles will be saved.")
+  ("range,r", po::value< std::vector<int> >()->multitoken()->default_value({ -1, -1}, ""), "Range of events to process e.g. -r 1 1000 .")
+  ("unpackerConfigFile,p", po::value<std::string>(), "xml file with TRB settings used by the unpacker program.")
+  ("unpackerCalibFile,c", po::value<std::string>(), "ROOT file with TRB calibration used by the unpacker program.")
+  ("runID,i", po::value<int>(), "Run ID.")
+  ("detector,k", po::value<std::string>()->default_value("barrel"), "Detector type: barrel (default) ot modular")
+  ("progressBar,b", po::bool_switch()->default_value(false), "Progress bar.")
+  ("localDB,l", po::value<std::string>(), "The file to use as the parameter database.")
+  ("localDBCreate,L", po::value<std::string>(), "File name to which the parameter database will be saved.")
+  ("userCfg,u", po::value<std::string>(), "Json file with optional user parameters.");
   po::variables_map variablesMap;
   po::store(po::parse_command_line(argc, argv, description), variablesMap);
   po::notify(variablesMap);
@@ -95,7 +98,6 @@ BOOST_AUTO_TEST_CASE(checkIfFunctionGetConfigFileNameWork)
   auto argv = args_char.data();
   po::options_description description("Allowed options");
   description.add_options()("userCfg_std::string,u", po::value<std::string>(), "Json file with optional user parameters.");
-  ;
   po::variables_map variablesMap;
   po::store(po::parse_command_line(argc, argv, description), variablesMap);
   po::notify(variablesMap);
@@ -106,7 +108,6 @@ BOOST_AUTO_TEST_CASE(checkIfFunctionGetConfigFileNameWork)
   auto argv2 = args_char2.data();
   po::options_description description2("Allowed options");
   description2.add_options()("userCfg_std::string,u", po::value<std::string>(), "Json file with optional user parameters.");
-  ;
   po::variables_map variablesMap2;
   po::store(po::parse_command_line(argc2, argv2, description2), variablesMap2);
   po::notify(variablesMap2);
@@ -121,14 +122,17 @@ BOOST_AUTO_TEST_CASE(checkIfFunctionToAddOptionsFromCfgFileWork)
   auto argc = args_char.size();
   auto argv = args_char.data();
   po::options_description description("Allowed options");
-  description.add_options()("file_std::vector<std::string>,f", po::value<std::vector<std::string>>(),
-                            "File(s) to open")("type_std::string,t", po::value<std::string>(), "type of file: hld, zip, root or scope")(
-      "range_std::vector<int>,r", po::value<std::vector<int>>(), "Range of events to process.")("param_std::string,p", po::value<std::string>(),
-                                                                                                "File with TRB numbers.")(
-      "runId_int,i", po::value<int>(), "Run id.")("progressBar_bool,b", po::bool_switch()->default_value(false), "Progress bar.")(
-      "localDB_std::string,l", po::value<std::string>(),
-      "The file to use as the parameter database.")("localDBCreate_std::string,L", po::value<std::string>(), "Where to save the parameter database.")(
-      "userCfg_std::string,u", po::value<std::string>(), "Json file with optional user parameters.");
+  description.add_options()
+  ("file_std::vector<std::string>,f", po::value<std::vector<std::string>>(), "File(s) to open")
+  ("type_std::string,t", po::value<std::string>(), "type of file: hld, zip, root or scope")
+  ("range_std::vector<int>,r", po::value<std::vector<int>>(), "Range of events to process.")
+  ("param_std::string,p", po::value<std::string>(), "File with TRB numbers.")
+  ("runID_int,i", po::value<int>(), "Run id.")
+  ("detector,k", po::value<std::string>()->default_value("barrel"), "Detector type: barrel (default) ot modular")
+  ("progressBar_bool,b", po::bool_switch()->default_value(false), "Progress bar.")
+  ("localDB_std::string,l", po::value<std::string>(), "The file to use as the parameter database.")
+  ("localDBCreate_std::string,L", po::value<std::string>(), "Where to save the parameter database.")
+  ("userCfg_std::string,u", po::value<std::string>(), "Json file with optional user parameters.");
   po::variables_map variablesMap;
   po::store(po::parse_command_line(argc, argv, description), variablesMap);
   po::notify(variablesMap);

--- a/tests/Options/JPetOptionsGenerator/JPetOptionsTypeHandlerTest.cpp
+++ b/tests/Options/JPetOptionsGenerator/JPetOptionsTypeHandlerTest.cpp
@@ -1,5 +1,5 @@
 /**
- *  @copyright Copyright 2018 The J-PET Framework Authors. All rights reserved.
+ *  @copyright Copyright 2021 The J-PET Framework Authors. All rights reserved.
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may find a copy of the License in the LICENCE file.
@@ -10,7 +10,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  *
- *  @file JPetOptionsGeneratorTest.cpp
+ *  @file JPetOptionsTypeHandlerTest.cpp
  */
 
 #define BOOST_TEST_DYN_LINK

--- a/tests/Options/JPetOptionsTools/JPetOptionsToolsTest.cpp
+++ b/tests/Options/JPetOptionsTools/JPetOptionsToolsTest.cpp
@@ -245,18 +245,20 @@ BOOST_AUTO_TEST_CASE(getOptionBy)
 
 BOOST_AUTO_TEST_CASE(getDetectorTypeTest)
 {
+  using namespace detector_type_checker;
+
   OptsStrAny opt1 = {{"detectorType_std::string", std::string("bar")}};
   OptsStrAny opt2 = {{"detectorType_std::string", std::string("barrel")}};
   OptsStrAny opt3 = {{"detectorType_std::string", std::string("mod")}};
   OptsStrAny opt4 = {{"detectorType_std::string", std::string("modular")}};
   OptsStrAny opt5 = {{"detectorType_std::string", std::string("kloe")}};
   OptsStrAny opt6 = {{"detectorType_std::string", std::string("lhcb")}};
-  BOOST_REQUIRE_EQUAL(DetectorTypeChecker::getDetectorType(opt1), DetectorTypeChecker::DetectorType::kBarrel);
-  BOOST_REQUIRE_EQUAL(DetectorTypeChecker::getDetectorType(opt2), DetectorTypeChecker::DetectorType::kBarrel);
-  BOOST_REQUIRE_EQUAL(DetectorTypeChecker::getDetectorType(opt3), DetectorTypeChecker::DetectorType::kModular);
-  BOOST_REQUIRE_EQUAL(DetectorTypeChecker::getDetectorType(opt4), DetectorTypeChecker::DetectorType::kModular);
-  BOOST_REQUIRE_EQUAL(DetectorTypeChecker::getDetectorType(opt5), DetectorTypeChecker::DetectorType::kBarrel);
-  BOOST_REQUIRE_EQUAL(DetectorTypeChecker::getDetectorType(opt6), DetectorTypeChecker::DetectorType::kBarrel);
+  BOOST_REQUIRE_EQUAL(getDetectorType(opt1), DetectorType::kBarrel);
+  BOOST_REQUIRE_EQUAL(getDetectorType(opt2), DetectorType::kBarrel);
+  BOOST_REQUIRE_EQUAL(getDetectorType(opt3), DetectorType::kModular);
+  BOOST_REQUIRE_EQUAL(getDetectorType(opt4), DetectorType::kModular);
+  BOOST_REQUIRE_EQUAL(getDetectorType(opt5), DetectorType::kBarrel);
+  BOOST_REQUIRE_EQUAL(getDetectorType(opt6), DetectorType::kBarrel);
 }
 
 BOOST_AUTO_TEST_CASE(testBooleanOptions)

--- a/tests/Options/JPetOptionsTools/JPetOptionsToolsTest.cpp
+++ b/tests/Options/JPetOptionsTools/JPetOptionsToolsTest.cpp
@@ -1,3 +1,18 @@
+/**
+ *  @copyright Copyright 2021 The J-PET Framework Authors. All rights reserved.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may find a copy of the License in the LICENCE file.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  @file JPetOptionsToolsTest.cpp
+ */
+
 #define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MODULE JPetOptionsTest
 #include "JPetOptionsTools/JPetOptionsTools.h"
@@ -134,12 +149,14 @@ BOOST_AUTO_TEST_CASE(createOptionsFromConfigFileThatHasWrongFormat)
 
 BOOST_AUTO_TEST_CASE(checkIfGetOptionAndIsOptionWork)
 {
-  std::map<std::string, boost::any> options = {{"firstEvent_int", -1},
-                                               {"lastEvent_int", -1},
-                                               {"progressBar_bool", false},
-                                               {"runId_int", -1},
-                                               {"unpackerConfigFile_std::string", std::string("conf_trb3.xml")},
-                                               {"unpackerCalibFile_std::string", std::string("")}};
+  std::map<std::string, boost::any> options = {
+    {"firstEvent_int", -1},
+    {"lastEvent_int", -1},
+    {"progressBar_bool", false},
+    {"runID_int", -1},
+    {"unpackerConfigFile_std::string", std::string("conf_trb3.xml")},
+    {"unpackerCalibFile_std::string", std::string("")}
+  };
 
   BOOST_REQUIRE(isOptionSet(options, "firstEvent_int"));
   BOOST_REQUIRE(isOptionSet(options, "lastEvent_int"));
@@ -150,18 +167,21 @@ BOOST_AUTO_TEST_CASE(checkIfGetOptionAndIsOptionWork)
 
 BOOST_AUTO_TEST_CASE(getTotalEventsTest)
 {
-  OptsStrAny options = {{"inputFile_std::string", std::string("input")},
-                        {"scopeConfigFile_std::string", std::string("test.json")},
-                        {"scopeInputDirectory_std::string", std::string("scopeData")},
-                        {"outputFile_std::string", std::string("output")},
-                        {"firstEvent_int", -1},
-                        {"lastEvent_int", -1},
-                        {"runId_int", 2001},
-                        {"progressBar_bool", true},
-                        {"inputFileType_std::string", std::string("root")},
-                        {"outputFileType_std::string", std::string("scope")},
-                        {"unpackerConfigFile_std::string", std::string("conf_trb3.xml")},
-                        {"unpackerCalibFile_std::string", std::string("")}};
+  OptsStrAny options = {
+    {"inputFile_std::string", std::string("input")},
+    {"scopeConfigFile_std::string", std::string("test.json")},
+    {"scopeInputDirectory_std::string", std::string("scopeData")},
+    {"outputFile_std::string", std::string("output")},
+    {"firstEvent_int", -1},
+    {"lastEvent_int", -1},
+    {"runID_int", 2001},
+    {"progressBar_bool", true},
+    {"inputFileType_std::string", std::string("root")},
+    {"outputFileType_std::string", std::string("scope")},
+    {"unpackerConfigFile_std::string", std::string("conf_trb3.xml")},
+    {"unpackerCalibFile_std::string", std::string("")}
+  };
+
   BOOST_REQUIRE_EQUAL(getTotalEvents(options), -1);
 
   options.at("firstEvent_int") = 0;
@@ -225,6 +245,22 @@ BOOST_AUTO_TEST_CASE(getOptionBy)
 
   BOOST_REQUIRE_EQUAL(getOptionAsVectorOfDoubles(opts, "my_vectD").size(), 4u);
   BOOST_REQUIRE_EQUAL(getOptionAsBool(opts, "my_bool"), false);
+}
+
+BOOST_AUTO_TEST_CASE(getDetectorTypeTest)
+{
+  OptsStrAny opt1 = {{"detectorType_std::string", std::string("bar")}};
+  OptsStrAny opt2 = {{"detectorType_std::string", std::string("barrel")}};
+  OptsStrAny opt3 = {{"detectorType_std::string", std::string("mod")}};
+  OptsStrAny opt4 = {{"detectorType_std::string", std::string("modular")}};
+  OptsStrAny opt5 = {{"detectorType_std::string", std::string("kloe")}};
+  OptsStrAny opt6 = {{"detectorType_std::string", std::string("lhcb")}};
+  BOOST_REQUIRE_EQUAL(DetectorTypeChecker::getDetectorType(opt1), DetectorTypeChecker::DetectorType::kBarrel);
+  BOOST_REQUIRE_EQUAL(DetectorTypeChecker::getDetectorType(opt2), DetectorTypeChecker::DetectorType::kBarrel);
+  BOOST_REQUIRE_EQUAL(DetectorTypeChecker::getDetectorType(opt3), DetectorTypeChecker::DetectorType::kModular);
+  BOOST_REQUIRE_EQUAL(DetectorTypeChecker::getDetectorType(opt4), DetectorTypeChecker::DetectorType::kModular);
+  BOOST_REQUIRE_EQUAL(DetectorTypeChecker::getDetectorType(opt5), DetectorTypeChecker::DetectorType::kBarrel);
+  BOOST_REQUIRE_EQUAL(DetectorTypeChecker::getDetectorType(opt6), DetectorTypeChecker::DetectorType::kBarrel);
 }
 
 BOOST_AUTO_TEST_CASE(testBooleanOptions)

--- a/tests/Options/JPetOptionsTools/JPetOptionsToolsTest.cpp
+++ b/tests/Options/JPetOptionsTools/JPetOptionsToolsTest.cpp
@@ -149,14 +149,12 @@ BOOST_AUTO_TEST_CASE(createOptionsFromConfigFileThatHasWrongFormat)
 
 BOOST_AUTO_TEST_CASE(checkIfGetOptionAndIsOptionWork)
 {
-  std::map<std::string, boost::any> options = {
-    {"firstEvent_int", -1},
-    {"lastEvent_int", -1},
-    {"progressBar_bool", false},
-    {"runID_int", -1},
-    {"unpackerConfigFile_std::string", std::string("conf_trb3.xml")},
-    {"unpackerCalibFile_std::string", std::string("")}
-  };
+  std::map<std::string, boost::any> options = {{"firstEvent_int", -1},
+                                               {"lastEvent_int", -1},
+                                               {"progressBar_bool", false},
+                                               {"runID_int", -1},
+                                               {"unpackerConfigFile_std::string", std::string("conf_trb3.xml")},
+                                               {"unpackerCalibFile_std::string", std::string("")}};
 
   BOOST_REQUIRE(isOptionSet(options, "firstEvent_int"));
   BOOST_REQUIRE(isOptionSet(options, "lastEvent_int"));
@@ -167,20 +165,18 @@ BOOST_AUTO_TEST_CASE(checkIfGetOptionAndIsOptionWork)
 
 BOOST_AUTO_TEST_CASE(getTotalEventsTest)
 {
-  OptsStrAny options = {
-    {"inputFile_std::string", std::string("input")},
-    {"scopeConfigFile_std::string", std::string("test.json")},
-    {"scopeInputDirectory_std::string", std::string("scopeData")},
-    {"outputFile_std::string", std::string("output")},
-    {"firstEvent_int", -1},
-    {"lastEvent_int", -1},
-    {"runID_int", 2001},
-    {"progressBar_bool", true},
-    {"inputFileType_std::string", std::string("root")},
-    {"outputFileType_std::string", std::string("scope")},
-    {"unpackerConfigFile_std::string", std::string("conf_trb3.xml")},
-    {"unpackerCalibFile_std::string", std::string("")}
-  };
+  OptsStrAny options = {{"inputFile_std::string", std::string("input")},
+                        {"scopeConfigFile_std::string", std::string("test.json")},
+                        {"scopeInputDirectory_std::string", std::string("scopeData")},
+                        {"outputFile_std::string", std::string("output")},
+                        {"firstEvent_int", -1},
+                        {"lastEvent_int", -1},
+                        {"runID_int", 2001},
+                        {"progressBar_bool", true},
+                        {"inputFileType_std::string", std::string("root")},
+                        {"outputFileType_std::string", std::string("scope")},
+                        {"unpackerConfigFile_std::string", std::string("conf_trb3.xml")},
+                        {"unpackerCalibFile_std::string", std::string("")}};
 
   BOOST_REQUIRE_EQUAL(getTotalEvents(options), -1);
 

--- a/tests/Options/JPetOptionsTools/JPetOptionsTransformatorsTest.cpp
+++ b/tests/Options/JPetOptionsTools/JPetOptionsTransformatorsTest.cpp
@@ -1,3 +1,18 @@
+/**
+ *  @copyright Copyright 2021 The J-PET Framework Authors. All rights reserved.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may find a copy of the License in the LICENCE file.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  @file JPetOptionsTransformatorsTest.cpp
+ */
+
 #define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MODULE JPetOptionsTest
 #include "JPetOptionsTools/JPetOptionsTools.h"

--- a/tests/Tasks/JPetParamBankHandlerTask/JPetParamBankHandlerTaskTest.cpp
+++ b/tests/Tasks/JPetParamBankHandlerTask/JPetParamBankHandlerTaskTest.cpp
@@ -1,5 +1,5 @@
 /**
- *  @copyright Copyright 2018 The J-PET Framework Authors. All rights reserved.
+ *  @copyright Copyright 2021 The J-PET Framework Authors. All rights reserved.
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may find a copy of the License in the LICENCE file.
@@ -31,7 +31,7 @@ BOOST_AUTO_TEST_CASE(goodRootFile)
 {
   JPetParamBankHandlerTask task;
   auto options = jpet_options_generator_tools::getDefaultOptions();
-  options["runId_int"] = -1;
+  options["runID_int"] = -1;
   options["inputFileType_std::string"] = std::string("root");
   options["inputFile_std::string"] = std::string("unitTestData/JPetTaskChainExecutorTest/dabc_17025151847.unk.evt.root");
   std::shared_ptr<JPetParamManager> manager = std::make_shared<JPetParamManager>();
@@ -48,7 +48,7 @@ BOOST_AUTO_TEST_CASE(badRootFile)
   gErrorIgnoreLevel = kFatal; /// To turn off ROOT error reporting.
   JPetParamBankHandlerTask task;
   auto options = jpet_options_generator_tools::getDefaultOptions();
-  options["runId_int"] = -1;
+  options["runID_int"] = -1;
   options["inputFileType_std::string"] = std::string("root");
   options["inputFile_std::string"] = std::string("unitTestData/auxdata.root");
   std::shared_ptr<JPetParamManager> manager = std::make_shared<JPetParamManager>();
@@ -112,7 +112,7 @@ BOOST_AUTO_TEST_CASE(goodUnknownFileFromConfig)
   gErrorIgnoreLevel = kFatal; /// To turn off ROOT error reporting.
   JPetParamBankHandlerTask task;
   auto options = jpet_options_generator_tools::getDefaultOptions();
-  options["runId_int"] = 44;
+  options["runID_int"] = 44;
   options["localDB_std::string"] = std::string("unitTestData/JPetParamBankHandlerTask/large_barrel.json");
   options["inputFile_std::string"] = std::string("unitTestData/auxdata.root");
   options["inputFileType_std::string"] = std::string("unknown");
@@ -132,7 +132,7 @@ BOOST_AUTO_TEST_CASE(badUnknownFileFromConfig)
   gErrorIgnoreLevel = kFatal; /// To turn off ROOT error reporting.
   JPetParamBankHandlerTask task;
   auto options = jpet_options_generator_tools::getDefaultOptions();
-  options["runId_int"] = 1;
+  options["runID_int"] = 1;
   options["localDB_std::string"] = std::string("unitTestData/JPetParamBankHandlerTask/large_barrel.json");
   options["inputFile_std::string"] = std::string("unitTestData/auxdata.root");
   options["inputFileType_std::string"] = std::string("unknown");
@@ -151,7 +151,7 @@ BOOST_AUTO_TEST_CASE(goodHldFile)
 {
   JPetParamBankHandlerTask task;
   auto options = jpet_options_generator_tools::getDefaultOptions();
-  options["runId_int"] = 44;
+  options["runID_int"] = 44;
   options["localDB_std::string"] = std::string("unitTestData/JPetParamBankHandlerTask/large_barrel.json");
   options["inputFileType_std::string"] = std::string("hld");
   std::shared_ptr<JPetParamManager> manager =


### PR DESCRIPTION
This PR adds a new command line option "-k" for selecting "detector type", that is which Unpacker should be used. Currently available are Unpacker2 for Big Barrel data and Unpacker2D for Modular Layer acquisition. 

"Barrel" option is a default one, so all current functionalities should not be disturbed if "-k" won't be used while running an example.
