### PR TITLE
Update root files urls for github workflows

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -23,8 +23,8 @@ jobs:
       if: matrix.os == 'ubuntu-22.04'
     - name: download  ROOT (for ubuntu 20.04)
       run: |
-        wget https://root.cern/download/root_v6.30.02.Linux-ubuntu20.04-x86_64-gcc9.4.tar.gz
-        tar xzf root_v6.30.02.Linux-ubuntu20.04-x86_64-gcc9.4.tar.gz
+        wget https://root.cern/download/root_v6.24.02.Linux-ubuntu20-x86_64-gcc9.3.tar.gz
+        tar xzf root_v6.24.02.Linux-ubuntu20-x86_64-gcc9.3.tar.gz
       if: matrix.os == 'ubuntu-20.04'
     - name: download  ROOT (for ubuntu-18.04)
       run: |

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -14,7 +14,7 @@ jobs:
     - name: system update
       run: |
        sudo apt-get -qq update
-       sudo apt-get install -y git libboost-all-dev libtbb-dev cmake
+       sudo apt-get install -y git libboost-all-dev libtbb-dev cmake nlohmann-json3-dev
 
     - name: download  ROOT (for ubuntu 22.04)
       run: |

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -18,18 +18,18 @@ jobs:
 
     - name: download  ROOT (for ubuntu 22.04)
       run: |
-        wget https://root.cern/download/root_v6.26.02.Linux-ubuntu22-x86_64-gcc11.2.tar.gz
-        tar xzf root_v6.26.02.Linux-ubuntu22-x86_64-gcc11.2.tar.gz
+        wget https://root.cern/download/root_v6.30.02.Linux-ubuntu22.04-x86_64-gcc11.4.tar.gz
+        tar xzf root_v6.30.02.Linux-ubuntu22.04-x86_64-gcc11.4.tar.gz
       if: matrix.os == 'ubuntu-22.04'
     - name: download  ROOT (for ubuntu 20.04)
       run: |
-        wget https://root.cern/download/root_v6.24.02.Linux-ubuntu20-x86_64-gcc9.3.tar.gz
-        tar xzf root_v6.24.02.Linux-ubuntu20-x86_64-gcc9.3.tar.gz
+        wget https://root.cern/download/root_v6.30.02.Linux-ubuntu20.04-x86_64-gcc9.4.tar.gz
+        tar xzf root_v6.30.02.Linux-ubuntu20.04-x86_64-gcc9.4.tar.gz
       if: matrix.os == 'ubuntu-20.04'
     - name: download  ROOT (for ubuntu-18.04)
       run: |
-        wget http://sphinx.if.uj.edu.pl/framework/root-6-20-06-ubuntu18-jpet.tar.gz 
-        tar xzf root-6-20-06-ubuntu18-jpet.tar.gz
+        wget http://sphinx.if.uj.edu.pl/framework/root_v6.25.01.Linux-ubuntu18-x86_64-gcc7.5.tar.gz
+        tar xzf root_v6.25.01.Linux-ubuntu18-x86_64-gcc7.5.tar.gz
       if: matrix.os == 'ubuntu-18.04'
     - name: cmake
       run: |


### PR DESCRIPTION
The automated tests with the git hub workflows are not working, because the files with the root packages disappeared from the website. Updating the run scheme with the newest root versions available on the downloads page.