### PR TITLE
MC tasks added to direct chain

### DIFF
--- a/include/Core/JPetManager/JPetManager.h
+++ b/include/Core/JPetManager/JPetManager.h
@@ -88,7 +88,8 @@ public:
    *
    * @throws exception in case of errors.
    */
-  void useTask(const std::string& name, const std::string& inputFileType = "", const std::string& outputFileType = "", int numTimes = 1);
+  void useTask(const std::string& name, const std::string& inputFileType = "", const std::string& outputFileType = "", int numTimes = 1,
+               bool toFront = false);
 
   bool areThreadsEnabled() const;
   void setThreadsEnabled(bool enable);
@@ -111,7 +112,7 @@ private:
    * generators in advance. This provate method is intended to register all
    * such tasks in advance of creation of the task generator chain.
    */
-  static void registerDefaultTasks();
+  static void registerAndUseMCTasks(const std::map<std::string, boost::any>& options);
 
   /**
    * @brief Adds any tasks definded in userParams.json

--- a/include/Core/JPetTaskFactory/JPetTaskFactory.h
+++ b/include/Core/JPetTaskFactory/JPetTaskFactory.h
@@ -155,7 +155,7 @@ TaskGeneratorChain generateDirectTaskGeneratorChain(const std::vector<TaskInfo>&
  * @param outChain chain of task  generators that will be modified.
  */
 void addDefaultTasksFromOptions(const std::map<std::string, boost::any>& options, const std::map<std::string, TaskGenerator>& generatorsMap,
-                                TaskGeneratorChain& outChain, const std::vector<TaskInfo>& tasksToUse);
+                                TaskGeneratorChain& outChain);
 
 /**
  * @brief generates the chain of task generators.

--- a/include/Core/JPetTaskFactory/JPetTaskFactory.h
+++ b/include/Core/JPetTaskFactory/JPetTaskFactory.h
@@ -99,7 +99,7 @@ public:
    * @brief Method adds task information to the collection of tasks to be used while creating the task chain.
    * @return false if the task with the name has not been registered. true otherwise.
    */
-  bool addTaskInfo(const std::string& name, const std::string& inputFileType, const std::string& outputFileType, int numIter);
+  bool addTaskInfo(const std::string& name, const std::string& inputFileType, const std::string& outputFileType, int numIter, bool toFront);
 
   std::vector<TaskInfo> getTasksToUse() const;
   std::map<std::string, TaskGenerator> getTasksDictionary() const;
@@ -155,7 +155,7 @@ TaskGeneratorChain generateDirectTaskGeneratorChain(const std::vector<TaskInfo>&
  * @param outChain chain of task  generators that will be modified.
  */
 void addDefaultTasksFromOptions(const std::map<std::string, boost::any>& options, const std::map<std::string, TaskGenerator>& generatorsMap,
-                                TaskGeneratorChain& outChain);
+                                TaskGeneratorChain& outChain, const std::vector<TaskInfo>& tasksToUse);
 
 /**
  * @brief generates the chain of task generators.

--- a/src/Core/JPetManager/JPetManager.cpp
+++ b/src/Core/JPetManager/JPetManager.cpp
@@ -50,7 +50,7 @@ void JPetManager::run(int argc, const char** argv)
     throw std::invalid_argument("Error in parsing command line arguments"); /// temporary change to check if the examples are working
   }
 
-  JPetManager::registerDefaultTasks();
+  JPetManager::registerAndUseMCTasks(allValidatedOptions);
   useTasksFromUserParams(allValidatedOptions);  // add userTasks registered in userParams to run
   checkDisableLogRotation(allValidatedOptions); // disable log rotation if enabled
   auto chainOfTasks = fTaskFactory.createTaskGeneratorChain(allValidatedOptions);
@@ -129,9 +129,9 @@ std::pair<bool, std::map<std::string, boost::any>> JPetManager::parseCmdLine(int
 }
 
 // cppcheck-suppress unusedFunction
-void JPetManager::useTask(const std::string& name, const std::string& inputFileType, const std::string& outputFileType, int numTimes)
+void JPetManager::useTask(const std::string& name, const std::string& inputFileType, const std::string& outputFileType, int numTimes, bool toFront)
 {
-  if (!fTaskFactory.addTaskInfo(name, inputFileType, outputFileType, numTimes))
+  if (!fTaskFactory.addTaskInfo(name, inputFileType, outputFileType, numTimes, toFront))
   {
     std::cerr << "Error has occurred while calling useTask! Check the log!" << std::endl;
     throw std::runtime_error("error in addTaskInfo");
@@ -146,10 +146,19 @@ void JPetManager::setThreadsEnabled(bool enable)
   ENABLE_THREADS_INFO(enable);
 }
 
-void JPetManager::registerDefaultTasks()
+void JPetManager::registerAndUseMCTasks(const std::map<std::string, boost::any>& options)
 {
-  JPetManager::getManager().registerTask<JPetGeantParser>("JPetGeantParser");
-  JPetManager::getManager().registerTask<JPetGateParser>("JPetGateParser");
+  auto fileType = file_type_checker::getInputFileType(options);
+  if (fileType == file_type_checker::kMCGeant)
+  {
+    JPetManager::getManager().registerTask<JPetGeantParser>("JPetGeantParser");
+    JPetManager::getManager().useTask("JPetGeantParser", "mcGeant", "hits", 1, true);
+  }
+  if (fileType == file_type_checker::kMCGATE)
+  {
+    JPetManager::getManager().registerTask<JPetGateParser>("JPetGateParser");
+    JPetManager::getManager().useTask("JPetGateParser", "mcGATE", "hits", 1, true);
+  }
 }
 
 void JPetManager::useTasksFromUserParams(const std::map<std::string, boost::any>& opts)

--- a/src/Core/JPetTaskFactory/JPetTaskFactory.cpp
+++ b/src/Core/JPetTaskFactory/JPetTaskFactory.cpp
@@ -80,7 +80,7 @@ TaskGeneratorChain generateTaskGeneratorChain(const std::vector<TaskInfo>& taskI
                                               const std::map<std::string, boost::any>& options)
 {
   TaskGeneratorChain chain;
-  addDefaultTasksFromOptions(options, generatorsMap, chain, taskInfoVect);
+  addDefaultTasksFromOptions(options, generatorsMap, chain);
   for (const auto& taskInfo : taskInfoVect)
   {
     addTaskToChain(generatorsMap, taskInfo, chain);
@@ -93,7 +93,7 @@ TaskGeneratorChain generateDirectTaskGeneratorChain(const std::vector<TaskInfo>&
                                                     const std::map<std::string, boost::any>& options)
 {
   TaskGeneratorChain chain;
-  addDefaultTasksFromOptions(options, generatorsMap, chain, taskInfoVect);
+  addDefaultTasksFromOptions(options, generatorsMap, chain);
 
   auto inT = taskInfoVect.front().inputFileType;
   auto outT = taskInfoVect.back().outputFileType;
@@ -126,7 +126,7 @@ TaskGeneratorChain generateDirectTaskGeneratorChain(const std::vector<TaskInfo>&
 }
 
 void addDefaultTasksFromOptions(const std::map<std::string, boost::any>& options, const std::map<std::string, TaskGenerator>& generatorsMap,
-                                TaskGeneratorChain& outChain, const std::vector<TaskInfo>& tasksToUse)
+                                TaskGeneratorChain& outChain)
 {
   using namespace jpet_options_tools;
   bool isDirect = jpet_options_tools::isDirectProcessing(options);

--- a/tests/Core/JPetManager/JPetManagerTest.cpp
+++ b/tests/Core/JPetManager/JPetManagerTest.cpp
@@ -19,8 +19,6 @@
 #include "./JPetManager/JPetManager.h"
 #include <boost/test/unit_test.hpp>
 
-// TODO create new test files and use combined_jpet_test.json
-
 BOOST_AUTO_TEST_SUITE(FirstSuite)
 
 BOOST_AUTO_TEST_CASE(create_unique_manager)
@@ -51,87 +49,84 @@ BOOST_AUTO_TEST_CASE(emptyRun)
 BOOST_AUTO_TEST_CASE(goodRootRun)
 {
   // goodRootFile.root needs to be updated
-  // JPetManager& manager = JPetManager::getManager();
-  // const char* args[7] = {
-  //   "test/Path",
-  //   "--file",
-  //   "unitTestData/JPetManagerTest/goodRootFile.root",
-  //   "--type",
-  //   "root",
-  //   "-p",
-  //   "conf_trb3.xml"
-  // };
-  // BOOST_REQUIRE_NO_THROW(manager.run(7, args));
+  JPetManager& manager = JPetManager::getManager();
+  const char* args[7] = {"test/Path", "--file", "unitTestData/JPetManagerTest/goodRootFile.hits.root", "--type",
+                         "root",      "-u",     "unitTestData/JPetManagerTest/userParamsDummy.json"};
+  BOOST_REQUIRE_NO_THROW(manager.run(7, args));
 }
 
 BOOST_AUTO_TEST_CASE(goodZipRun)
 {
-  // std::remove("unitTestData/JPetManagerTest/xx14099113231.hld");
-  // JPetManager& manager = JPetManager::getManager();
-  // const char* args[14] = {"test/Path",
-  //                         "--file",
-  //                         "unitTestData/JPetManagerTest/xx14099113231.hld.xz",
-  //                         "--type",
-  //                         "zip",
-  //                         "-p",
-  //                         "unitTestData/JPetManagerTest/conf_trb3.xml",
-  //                         "-r",
-  //                         "0",
-  //                         "10",
-  //                         "-l",
-  //                         "unitTestData/JPetManagerTest/large_barrel.json",
-  //                         "-i",
-  //                         "44"};
-  // BOOST_REQUIRE_NO_THROW(manager.run(14, args));
+  std::remove("unitTestData/JPetManagerTest/xx14099113231.hld");
+  JPetManager& manager = JPetManager::getManager();
+  const char* args[14] = {"test/Path",
+                          "--file",
+                          "unitTestData/JPetManagerTest/xx14099113231.hld.xz",
+                          "--type",
+                          "zip",
+                          "-p",
+                          "unitTestData/JPetManagerTest/conf_trb3.xml",
+                          "-r",
+                          "0",
+                          "10",
+                          "-l",
+                          "unitTestData/JPetManagerTest/modular_setup_clinical_fixed_ds.json",
+                          "-i",
+                          "38"};
+  BOOST_REQUIRE_NO_THROW(manager.run(14, args));
 }
 
 BOOST_AUTO_TEST_CASE(goodMCRun)
 {
-  // JPetManager& manager = JPetManager::getManager();
-  // const char* args[11] = {"test/Path",     "--file", "unitTestData/JPetManagerTest/goodMCFile.mcGeant.root", "--type", "mcGeant", "-p",
-  //                         "conf_trb3.xml", "-l",     "unitTestData/JPetManagerTest/large_barrel.json",       "-i",     "44"};
-  // BOOST_REQUIRE_NO_THROW(manager.run(11, args));
+  JPetManager& manager = JPetManager::getManager();
+  const char* args[16] = {"test/Path",
+                          "--file",
+                          "unitTestData/JPetManagerTest/goodMCFile2.mcGeant.root",
+                          "--type",
+                          "mcGeant",
+                          "-k",
+                          "mod",
+                          "-u",
+                          "unitTestData/JPetManagerTest/userParamsDummy.json",
+                          "-l",
+                          "unitTestData/JPetManagerTest/modular_setup_clinical_fixed_ds.json",
+                          "-i",
+                          "38",
+                          "-r",
+                          "0",
+                          "100"};
+  BOOST_REQUIRE_NO_THROW(manager.run(16, args));
 }
 
-BOOST_AUTO_TEST_CASE(goodControlTasks)
-{
-  // JPetManager& manager = JPetManager::getManager();
-  // std::vector<const char*> args = {
-  //     "test/Path",
-  //     "--file",
-  //     "unitTestData/JPetManagerTest/goodRootFile.root",
-  //     "--type",
-  //     "root",
-  //     "-u",
-  //     "unitTestData/JPetManagerTest/userParamsControlTasksGood.json",
-  // };
-  // manager.registerTask<TestTask>("TestTask");
-  // BOOST_REQUIRE_NO_THROW(manager.run(args.size(), args.data()));
-}
+// BOOST_AUTO_TEST_CASE(goodControlTasks)
+// {
+//   JPetManager& manager = JPetManager::getManager();
+//   std::vector<const char*> args = {
+//       "test/Path", "--file", "unitTestData/JPetManagerTest/goodRootFile.hits.root",          "--type",
+//       "root",      "-u",     "unitTestData/JPetManagerTest/userParamsControlTasksGood.json",
+//   };
+//   manager.registerTask<TestTask>("TestTask");
+//   BOOST_REQUIRE_NO_THROW(manager.run(args.size(), args.data()));
+// }
 
 BOOST_AUTO_TEST_CASE(notRegisteredTask)
 {
-  // JPetManager& manager = JPetManager::getManager();
-  // std::vector<const char*> args = {
-  //     "test/Path",
-  //     "--file",
-  //     "unitTestData/JPetManagerTest/goodRootFile.root",
-  //     "--type",
-  //     "root",
-  //     "-u",
-  //     "unitTestData/JPetManagerTest/userParamsUnregisteredTask.json",
-  // };
-  // BOOST_CHECK_THROW(manager.run(args.size(), args.data()), std::runtime_error);
+  JPetManager& manager = JPetManager::getManager();
+  std::vector<const char*> args = {
+      "test/Path", "--file", "unitTestData/JPetManagerTest/goodRootFile.hits.root",          "--type",
+      "root",      "-u",     "unitTestData/JPetManagerTest/userParamsUnregisteredTask.json",
+  };
+  BOOST_CHECK_THROW(manager.run(args.size(), args.data()), std::runtime_error);
 }
 
 BOOST_AUTO_TEST_CASE(badOptionsTask)
 {
-  // JPetManager& manager = JPetManager::getManager();
-  // std::vector<const char*> args = {
-  //     "test/Path", "--file", "unitTestData/JPetManagerTest/goodRootFile.root",         "--type",
-  //     "root",      "-u",     "unitTestData/JPetManagerTest/userParamsBadOptions.json",
-  // };
-  // BOOST_REQUIRE_NO_THROW(manager.run(11, args));
+  JPetManager& manager = JPetManager::getManager();
+  std::vector<const char*> args = {
+      "test/Path", "--file", "unitTestData/JPetManagerTest/goodRootFile.hits.root",    "--type",
+      "root",      "-u",     "unitTestData/JPetManagerTest/userParamsBadOptions.json",
+  };
+  BOOST_CHECK_THROW(manager.run(args.size(), args.data()), std::runtime_error);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This PR resolves the issue of MC tasks not being included in the direct data processing. Now, if mcGeant or mcGATE option is specified, the appropriate task is registered and added to the front of the chain of tasks, to be executed first. 
Also, some unit tests for JPetManager were restored. 

