### PR TITLE
Changing reference time for MC Hit to the event time

### DIFF
--- a/include/GeantParser/JPetGeantParser/JPetGeantParserTools.h
+++ b/include/GeantParser/JPetGeantParser/JPetGeantParserTools.h
@@ -40,9 +40,9 @@
 class JPetGeantParserTools
 {
 public:
-  static JPetMCHit createJPetMCHit(JPetGeantScinHits* geantHit, const JPetParamBank& paramBank);
+  static JPetMCHit createJPetMCHit(JPetGeantScinHits* geantHit, const JPetParamBank& paramBank, const float timeShift);
 
-  static JPetHit reconstructHit(JPetMCHit& hit, const JPetParamBank& paramBank, const float timeShift, JPetHitExperimentalParametrizer& parametrizer);
+  static JPetHit reconstructHit(JPetMCHit& hit, const JPetParamBank& paramBank, JPetHitExperimentalParametrizer& parametrizer);
 
   static bool isHitReconstructed(JPetHit& hit, const float th);
 

--- a/src/GeantParser/JPetGeantParser/JPetGeantParser.cpp
+++ b/src/GeantParser/JPetGeantParser/JPetGeantParser.cpp
@@ -315,12 +315,12 @@ void JPetGeantParser::processMCEvent(JPetGeantEventPack* evPack)
   {
 
     // translate geantHit -> JPetMCHit
-    JPetMCHit mcHit = JPetGeantParserTools::createJPetMCHit(evPack->GetHit(i), getParamBank());
+    JPetMCHit mcHit = JPetGeantParserTools::createJPetMCHit(evPack->GetHit(i), getParamBank(), timeShift);
 
     if (fMakeHisto)
       fillHistoMCGen(mcHit);
     // create reconstructed hit and add all smearings
-    JPetHit recHit = JPetGeantParserTools::reconstructHit(mcHit, getParamBank(), timeShift, fExperimentalParametrizer);
+    JPetHit recHit = JPetGeantParserTools::reconstructHit(mcHit, getParamBank(), fExperimentalParametrizer);
 
     // add criteria for possible rejection of reconstructed events (e.g. E>50 keV)
     if (JPetGeantParserTools::isHitReconstructed(recHit, fExperimentalThreshold))

--- a/src/GeantParser/JPetGeantParser/JPetGeantParserTools.cpp
+++ b/src/GeantParser/JPetGeantParser/JPetGeantParserTools.cpp
@@ -18,12 +18,12 @@
 
 #include <TMath.h>
 
-JPetMCHit JPetGeantParserTools::createJPetMCHit(JPetGeantScinHits* geantHit, const JPetParamBank& paramBank)
+JPetMCHit JPetGeantParserTools::createJPetMCHit(JPetGeantScinHits* geantHit, const JPetParamBank& paramBank, const float timeShift)
 {
-  JPetMCHit mcHit = JPetMCHit(0,          // UInt_t MCDecayTreeIndex,
-                              geantHit->GetEvtID(),    // UInt_t MCVtxIndex,
-                              geantHit->GetEneDepos(), //  keV
-                              geantHit->GetTime(),     //  ps
+  JPetMCHit mcHit = JPetMCHit(0,                               // UInt_t MCDecayTreeIndex,
+                              geantHit->GetEvtID(),            // UInt_t MCVtxIndex,
+                              geantHit->GetEneDepos(),         //  keV
+                              geantHit->GetTime() + timeShift, //  ps
                               geantHit->GetHitPosition(), geantHit->GetPolarizationIn(), geantHit->GetMomentumIn());
 
   JPetScin& scin = paramBank.getScintillator(geantHit->GetScinID());
@@ -33,15 +33,14 @@ JPetMCHit JPetGeantParserTools::createJPetMCHit(JPetGeantScinHits* geantHit, con
   return mcHit;
 }
 
-JPetHit JPetGeantParserTools::reconstructHit(JPetMCHit& mcHit, const JPetParamBank& paramBank, const float timeShift,
-                                             JPetHitExperimentalParametrizer& parametrizer)
+JPetHit JPetGeantParserTools::reconstructHit(JPetMCHit& mcHit, const JPetParamBank& paramBank, JPetHitExperimentalParametrizer& parametrizer)
 {
   JPetHit hit = dynamic_cast<JPetHit&>(mcHit);
   /// Nonsmeared values
   auto scinID = mcHit.getScintillator().getID();
   auto posZ = mcHit.getPosZ();
   auto energy = mcHit.getEnergy();
-  auto time = mcHit.getTime() + timeShift;
+  auto time = mcHit.getTime();
 
   hit.setEnergy(parametrizer.addEnergySmearing(scinID, posZ, energy, time));
   // adjust to time window and smear


### PR DESCRIPTION
Following the topic. Time of the MCHit is now referenced by the time of the time window. It allows to check the smearing of the time later during the analysis.