### PR TITLE
Fix GH Actions CI tests

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-16.04, ubuntu-18.04]
+        os: [ubuntu-20.04, ubuntu-18.04]
    
     steps:
     - uses: actions/checkout@v2
@@ -16,11 +16,11 @@ jobs:
        sudo apt-get -qq update
        sudo apt-get install -y git libboost-all-dev libtbb-dev cmake
       
-    - name: download  ROOT (for ubuntu 16.04)
+    - name: download  ROOT (for ubuntu 20.04)
       run: |
-        wget https://root.cern/download/root_v6.12.06.Linux-ubuntu16-x86_64-gcc5.4.tar.gz
+        wget https://root.cern/download/root_v6.24.02.Linux-ubuntu20-x86_64-gcc9.3.tar.gz
         tar xzf root_v6.12.06.Linux-ubuntu16-x86_64-gcc5.4.tar.gz
-      if: matrix.os == 'ubuntu-16.04'
+      if: matrix.os == 'ubuntu-20.04'
     - name: download  ROOT (for ubuntu-18.04)
       run: |
         wget http://sphinx.if.uj.edu.pl/framework/root-6-20-06-ubuntu18-jpet.tar.gz 

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-18.04]
+        os: [ubuntu-22.04, ubuntu-20.04, ubuntu-18.04]
    
     steps:
     - uses: actions/checkout@v2
@@ -15,11 +15,16 @@ jobs:
       run: |
        sudo apt-get -qq update
        sudo apt-get install -y git libboost-all-dev libtbb-dev cmake
-      
+
+    - name: download  ROOT (for ubuntu 22.04)
+      run: |
+        wget https://root.cern/download/root_v6.26.02.Linux-ubuntu22-x86_64-gcc11.2.tar.gz
+        tar xzf root_v6.26.02.Linux-ubuntu22-x86_64-gcc11.2.tar.gz
+      if: matrix.os == 'ubuntu-22.04'
     - name: download  ROOT (for ubuntu 20.04)
       run: |
         wget https://root.cern/download/root_v6.24.02.Linux-ubuntu20-x86_64-gcc9.3.tar.gz
-        tar xzf root_v6.12.06.Linux-ubuntu16-x86_64-gcc5.4.tar.gz
+        tar xzf root_v6.24.02.Linux-ubuntu20-x86_64-gcc9.3.tar.gz
       if: matrix.os == 'ubuntu-20.04'
     - name: download  ROOT (for ubuntu-18.04)
       run: |

--- a/tests/Core/JPetWriter/JPetWriterTest.cpp
+++ b/tests/Core/JPetWriter/JPetWriterTest.cpp
@@ -29,6 +29,7 @@
 
 #include <TFile.h>
 #include <TList.h>
+#include <THashTable.h>
 #include <TNamed.h>
 #include <iostream>
 


### PR DESCRIPTION
This PR replaces the Ubuntu-16 image (no longer supported) with Ubuntu-20 and adds a new test based on Ubuntu-22.
Additionally, it fixes a missing explicit include in JPetWriterTest.cpp which is required with new ROOT.