### PR TITLE
"BOOST_LOG_DYN_LINK" redefined  & BOOST_BIND_GLOBAL_PLACEHOLDERS issues resolved

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -310,8 +310,17 @@ ROOT_GENERATE_DICTIONARY(${DICTIONARY_NAME} ${HEADERS_WITH_DICTIONARY_REQUIRED}
 ## Building Framework library
 add_library(JPetFramework SHARED ${SOURCES} ${DICTIONARY_NAME}.cxx)
 add_library(JPetFramework::JPetFramework ALIAS JPetFramework)
+add_definitions("-DBOOST_BIND_GLOBAL_PLACEHOLDERS")
 target_compile_options(JPetFramework PRIVATE -Wunused-parameter -Wall)
-target_compile_definitions(JPetFramework PUBLIC BOOST_LOG_DYN_LINK=true)
+if(DEFINED BOOST_LOG_DYN_LINK)
+	set(BOOST_LOG_DYN_LINK=false)
+	target_compile_definitions(JPetFramework PUBLIC BOOST_LOG_DYN_LINK)
+else()
+	set(BOOST_LOG_DYN_LINK=true)
+	target_compile_definitions(JPetFramework PUBLIC BOOST_LOG_DYN_LINK)
+endif()
+
+##target_compile_definitions(JPetFramework PUBLIC BOOST_LOG_DYN_LINK=true)
 foreach(dir ${FOLDERS_WITH_SOURCE})
   target_include_directories(JPetFramework PUBLIC
                              $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/${dir}>


### PR DESCRIPTION
Issues related to warnings from "BOOST_LOG_DYN_LINK" redefined and BOOST_BIND_GLOBAL_PLACEHOLDERS were solved.