### PR TITLE
Event type fix

### DIFF
--- a/include/DataObjects/JPetEventType/JPetEventType.h
+++ b/include/DataObjects/JPetEventType/JPetEventType.h
@@ -25,4 +25,9 @@ enum class JPetEventType
   kScattered = 16,
   kCosmic = 32
 };
+
+inline JPetEventType operator|(JPetEventType a, JPetEventType b) { return static_cast<JPetEventType>(static_cast<int>(a) | static_cast<int>(b)); }
+inline JPetEventType operator&(JPetEventType a, JPetEventType b) { return static_cast<JPetEventType>(static_cast<int>(a) & static_cast<int>(b)); }
+inline JPetEventType operator~(JPetEventType a) { return static_cast<JPetEventType>(~static_cast<int>(a)); }
+
 #endif /* !JPETEVENTTYPE_H */

--- a/include/DataObjects/JPetEventType/JPetEventType.h
+++ b/include/DataObjects/JPetEventType/JPetEventType.h
@@ -1,5 +1,5 @@
 /**
- *  @copyright Copyright 2018 The J-PET Framework Authors. All rights reserved.
+ *  @copyright Copyright 2021 The J-PET Framework Authors. All rights reserved.
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may find a copy of the License in the LICENCE file.
@@ -16,7 +16,8 @@
 #ifndef JPETEVENTTYPE_H
 #define JPETEVENTTYPE_H
 
-enum JPetEventType {
+enum class JPetEventType
+{
   kUnknown = 1,
   k2Gamma = 2,
   k3Gamma = 4,

--- a/src/DataObjects/JPetEvent/JPetEvent.cpp
+++ b/src/DataObjects/JPetEvent/JPetEvent.cpp
@@ -1,5 +1,5 @@
 /**
- *  @copyright Copyright 2018 The J-PET Framework Authors. All rights reserved.
+ *  @copyright Copyright 2021 The J-PET Framework Authors. All rights reserved.
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may find a copy of the License in the LICENCE file.
@@ -97,6 +97,6 @@ void JPetEvent::addEventType(JPetEventType type)
 
 void JPetEvent::Clear(Option_t*)
 {
-  fType = kUnknown;
+  fType = JPetEventType::kUnknown;
   fHits.clear();
 }


### PR DESCRIPTION
Our new beta-tester (@nenprio ) discovered that there is a conflict between and enum definition in JPetEventType.h and one of the newer  version of the ROOT 6.20.04). More specifically in TStructNode.h there is an enum that has a value of kUnknown as in our JPetEventType. I could have changed the name, but wanted to be more clever and I changed the definition to scoped enum.
Then,  bitwise operations didn't work anymore, so I added the overloaded operators. I hope that is all.... .
Briefly:
-replaced enum by scoped enum
-add overloaded version of & | and ~ operators
-fix tests and the code